### PR TITLE
Fix: CDC picks up config/Package-created triggers without restart

### DIFF
--- a/backend/app/cdc/service.py
+++ b/backend/app/cdc/service.py
@@ -113,6 +113,38 @@ class CDCManager:
         else:
             logger.warning(f"Unknown CDC action: {action}")
 
+    async def reload(self):
+        """Reconcile poll tasks against the active triggers in the DB.
+
+        Starts a poll task for every active trigger that isn't already running,
+        and prunes finished tasks (a deleted/deactivated trigger's loop stops
+        itself). Config *updates* are picked up by the running loop's per-cycle
+        re-query, so reload only needs to handle add/remove.
+
+        Used to pick up triggers created via config apply / Package install,
+        which don't emit a per-trigger notification.
+        """
+        from app.models.database_trigger import DatabaseTrigger
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                select(DatabaseTrigger.id).where(DatabaseTrigger.is_active == True)
+            )
+            active_ids = {str(row[0]) for row in result.all()}
+
+        # Drop finished tasks (triggers that were deleted/deactivated).
+        for tid in [t for t, task in self._poll_tasks.items() if task.done()]:
+            del self._poll_tasks[tid]
+
+        started = 0
+        for tid in active_ids:
+            if tid not in self._poll_tasks:
+                self._start_poll_task(tid)
+                started += 1
+        logger.info(
+            f"CDC reload: {len(active_ids)} active trigger(s), started {started} new poll task(s)"
+        )
+
     def _start_poll_task(self, trigger_id: str):
         """Start a background poll loop task for one trigger."""
         task = asyncio.create_task(self._run_poll_loop(trigger_id))
@@ -312,12 +344,15 @@ async def _listen_for_trigger_changes(manager: CDCManager, stop_event: asyncio.E
             try:
                 payload = json.loads(msg["data"])
                 action = payload["action"]
-                trigger_id = payload["trigger_id"]
+                trigger_id = payload.get("trigger_id", "")
             except (json.JSONDecodeError, KeyError) as e:
                 logger.warning(f"Invalid CDC message: {e}")
                 continue
 
-            await manager.handle_trigger_change(action, trigger_id)
+            if action == "reload":
+                await manager.reload()
+            else:
+                await manager.handle_trigger_change(action, trigger_id)
     finally:
         await pubsub.unsubscribe(CDC_CHANNEL)
         await pubsub.aclose()

--- a/backend/app/services/config_apply/service.py
+++ b/backend/app/services/config_apply/service.py
@@ -255,6 +255,24 @@ class ConfigApplyService:
 
             if not dry_run and self.auto_commit:
                 await self.db.commit()
+                # Notify the CDC worker so database triggers created/updated via
+                # config apply (e.g. a Package install) are picked up without a
+                # restart — the REST endpoint notifies per-trigger, this path
+                # did not. One reconcile signal; the worker diffs running poll
+                # tasks against active triggers. Best-effort: never fail the
+                # apply on a notify error.
+                try:
+                    import json
+
+                    from app.core.redis import get_redis
+
+                    redis = await get_redis()
+                    await redis.publish(
+                        "sinas:cdc:triggers",
+                        json.dumps({"action": "reload", "trigger_id": ""}),
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to notify CDC after config apply: {e}")
 
             return ConfigApplyResponse(
                 success=True,


### PR DESCRIPTION
## Problem
Database triggers created or updated via **config apply** (Package install or declarative YAML) were never announced to the cdc-worker — only the REST endpoint published a change event — so they were ignored until the worker was restarted.

## Fix
- `CDCManager.reload()` reconciles poll tasks against the active triggers in the DB (starts the missing ones, prunes finished). Running poll loops already re-query their own config each cycle, so *updates* need no special handling.
- The pub/sub listener handles a new `reload` action (tolerant of a missing `trigger_id`).
- Config apply publishes one `reload` to `sinas:cdc:triggers` **after commit** (best-effort; never fails the apply).

## Validation
Compiles; verified locally that the cdc-worker loads triggers and listens on `sinas:cdc:triggers`. The reconcile is idempotent and self-healing.

Note: this is unrelated to #80 (non-text poll-column binding), which remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
