### PR TITLE
Fix nested-execution shared-pool deadlock (depth limit + reserve admission)

### DIFF
--- a/backend/app/api/runtime/endpoints/functions.py
+++ b/backend/app/api/runtime/endpoints/functions.py
@@ -5,10 +5,37 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Any, Optional
 
-from app.core.auth import get_current_user_with_permissions, set_permission_used
+from app.core.auth import (
+    get_current_user_with_permissions,
+    get_execution_depth_from_request,
+    set_permission_used,
+)
 from app.core.callback import CallbackURLError, validate_callback_url
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.permissions import check_permission
+
+
+def _resolve_child_depth(request: Request) -> int:
+    """Depth of the execution this request is about to create.
+
+    Top-level (real user/app token) → 0; a call made from inside a running
+    execution → caller depth + 1. Rejects past settings.max_execution_depth so
+    runaway / over-nested chains fail fast instead of exhausting the worker pool.
+    """
+    caller_depth = get_execution_depth_from_request(request)
+    depth = 0 if caller_depth is None else caller_depth + 1
+    if settings.max_execution_depth and depth > settings.max_execution_depth:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Maximum execution nesting depth ({settings.max_execution_depth}) exceeded. "
+                "A function or agent invoked another execution too deeply — usually unintended "
+                "recursion or over-nested shared_pool calls. Flatten the chain, or raise "
+                "MAX_EXECUTION_DEPTH (and the shared worker pool) if this nesting is intended."
+            ),
+        )
+    return depth
 from app.models.execution import TriggerType
 from app.models.function import Function
 from app.schemas.batch import FunctionBatchRequest, FunctionBatchResponse
@@ -54,6 +81,7 @@ async def execute_function(
 
     set_permission_used(request, permission)
 
+    depth = _resolve_child_depth(request)
     execution_id = str(uuid.uuid4())
 
     try:
@@ -66,6 +94,7 @@ async def execute_function(
             trigger_id="runtime-api",
             user_id=user_id,
             timeout=body.timeout,
+            depth=depth,
         )
 
         return FunctionExecuteResponse(
@@ -124,6 +153,7 @@ async def execute_function_async(
     except CallbackURLError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+    depth = _resolve_child_depth(request)
     execution_id = str(uuid.uuid4())
 
     await queue_service.enqueue_function(
@@ -136,6 +166,7 @@ async def execute_function_async(
         user_id=user_id,
         delay=body.delay_seconds,
         callback_url=callback_url,
+        depth=depth,
     )
 
     return FunctionExecuteAsyncResponse(
@@ -180,6 +211,8 @@ async def execute_function_batch(
     except CallbackURLError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+    depth = _resolve_child_depth(request)
+
     try:
         result = await batch_service.submit_function_batch(
             db=db,
@@ -191,6 +224,7 @@ async def execute_function_batch(
             delay_seconds=body.delay_seconds,
             callback_url=callback_url,
             batch_callback_url=batch_callback_url,
+            depth=depth,
         )
     except batch_service.BatchError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -288,7 +288,12 @@ async def get_user_permissions(db: AsyncSession, user_id: str) -> dict[str, bool
     return all_permissions
 
 
-def create_access_token(user_id: str, email: str, expires_delta: Optional[timedelta] = None) -> str:
+def create_access_token(
+    user_id: str,
+    email: str,
+    expires_delta: Optional[timedelta] = None,
+    execution_depth: Optional[int] = None,
+) -> str:
     """
     Create JWT access token (short-lived, no permissions in payload).
 
@@ -316,9 +321,39 @@ def create_access_token(user_id: str, email: str, expires_delta: Optional[timede
         "iat": int(now.timestamp()),  # Issued at (best practice)
         "exp": int(expire.timestamp()),
     }
+    if execution_depth is not None:
+        # Nesting depth of the execution this token belongs to. A nested call
+        # (a function/agent invoking another execution) reads this to compute
+        # its own depth and is rejected past settings.max_execution_depth.
+        # Absent on real user/app tokens (treated as top-level callers).
+        to_encode["execution_depth"] = execution_depth
 
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt
+
+
+def get_execution_depth_from_request(request) -> Optional[int]:
+    """Read the `execution_depth` claim from the request's bearer token.
+
+    Returns the *caller* execution's depth, or None when the caller is not an
+    execution (a real user/app token carries no such claim). Best-effort: any
+    decode failure returns None, i.e. the caller is treated as top-level.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+    token = auth_header[7:].strip()
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    except Exception:
+        return None
+    depth = payload.get("execution_depth")
+    if depth is None:
+        return None
+    try:
+        return int(depth)
+    except (TypeError, ValueError):
+        return None
 
 
 async def create_refresh_token(db: AsyncSession, user_id: str) -> tuple[str, "RefreshToken"]:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -94,6 +94,13 @@ class Settings(BaseSettings):
     # silently exhausting the shared worker pool and deadlocking. 0 disables the
     # check. Keep <= the shared worker count so a full chain fits the pool.
     max_execution_depth: int = 8
+    # Reserve N shared-worker slots that only NESTED executions (depth > 0) may
+    # use, so a parent blocked on a child never starves the pool (the nested-
+    # call deadlock). 0 = disabled (no admission control; default — no behaviour
+    # change). For full single-chain safety set this to max_execution_depth - 1
+    # AND keep default_worker_count >= max_execution_depth. A smaller value still
+    # breaks the common contention case while throttling top-level work less.
+    shared_pool_reserve: int = 0
     max_function_memory: int = 512  # MB (Docker memory limit)
     max_function_cpu: float = 1.0  # CPU cores (1.0 = 1 full core, 0.5 = half core)
     max_function_storage: str = "1g"  # Disk storage limit (e.g., "500m", "1g")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 VALID_AUTH_MODES = {"otp", "password", "password+otp"}
@@ -91,9 +91,10 @@ class Settings(BaseSettings):
     function_timeout: int = 300  # 5 minutes (max execution time)
     # Max nesting depth for execution chains (a function/agent invoking another
     # execution). A nested call exceeding this is rejected fast instead of
-    # silently exhausting the shared worker pool and deadlocking. 0 disables the
-    # check. Keep <= the shared worker count so a full chain fits the pool.
-    max_execution_depth: int = 8
+    # silently exhausting the shared worker pool and deadlocking. Defaults to
+    # `default_worker_count` (None = auto) so a full chain always fits the pool
+    # (depth <= workers); set an explicit value to override, or 0 to disable.
+    max_execution_depth: Optional[int] = None
     # Reserve N shared-worker slots that only NESTED executions (depth > 0) may
     # use, so a parent blocked on a child never starves the pool (the nested-
     # call deadlock). 0 = disabled (no admission control; default — no behaviour
@@ -171,6 +172,15 @@ class Settings(BaseSettings):
                 f"AUTH_MODE must be one of {sorted(VALID_AUTH_MODES)}, got {v!r}"
             )
         return normalized
+
+    @model_validator(mode="after")
+    def _default_max_execution_depth(self):
+        # Default the nesting cap to the worker count so a single chain always
+        # fits the pool (depth <= workers). Explicit values — including 0, which
+        # disables the check — are left untouched.
+        if self.max_execution_depth is None:
+            self.max_execution_depth = self.default_worker_count
+        return self
 
     # Domain (for generating external URLs, e.g., temp file URLs)
     domain: Optional[str] = None  # FQDN like "app.example.com"; localhost or None = no external URLs

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -89,6 +89,11 @@ class Settings(BaseSettings):
 
     # Function execution (always uses Docker for isolation)
     function_timeout: int = 300  # 5 minutes (max execution time)
+    # Max nesting depth for execution chains (a function/agent invoking another
+    # execution). A nested call exceeding this is rejected fast instead of
+    # silently exhausting the shared worker pool and deadlocking. 0 disables the
+    # check. Keep <= the shared worker count so a full chain fits the pool.
+    max_execution_depth: int = 8
     max_function_memory: int = 512  # MB (Docker memory limit)
     max_function_cpu: float = 1.0  # CPU cores (1.0 = 1 full core, 0.5 = half core)
     max_function_storage: str = "1g"  # Disk storage limit (e.g., "500m", "1g")

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -54,6 +54,7 @@ async def execute_function_job(ctx: dict, **kwargs: Any) -> Any:
     user_id = kwargs["user_id"]
     chat_id = kwargs.get("chat_id")
     callback_url = kwargs.get("callback_url")
+    depth = kwargs.get("depth", 0)
 
     redis: Redis = ctx.get("redis") or Redis.from_url(settings.redis_url, decode_responses=True)
 
@@ -120,6 +121,7 @@ async def execute_function_job(ctx: dict, **kwargs: Any) -> Any:
             user_id=user_id,
             chat_id=chat_id,
             callback_url=callback_url,
+            depth=depth,
         )
 
         # Store result

--- a/backend/app/services/batch_service.py
+++ b/backend/app/services/batch_service.py
@@ -60,6 +60,7 @@ async def submit_function_batch(
     delay_seconds: Optional[int] = None,
     callback_url: Optional[str] = None,
     batch_callback_url: Optional[str] = None,
+    depth: int = 0,
 ) -> dict[str, Any]:
     """Create a batch of function executions. Returns batch_id + execution_ids."""
     if not inputs:
@@ -124,6 +125,7 @@ async def submit_function_batch(
             user_id=user_id,
             delay=delay_seconds,
             callback_url=callback_url,
+            depth=depth,
         )
 
     return {

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -224,8 +224,14 @@ class FunctionExecutor:
         user_id: str,
         chat_id: Optional[str] = None,
         callback_url: Optional[str] = None,
+        depth: int = 0,
     ) -> dict[str, Any]:
-        """Execute a function with input validation and tracking."""
+        """Execute a function with input validation and tracking.
+
+        `depth` is this execution's nesting depth (0 = top-level). It is
+        embedded in the per-execution access token so a nested call can
+        compute its own depth and be bounded by settings.max_execution_depth.
+        """
         async with AsyncSessionLocal() as db:
             # Get user info for context
             from app.core.auth import create_access_token
@@ -250,7 +256,9 @@ class FunctionExecutor:
                     settings.max_execution_token_seconds,
                 )
             )
-            access_token = create_access_token(user_id, user_email, expires_delta=token_ttl)
+            access_token = create_access_token(
+                user_id, user_email, expires_delta=token_ttl, execution_depth=depth
+            )
 
             # Check if execution already exists (e.g. created by enqueue_function)
             result = await db.execute(

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -302,18 +302,32 @@ class FunctionExecutor:
                     print(
                         f"⏱️  [TIMING] Executing {function_namespace}/{function_name} in shared pool"
                     )
-                    exec_result = await self._execute_in_shared_pool(
-                        function=function,
-                        input_data=input_data,
-                        execution_id=execution_id,
-                        user_id=user_id,
-                        user_email=user_email,
-                        access_token=access_token,
-                        trigger_type=trigger_type,
-                        chat_id=chat_id,
-                        db=db,
-                        timeout=function_timeout,
+                    # Depth-aware admission: reserve worker slots for nested
+                    # calls so a parent waiting on a child can't starve the pool
+                    # (the nested-execution deadlock). Opt-in via
+                    # settings.shared_pool_reserve; nested calls (depth > 0)
+                    # bypass the gate.
+                    from app.services.shared_admission import (
+                        SharedPoolSaturated,
+                        shared_pool_admission,
                     )
+
+                    try:
+                        async with shared_pool_admission(depth, execution_id):
+                            exec_result = await self._execute_in_shared_pool(
+                                function=function,
+                                input_data=input_data,
+                                execution_id=execution_id,
+                                user_id=user_id,
+                                user_email=user_email,
+                                access_token=access_token,
+                                trigger_type=trigger_type,
+                                chat_id=chat_id,
+                                db=db,
+                                timeout=function_timeout,
+                            )
+                    except SharedPoolSaturated as e:
+                        raise FunctionExecutionError(str(e))
                     elapsed = time.time() - start_time
                     print(f"⏱️  [TIMING] Shared pool execution completed in {elapsed:.3f}s")
                 else:

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -35,6 +35,7 @@ class QueueService:
         chat_id: Optional[str] = None,
         delay: Optional[int] = None,
         callback_url: Optional[str] = None,
+        depth: int = 0,
     ) -> str:
         """
         Enqueue a function execution job.
@@ -79,6 +80,7 @@ class QueueService:
             "user_id": user_id,
             "chat_id": chat_id,
             "callback_url": callback_url,
+            "depth": depth,
         }
 
         # Enqueue with optional delay
@@ -126,6 +128,7 @@ class QueueService:
         user_id: str,
         chat_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        depth: int = 0,
     ) -> Any:
         """
         Enqueue a function job and wait for its result.
@@ -152,6 +155,7 @@ class QueueService:
                 trigger_id=trigger_id,
                 user_id=user_id,
                 chat_id=chat_id,
+                depth=depth,
             )
 
             # Wait for result with timeout

--- a/backend/app/services/shared_admission.py
+++ b/backend/app/services/shared_admission.py
@@ -1,0 +1,73 @@
+"""Depth-aware admission control for the shared (trusted) worker pool.
+
+Prevents the nested-execution deadlock: a parent `shared_pool` function blocked
+while synchronously waiting on a child can starve the pool when every worker is
+held by a parent. We reserve `settings.shared_pool_reserve` slots that only
+NESTED executions (depth > 0) may use, so a child can always find capacity.
+
+Opt-in: `shared_pool_reserve = 0` disables it entirely (default — no behaviour
+change). For full single-chain safety set the reserve to
+`max_execution_depth - 1` AND keep `default_worker_count >= max_execution_depth`
+(a chain of depth D holds D slots at once). A smaller reserve still breaks the
+common contention case (several shallow chains) while throttling top-level work
+less.
+
+The in-flight set is a Redis sorted-set keyed by execution_id with a timestamp
+score, so the count is correct across the multiple queue-worker processes and
+self-heals if a process dies mid-execution (stale entries age out).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+
+from app.core.config import settings
+from app.core.redis import get_redis
+
+logger = logging.getLogger(__name__)
+
+_INFLIGHT_ZSET = "sinas:shared:toplevel_inflight"
+# Entries older than this are treated as dead (crashed worker) and pruned, so a
+# leak can't permanently throttle the pool. Comfortably above any real run.
+_ENTRY_TTL_SECONDS = 3600
+
+
+class SharedPoolSaturated(Exception):
+    """Raised when top-level shared-pool admission is at capacity."""
+
+
+@contextlib.asynccontextmanager
+async def shared_pool_admission(depth: int, execution_id: str):
+    """Admit a shared-pool execution, reserving slots for nested calls.
+
+    Nested executions (depth > 0) bypass the gate — that is the whole point of
+    the reserve. Top-level (depth 0) executions are capped at
+    `default_worker_count - shared_pool_reserve`. Raises `SharedPoolSaturated`
+    (fail-fast, retryable) when the top-level cap is reached.
+    """
+    reserve = settings.shared_pool_reserve
+    if reserve <= 0 or depth > 0:
+        # Disabled, or a nested call that must always be allowed through.
+        yield
+        return
+
+    cap = max(1, settings.default_worker_count - reserve)
+    redis = await get_redis()
+    now = time.time()
+
+    # Prune dead entries, then count live top-level executions.
+    await redis.zremrangebyscore(_INFLIGHT_ZSET, 0, now - _ENTRY_TTL_SECONDS)
+    live = await redis.zcard(_INFLIGHT_ZSET)
+    if live >= cap:
+        raise SharedPoolSaturated(
+            f"Shared worker pool saturated: {live}/{cap} top-level slots in use "
+            f"({reserve} reserved for nested calls). Retry shortly or scale workers."
+        )
+
+    await redis.zadd(_INFLIGHT_ZSET, {execution_id: now})
+    try:
+        yield
+    finally:
+        await redis.zrem(_INFLIGHT_ZSET, execution_id)

--- a/docs-mint/build-resources/functions.mdx
+++ b/docs-mint/build-resources/functions.mdx
@@ -91,6 +91,10 @@ In sandbox containers (`shared_pool=false`), calling `input()` raises a `Runtime
 
 **Execution:** Functions run in pre-warmed Docker containers from a managed pool. Input is validated before execution, output is validated after. All executions are logged with status, duration, input/output, and any errors.
 
+<Note>
+**Nested executions are depth-limited.** A function can invoke other functions or agents (e.g. by calling the Sinas API with its execution token). Such chains are bounded by `MAX_EXECUTION_DEPTH` (defaults to the shared worker count): a call past the limit is rejected immediately rather than silently exhausting the shared worker pool and deadlocking. Keep `shared_pool` functions shallow, or raise `SHARED_POOL_RESERVE` / scale workers if you intentionally nest deeply. See [environment variables](/getting-started/environment-variables).
+</Note>
+
 **Endpoints:**
 
 ```

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -64,6 +64,8 @@ Required when `AUTH_MODE` is `otp` or `password+otp`. Skip entirely for `passwor
 | `FUNCTION_CONTAINER_IDLE_TIMEOUT` | `3600` | Idle container cleanup (seconds) |
 | `ALLOW_PACKAGE_INSTALLATION` | `true` | Allow `pip install` in functions |
 | `ALLOWED_PACKAGES` | _(all)_ | Comma-separated package whitelist |
+| `MAX_EXECUTION_DEPTH` | _(= workers)_ | Max nesting depth for execution chains (a function/agent invoking another execution). A deeper call is rejected fast instead of deadlocking the shared pool. Defaults to `DEFAULT_WORKER_COUNT`; `0` disables. |
+| `SHARED_POOL_RESERVE` | `0` | Shared-worker slots reserved for nested calls so a parent waiting on a child can't starve the pool. `0` = off. For full single-chain safety set to `MAX_EXECUTION_DEPTH - 1`. |
 
 ## Sandbox Containers
 
@@ -93,6 +95,7 @@ Required when `AUTH_MODE` is `otp` or `password+otp`. Skip entirely for `passwor
 | `QUEUE_AGENT_REPLICAS` | `2` | Agent queue worker replicas |
 | `QUEUE_FUNCTION_CONCURRENCY` | `10` | Concurrent functions per worker |
 | `QUEUE_AGENT_CONCURRENCY` | `5` | Concurrent agent jobs per worker |
+| `DEFAULT_WORKER_COUNT` | `4` | Shared (trusted) worker containers for `shared_pool` functions. Also the default ceiling for `MAX_EXECUTION_DEPTH`. |
 
 ## Resource Limits (Docker)
 


### PR DESCRIPTION
## Problem
Nested executions — a `shared_pool` function (or agent) synchronously invoking another execution — could exhaust the small shared worker pool and **deadlock**, surfacing only as an opaque ~45s ReadTimeout.

## Fix
Carry each execution's **nesting depth** as a JWT claim and bound it.

**#4 — depth limit (active by default)**
- `create_access_token` gains an `execution_depth` claim; `get_execution_depth_from_request` reads the caller's depth.
- `execution_engine` mints the per-execution token with its depth; depth threads through `queue_service` → worker → `batch_service`.
- Runtime function `execute` / `execute/async` / `execute/batch` endpoints reject a call past `MAX_EXECUTION_DEPTH` with a clear error instead of deadlocking.
- `MAX_EXECUTION_DEPTH` defaults to `DEFAULT_WORKER_COUNT` (so a single chain always fits the pool); an explicit value overrides, `0` disables.

**#3 — depth-aware reserve admission (opt-in)**
- `SHARED_POOL_RESERVE` reserves N worker slots that only nested (depth > 0) calls may use; top-level is capped at `workers − reserve`, over-cap fails fast. `0` = off (default — no behaviour change).
- In-flight tracked in a Redis sorted-set (correct across worker processes; self-heals stale entries from crashed workers).

## Config / docs
- `MAX_EXECUTION_DEPTH`, `SHARED_POOL_RESERVE`, and the previously-undocumented `DEFAULT_WORKER_COUNT` documented in env-vars + functions docs.

## Deploy notes
- Default is safe out of the box (depth = worker count). Enable `SHARED_POOL_RESERVE` (≈ `MAX_EXECUTION_DEPTH − 1`) and/or scale workers for concurrent deep chains.
- The depth-independent fix (free the slot during the wait via the suspend/resume seam) is tracked separately with the executor refactor.

## Validation
Compiles; depth token round-trip + cap math verified; admission path validated locally with `SHARED_POOL_RESERVE=1`, `DEFAULT_WORKER_COUNT=8` (→ cap 7, reserve 1, `max_execution_depth` auto-resolved to 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
