### PR TITLE
OAuth 2.0 for Connectors (#66)

### DIFF
--- a/backend/alembic/versions/0a1u2t3h4t5k_add_connector_oauth_tokens.py
+++ b/backend/alembic/versions/0a1u2t3h4t5k_add_connector_oauth_tokens.py
@@ -1,0 +1,49 @@
+"""add connector_oauth_tokens table (per-user authorization-code grant)
+
+Also merges the two open migration heads (b1a2t3c4h5e6, 20260131_states) into one.
+
+Revision ID: 0a1u2t3h4t5k
+Revises: b1a2t3c4h5e6, 20260131_states
+Create Date: 2026-07-03
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0a1u2t3h4t5k"
+down_revision = ("b1a2t3c4h5e6", "20260131_states")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "connector_oauth_tokens",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "connector_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("connectors.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("encrypted_access_token", sa.Text(), nullable=False),
+        sa.Column("encrypted_refresh_token", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("scope", sa.Text(), nullable=True),
+        sa.Column("token_type", sa.String(length=40), nullable=False, server_default="Bearer"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("connector_id", "user_id", name="uq_connector_oauth_token_connector_user"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("connector_oauth_tokens")

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -2,6 +2,7 @@
 
 import html as html_lib
 import json
+import logging
 import secrets
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -66,6 +67,7 @@ async def _issue_tokens(db: AsyncSession, user: User) -> tuple[str, str, AuthUse
     return access_token, refresh_token_plain, user_resp
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post("/login", response_model=LoginResponse)
@@ -376,10 +378,10 @@ def _oauth_result_page(ok: bool, message: str) -> HTMLResponse:
     """
     status_word = "success" if ok else "error"
     safe = html_lib.escape(message)
-    # Target the app's own origin (not "*"). settings.public_base_url drives both the
-    # console and this callback, so the console window is same-origin with this page in
-    # real deployments; the console-side listener validates event.origin in turn.
-    target_origin_js = json.dumps(settings.public_base_url)
+    # The message carries no secret (just a status flag), and the console/API can be on
+    # different origins in local dev, so we post to "*". Spoofing is prevented on the
+    # RECEIVER side: the console validates event.origin against the API origin before
+    # trusting the message (see ConnectorEditor's message listener).
     html = f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Connector authorization</title></head>
 <body style="font-family:system-ui;background:#0d0d0d;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
@@ -389,7 +391,7 @@ def _oauth_result_page(ok: bool, message: str) -> HTMLResponse:
 </div>
 <script>
   try {{ window.opener && window.opener.postMessage(
-    {{ type: "connector-oauth", status: "{status_word}" }}, {target_origin_js}); }} catch (e) {{}}
+    {{ type: "connector-oauth", status: "{status_word}" }}, "*"); }} catch (e) {{}}
   setTimeout(function () {{ window.close(); }}, 1200);
 </script>
 </body></html>"""
@@ -425,9 +427,12 @@ async def connector_oauth_callback(
     # it. The nonce was set as an HttpOnly cookie by the authenticated begin endpoint;
     # require it to match the one stored with the state. This defeats OAuth account-linking
     # (an attacker minting a state and having a victim complete it). Constant-time compare.
+    # Skippable only in split-origin local dev (see settings.oauth_bind_browser_session),
+    # where the cookie can't round-trip cross-origin.
     cookie_nonce = request.cookies.get(BIND_COOKIE_NAME) or ""
     expected_nonce = ctx.get("browser_nonce") or ""
-    if not expected_nonce or not secrets.compare_digest(cookie_nonce, expected_nonce):
+    binding_ok = bool(expected_nonce) and secrets.compare_digest(cookie_nonce, expected_nonce)
+    if settings.oauth_bind_browser_session and not binding_ok:
         resp = _oauth_result_page(
             False,
             "This authorization could not be verified for your session. "
@@ -435,6 +440,11 @@ async def connector_oauth_callback(
         )
         resp.delete_cookie(BIND_COOKIE_NAME, path="/")
         return resp
+    if not binding_ok:
+        logger.warning(
+            "OAuth browser-binding check skipped (oauth_bind_browser_session=false) — "
+            "acceptable only for local single-user dev, never production."
+        )
 
     if not code:
         return _oauth_result_page(False, "No authorization code was returned by the provider.")

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -1,6 +1,7 @@
 """Authentication endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -359,3 +360,66 @@ async def check_permissions(
         result = any(check.has_permission for check in checks)
 
     return PermissionCheckResponse(result=result, logic=check_request.logic, checks=checks)
+
+
+def _oauth_result_page(ok: bool, message: str) -> HTMLResponse:
+    """Render a tiny page that notifies the opener window and closes itself.
+
+    The connector OAuth flow is opened in a popup; this signals the console (via
+    postMessage) whether the connection succeeded, then closes. No secrets are sent.
+    """
+    status_word = "success" if ok else "error"
+    safe = message.replace("<", "&lt;").replace(">", "&gt;")
+    html = f"""<!doctype html>
+<html><head><meta charset="utf-8"><title>Connector authorization</title></head>
+<body style="font-family:system-ui;background:#0d0d0d;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+<p style="font-size:15px">{safe}</p>
+<p style="font-size:13px;color:#888">You can close this window.</p>
+</div>
+<script>
+  try {{ window.opener && window.opener.postMessage(
+    {{ type: "connector-oauth", status: "{status_word}" }}, "*"); }} catch (e) {{}}
+  setTimeout(function () {{ window.close(); }}, 1200);
+</script>
+</body></html>"""
+    return HTMLResponse(content=html, status_code=200 if ok else 400)
+
+
+@router.get("/connectors/oauth/callback", include_in_schema=False)
+async def connector_oauth_callback(
+    request: Request,
+    code: str = Query(default=""),
+    state: str = Query(default=""),
+    error: str = Query(default=""),
+    error_description: str = Query(default=""),
+    db: AsyncSession = Depends(get_db),
+):
+    """Public OAuth redirect target. Exchanges the code for tokens for the initiating user.
+
+    Unauthenticated by design (the provider won't send our bearer). The initiating user and
+    connector are recovered from the single-use `state` minted at /connectors/.../oauth/authorize.
+    """
+    from app.core.oauth_state import consume_state
+    from app.models.connector import Connector
+    from app.services.connector_service import connector_service
+
+    if error:
+        return _oauth_result_page(False, f"Authorization was denied: {error_description or error}")
+
+    ctx = await consume_state(state)
+    if ctx is None:
+        return _oauth_result_page(False, "This authorization link has expired or was already used.")
+    if not code:
+        return _oauth_result_page(False, "No authorization code was returned by the provider.")
+
+    connector = await Connector.get_by_name(db, ctx["namespace"], ctx["name"])
+    if connector is None or (connector.auth or {}).get("type") != "oauth2_authorization_code":
+        return _oauth_result_page(False, "Connector is no longer configured for OAuth.")
+
+    ok = await connector_service.exchange_authorization_code(
+        db=db, connector=connector, user_id=ctx["user_id"], code=code, code_verifier=ctx["code_verifier"],
+    )
+    if not ok:
+        return _oauth_result_page(False, "Failed to exchange the authorization code for a token.")
+    return _oauth_result_page(True, f"Connected {connector.namespace}/{connector.name}.")

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -376,14 +376,10 @@ def _oauth_result_page(ok: bool, message: str) -> HTMLResponse:
     """
     status_word = "success" if ok else "error"
     safe = html_lib.escape(message)
-    # Target the app's own origin. settings.domain drives both the console and this
-    # callback, so the console window is same-origin with this page in real deployments.
-    domain = (settings.domain or "").strip()
-    if not domain or domain.lower() in ("localhost", "127.0.0.1"):
-        target_origin = f"http://localhost:{settings.backend_port}"
-    else:
-        target_origin = f"https://{domain}"
-    target_origin_js = json.dumps(target_origin)
+    # Target the app's own origin (not "*"). settings.public_base_url drives both the
+    # console and this callback, so the console window is same-origin with this page in
+    # real deployments; the console-side listener validates event.origin in turn.
+    target_origin_js = json.dumps(settings.public_base_url)
     html = f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Connector authorization</title></head>
 <body style="font-family:system-ui;background:#0d0d0d;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -1,5 +1,9 @@
 """Authentication endpoints."""
 
+import html as html_lib
+import json
+import secrets
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 from sqlalchemy import select
@@ -367,9 +371,19 @@ def _oauth_result_page(ok: bool, message: str) -> HTMLResponse:
 
     The connector OAuth flow is opened in a popup; this signals the console (via
     postMessage) whether the connection succeeded, then closes. No secrets are sent.
+    The message is targeted at the console's own origin (not "*") so it can't be read by
+    an unrelated opener, and the console-side listener validates event.origin in turn.
     """
     status_word = "success" if ok else "error"
-    safe = message.replace("<", "&lt;").replace(">", "&gt;")
+    safe = html_lib.escape(message)
+    # Target the app's own origin. settings.domain drives both the console and this
+    # callback, so the console window is same-origin with this page in real deployments.
+    domain = (settings.domain or "").strip()
+    if not domain or domain.lower() in ("localhost", "127.0.0.1"):
+        target_origin = f"http://localhost:{settings.backend_port}"
+    else:
+        target_origin = f"https://{domain}"
+    target_origin_js = json.dumps(target_origin)
     html = f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Connector authorization</title></head>
 <body style="font-family:system-ui;background:#0d0d0d;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
@@ -379,7 +393,7 @@ def _oauth_result_page(ok: bool, message: str) -> HTMLResponse:
 </div>
 <script>
   try {{ window.opener && window.opener.postMessage(
-    {{ type: "connector-oauth", status: "{status_word}" }}, "*"); }} catch (e) {{}}
+    {{ type: "connector-oauth", status: "{status_word}" }}, {target_origin_js}); }} catch (e) {{}}
   setTimeout(function () {{ window.close(); }}, 1200);
 </script>
 </body></html>"""
@@ -400,7 +414,7 @@ async def connector_oauth_callback(
     Unauthenticated by design (the provider won't send our bearer). The initiating user and
     connector are recovered from the single-use `state` minted at /connectors/.../oauth/authorize.
     """
-    from app.core.oauth_state import consume_state
+    from app.core.oauth_state import BIND_COOKIE_NAME, consume_state
     from app.models.connector import Connector
     from app.services.connector_service import connector_service
 
@@ -410,6 +424,22 @@ async def connector_oauth_callback(
     ctx = await consume_state(state)
     if ctx is None:
         return _oauth_result_page(False, "This authorization link has expired or was already used.")
+
+    # Browser-binding check: the flow must be completed by the same browser that started
+    # it. The nonce was set as an HttpOnly cookie by the authenticated begin endpoint;
+    # require it to match the one stored with the state. This defeats OAuth account-linking
+    # (an attacker minting a state and having a victim complete it). Constant-time compare.
+    cookie_nonce = request.cookies.get(BIND_COOKIE_NAME) or ""
+    expected_nonce = ctx.get("browser_nonce") or ""
+    if not expected_nonce or not secrets.compare_digest(cookie_nonce, expected_nonce):
+        resp = _oauth_result_page(
+            False,
+            "This authorization could not be verified for your session. "
+            "Please start the connection again from the connector page.",
+        )
+        resp.delete_cookie(BIND_COOKIE_NAME, path="/")
+        return resp
+
     if not code:
         return _oauth_result_page(False, "No authorization code was returned by the provider.")
 
@@ -420,6 +450,10 @@ async def connector_oauth_callback(
     ok = await connector_service.exchange_authorization_code(
         db=db, connector=connector, user_id=ctx["user_id"], code=code, code_verifier=ctx["code_verifier"],
     )
-    if not ok:
-        return _oauth_result_page(False, "Failed to exchange the authorization code for a token.")
-    return _oauth_result_page(True, f"Connected {connector.namespace}/{connector.name}.")
+    result = _oauth_result_page(
+        ok,
+        f"Connected {connector.namespace}/{connector.name}." if ok
+        else "Failed to exchange the authorization code for a token.",
+    )
+    result.delete_cookie(BIND_COOKIE_NAME, path="/")
+    return result

--- a/backend/app/api/v1/endpoints/connectors.py
+++ b/backend/app/api/v1/endpoints/connectors.py
@@ -25,7 +25,7 @@ from app.schemas.connector import (
     OpenAPIImportResponse,
     OperationConfig,
 )
-from app.services.connector_openapi import extract_operations, parse_openapi_spec
+from app.services.connector_openapi import extract_auth, extract_operations, parse_openapi_spec
 from app.services.connector_service import connector_service
 from app.services.package_service import detach_if_package_managed
 
@@ -106,6 +106,7 @@ async def parse_openapi_standalone(
         spec_title=spec_title,
         spec_description=spec_description,
         spec_base_url=spec_base_url,
+        suggested_auth=extract_auth(spec),
     )
 
 

--- a/backend/app/api/v1/endpoints/connectors.py
+++ b/backend/app/api/v1/endpoints/connectors.py
@@ -3,13 +3,18 @@ import ipaddress
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy import and_, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
-from app.core.oauth_state import generate_pkce_pair, store_state
+from app.core.oauth_state import (
+    BIND_COOKIE_NAME,
+    generate_browser_nonce,
+    generate_pkce_pair,
+    store_state,
+)
 from app.core.permissions import check_permission
 from app.models.connector import Connector
 from app.models.connector_oauth_token import ConnectorOAuthToken
@@ -26,7 +31,7 @@ from app.schemas.connector import (
     OperationConfig,
 )
 from app.services.connector_openapi import extract_auth, extract_operations, parse_openapi_spec
-from app.services.connector_service import connector_service
+from app.services.connector_service import ConnectorAuthError, connector_service
 from app.services.package_service import detach_if_package_managed
 
 router = APIRouter(prefix="/connectors", tags=["connectors"])
@@ -349,6 +354,7 @@ async def import_openapi(
 @router.post("/{namespace}/{name}/oauth/authorize", response_model=OAuthAuthorizeResponse)
 async def begin_oauth_authorization(
     request: Request,
+    response: Response,
     namespace: str,
     name: str,
     db: AsyncSession = Depends(get_db),
@@ -366,12 +372,26 @@ async def begin_oauth_authorization(
         raise HTTPException(status_code=400, detail="Connector is not configured for OAuth authorization-code auth")
 
     verifier, challenge = generate_pkce_pair()
+    # Bind this flow to the initiating browser: the nonce is stored with the state AND set
+    # as an HttpOnly cookie here; the callback requires the two to match. This is what stops
+    # an attacker minting a state and having a victim complete it under the attacker's account.
+    browser_nonce = generate_browser_nonce()
     state = await store_state(
-        user_id=str(user_id), namespace=namespace, name=name, code_verifier=verifier
+        user_id=str(user_id), namespace=namespace, name=name,
+        code_verifier=verifier, browser_nonce=browser_nonce,
     )
     url = connector_service.build_authorize_url(connector.auth, state, challenge)
     if not url:
         raise HTTPException(status_code=400, detail="Connector OAuth config is incomplete (authorize_url/client_id)")
+    response.set_cookie(
+        key=BIND_COOKIE_NAME,
+        value=browser_nonce,
+        max_age=600,  # matches STATE_TTL_SECONDS
+        httponly=True,
+        secure=request.url.scheme == "https",
+        samesite="lax",  # sent on the provider's top-level GET redirect back to the callback
+        path="/",
+    )
     return OAuthAuthorizeResponse(authorize_url=url)
 
 
@@ -454,6 +474,7 @@ async def test_operation(
             operation_name=operation_name,
             parameters=test_data.parameters,
             user_token=user_token,
+            user_id=user_id,
         )
         return ConnectorTestResponse(
             status_code=result["status_code"],
@@ -461,6 +482,8 @@ async def test_operation(
             body=result.get("body"),
             elapsed_ms=result.get("elapsed_ms", 0),
         )
+    except ConnectorAuthError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/backend/app/api/v1/endpoints/connectors.py
+++ b/backend/app/api/v1/endpoints/connectors.py
@@ -4,19 +4,23 @@ from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import and_, select
+from sqlalchemy import and_, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
+from app.core.oauth_state import generate_pkce_pair, store_state
 from app.core.permissions import check_permission
 from app.models.connector import Connector
+from app.models.connector_oauth_token import ConnectorOAuthToken
 from app.schemas.connector import (
     ConnectorCreate,
     ConnectorResponse,
     ConnectorTestRequest,
     ConnectorTestResponse,
     ConnectorUpdate,
+    OAuthAuthorizeResponse,
+    OAuthStatusResponse,
     OpenAPIImportRequest,
     OpenAPIImportResponse,
     OperationConfig,
@@ -338,6 +342,81 @@ async def import_openapi(
         operations=parsed_ops,
         warnings=warnings,
         applied=applied,
+    )
+
+
+@router.post("/{namespace}/{name}/oauth/authorize", response_model=OAuthAuthorizeResponse)
+async def begin_oauth_authorization(
+    request: Request,
+    namespace: str,
+    name: str,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Begin the per-user OAuth authorization-code flow; returns the provider URL to open."""
+    user_id, permissions = current_user_data
+    connector = await Connector.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="read",
+        namespace=namespace, name=name,
+    )
+    set_permission_used(request, f"sinas.connectors/{namespace}/{name}.read")
+
+    if (connector.auth or {}).get("type") != "oauth2_authorization_code":
+        raise HTTPException(status_code=400, detail="Connector is not configured for OAuth authorization-code auth")
+
+    verifier, challenge = generate_pkce_pair()
+    state = await store_state(
+        user_id=str(user_id), namespace=namespace, name=name, code_verifier=verifier
+    )
+    url = connector_service.build_authorize_url(connector.auth, state, challenge)
+    if not url:
+        raise HTTPException(status_code=400, detail="Connector OAuth config is incomplete (authorize_url/client_id)")
+    return OAuthAuthorizeResponse(authorize_url=url)
+
+
+@router.get("/{namespace}/{name}/oauth/status", response_model=OAuthStatusResponse)
+async def oauth_status(
+    request: Request,
+    namespace: str,
+    name: str,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Report whether the current user has a stored OAuth token for this connector."""
+    user_id, permissions = current_user_data
+    connector = await Connector.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="read",
+        namespace=namespace, name=name,
+    )
+    result = await db.execute(
+        select(ConnectorOAuthToken).where(
+            and_(ConnectorOAuthToken.connector_id == connector.id, ConnectorOAuthToken.user_id == user_id)
+        )
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        return OAuthStatusResponse(connected=False)
+    return OAuthStatusResponse(connected=True, expires_at=row.expires_at, scope=row.scope)
+
+
+@router.delete("/{namespace}/{name}/oauth/token", status_code=status.HTTP_204_NO_CONTENT)
+async def disconnect_oauth(
+    request: Request,
+    namespace: str,
+    name: str,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Delete the current user's stored OAuth token for this connector."""
+    user_id, permissions = current_user_data
+    connector = await Connector.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="read",
+        namespace=namespace, name=name,
+    )
+    await db.execute(
+        delete(ConnectorOAuthToken).where(
+            and_(ConnectorOAuthToken.connector_id == connector.id, ConnectorOAuthToken.user_id == user_id)
+        )
     )
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -185,6 +185,19 @@ class Settings(BaseSettings):
     # Domain (for generating external URLs, e.g., temp file URLs)
     domain: Optional[str] = None  # FQDN like "app.example.com"; localhost or None = no external URLs
 
+    @property
+    def public_base_url(self) -> str:
+        """External origin the browser reaches this app at ('scheme://host', no trailing slash).
+
+        Single source of truth for public URLs the browser must hit exactly (OAuth
+        redirect/callback, postMessage target origin). Falls back to the backend port for
+        local dev when no external domain is configured.
+        """
+        domain = (self.domain or "").strip()
+        if not domain or domain.lower() in ("localhost", "127.0.0.1"):
+            return f"http://localhost:{self.backend_port}"
+        return f"https://{domain}"
+
     # Component builder
     builder_url: str = "http://sinas-builder:3000"  # URL for esbuild compilation service
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -185,6 +185,15 @@ class Settings(BaseSettings):
     # Domain (for generating external URLs, e.g., temp file URLs)
     domain: Optional[str] = None  # FQDN like "app.example.com"; localhost or None = no external URLs
 
+    # OAuth authorization-code: bind the consent flow to the browser that started it
+    # (an HttpOnly nonce cookie set by the authenticated begin call, checked at the
+    # callback) to prevent account-linking/login-CSRF. Requires the console and API to be
+    # same-site (they are in a normal single-domain deployment). MUST stay True in any
+    # multi-user/production deployment. Set False ONLY for local dev where the console and
+    # API run on different origins (e.g. console :51245 + API :8000) so the cookie can't
+    # round-trip — disabling it there just removes the extra CSRF check for local testing.
+    oauth_bind_browser_session: bool = True
+
     @property
     def public_base_url(self) -> str:
         """External origin the browser reaches this app at ('scheme://host', no trailing slash).

--- a/backend/app/core/oauth_state.py
+++ b/backend/app/core/oauth_state.py
@@ -1,0 +1,53 @@
+"""Short-lived, single-use state for the connector OAuth authorization-code flow.
+
+The provider does not send our bearer token on its redirect, so we cannot authenticate
+the callback directly. Instead the authenticated "begin" endpoint mints an opaque state,
+stores the initiating user + connector (and the PKCE verifier) in Redis under it, and the
+public callback looks the request back up by state. State is deleted on first use (CSRF /
+replay protection) and expires on its own after STATE_TTL_SECONDS.
+"""
+import base64
+import hashlib
+import json
+import secrets
+from typing import Optional
+
+from app.core.redis import get_redis
+
+STATE_TTL_SECONDS = 600  # 10 minutes to complete the consent screen
+_KEY_PREFIX = "connector_oauth_state:"
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for PKCE S256."""
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+async def store_state(*, user_id: str, namespace: str, name: str, code_verifier: str) -> str:
+    """Persist flow context under a fresh opaque state token and return the token."""
+    state = secrets.token_urlsafe(32)
+    payload = json.dumps(
+        {"user_id": user_id, "namespace": namespace, "name": name, "code_verifier": code_verifier}
+    )
+    redis = await get_redis()
+    await redis.set(_KEY_PREFIX + state, payload, ex=STATE_TTL_SECONDS)
+    return state
+
+
+async def consume_state(state: str) -> Optional[dict]:
+    """Fetch and delete the flow context for a state. Returns None if unknown/expired."""
+    if not state:
+        return None
+    redis = await get_redis()
+    key = _KEY_PREFIX + state
+    # GETDEL makes state single-use even under concurrent callbacks.
+    raw = await redis.getdel(key)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None

--- a/backend/app/core/oauth_state.py
+++ b/backend/app/core/oauth_state.py
@@ -5,6 +5,12 @@ the callback directly. Instead the authenticated "begin" endpoint mints an opaqu
 stores the initiating user + connector (and the PKCE verifier) in Redis under it, and the
 public callback looks the request back up by state. State is deleted on first use (CSRF /
 replay protection) and expires on its own after STATE_TTL_SECONDS.
+
+The state also carries a `browser_nonce` that the begin endpoint sets as an HttpOnly
+cookie in the initiating browser; the callback requires the cookie to match. This binds
+the flow to the browser that started it, preventing OAuth account-linking / login-CSRF:
+an attacker who mints a state and hands its authorize URL to a victim cannot capture the
+victim's tokens, because the victim's browser won't carry the attacker's nonce cookie.
 """
 import base64
 import hashlib
@@ -15,6 +21,7 @@ from typing import Optional
 from app.core.redis import get_redis
 
 STATE_TTL_SECONDS = 600  # 10 minutes to complete the consent screen
+BIND_COOKIE_NAME = "sinas_coauth"  # HttpOnly cookie carrying the browser-binding nonce
 _KEY_PREFIX = "connector_oauth_state:"
 
 
@@ -26,15 +33,28 @@ def generate_pkce_pair() -> tuple[str, str]:
     return verifier, challenge
 
 
-async def store_state(*, user_id: str, namespace: str, name: str, code_verifier: str) -> str:
+async def store_state(
+    *, user_id: str, namespace: str, name: str, code_verifier: str, browser_nonce: str
+) -> str:
     """Persist flow context under a fresh opaque state token and return the token."""
     state = secrets.token_urlsafe(32)
     payload = json.dumps(
-        {"user_id": user_id, "namespace": namespace, "name": name, "code_verifier": code_verifier}
+        {
+            "user_id": user_id,
+            "namespace": namespace,
+            "name": name,
+            "code_verifier": code_verifier,
+            "browser_nonce": browser_nonce,
+        }
     )
     redis = await get_redis()
     await redis.set(_KEY_PREFIX + state, payload, ex=STATE_TTL_SECONDS)
     return state
+
+
+def generate_browser_nonce() -> str:
+    """Return an opaque nonce to bind an authorization flow to one browser."""
+    return secrets.token_urlsafe(32)
 
 
 async def consume_state(state: str) -> Optional[dict]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from .base import Base
 from .batch import Batch, BatchKind, BatchStatus
 from .chat import Chat, Message
 from .connector import Connector
+from .connector_oauth_token import ConnectorOAuthToken
 from .component import Component
 from .component_share import ComponentShare
 from .database_connection import DatabaseConnection
@@ -55,6 +56,7 @@ __all__ = [
     "Component",
     "ComponentShare",
     "Connector",
+    "ConnectorOAuthToken",
     "LLMProvider",
     "DatabaseConnection",
     "DatabaseTrigger",

--- a/backend/app/models/connector.py
+++ b/backend/app/models/connector.py
@@ -23,7 +23,7 @@ class Connector(Base, PermissionMixin):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     base_url: Mapped[str] = mapped_column(Text, nullable=False)
 
-    # Auth: {"type": "bearer|basic|api_key|sinas_token|none", "secret": "SECRET_NAME", ...}
+    # Auth: {"type": "bearer|basic|api_key|sinas_token|oauth2_client_credentials|none", "secret": "SECRET_NAME", ...}
     auth: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict, server_default='{"type": "none"}')
 
     # Static default headers: {"X-Custom": "value"}

--- a/backend/app/models/connector_oauth_token.py
+++ b/backend/app/models/connector_oauth_token.py
@@ -1,0 +1,44 @@
+"""Per-user OAuth 2.0 tokens for connectors using the authorization-code grant.
+
+One row per (connector, user). Access and refresh tokens are encrypted at rest with
+the same Fernet-based encryption_service used for Secrets; expires_at is kept in a
+plain column so the resolver can decide when to refresh without decrypting anything.
+"""
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base, created_at, updated_at, uuid_pk
+
+
+class ConnectorOAuthToken(Base):
+    """A user's stored OAuth token for a connector (authorization-code grant)."""
+
+    __tablename__ = "connector_oauth_tokens"
+
+    id: Mapped[uuid_pk]
+    connector_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("connectors.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Ciphertext produced by encryption_service.encrypt (never store raw tokens).
+    encrypted_access_token: Mapped[str] = mapped_column(Text, nullable=False)
+    encrypted_refresh_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # Plain columns so refresh decisions don't require decryption.
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    scope: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    token_type: Mapped[str] = mapped_column(String(40), nullable=False, default="Bearer", server_default="Bearer")
+
+    created_at: Mapped[created_at]
+    updated_at: Mapped[updated_at]
+
+    __table_args__ = (
+        UniqueConstraint("connector_id", "user_id", name="uq_connector_oauth_token_connector_user"),
+    )

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -382,6 +382,25 @@ class ConnectorAuthConfig(BaseModel):
     tokenParams: Optional[dict[str, str]] = None
 
 
+# Single source of truth for connector auth field names across the config round-trip:
+# (camelCase config key, snake_case stored-auth key). Used by config-apply (camel→snake)
+# and the serializer (snake→camel) so a new auth field is added in exactly one place here
+# plus the two schema models above/`ConnectorAuth`, not in four hand-kept lists.
+CONNECTOR_AUTH_FIELD_MAP: list[tuple[str, str]] = [
+    ("type", "type"),
+    ("secret", "secret"),
+    ("header", "header"),
+    ("position", "position"),
+    ("paramName", "param_name"),
+    ("tokenUrl", "token_url"),
+    ("clientId", "client_id"),
+    ("scopes", "scopes"),
+    ("clientAuthMethod", "client_auth_method"),
+    ("authorizeUrl", "authorize_url"),
+    ("tokenParams", "token_params"),
+]
+
+
 class ConnectorRetryConfig(BaseModel):
     """Connector retry configuration"""
 

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -367,6 +367,13 @@ class ConnectorAuthConfig(BaseModel):
     header: Optional[str] = None
     position: Optional[str] = None
     paramName: Optional[str] = None
+    # OAuth 2.0 (client-credentials and authorization-code) fields.
+    tokenUrl: Optional[str] = None
+    clientId: Optional[str] = None
+    scopes: Optional[list[str]] = None
+    clientAuthMethod: Optional[str] = None
+    authorizeUrl: Optional[str] = None
+    tokenParams: Optional[dict[str, str]] = None
 
 
 class ConnectorRetryConfig(BaseModel):

--- a/backend/app/schemas/connector.py
+++ b/backend/app/schemas/connector.py
@@ -19,11 +19,25 @@ class OperationConfig(BaseModel):
 
 
 class ConnectorAuth(BaseModel):
-    type: str = Field(default="none", pattern=r"^(bearer|basic|api_key|sinas_token|none)$")
+    type: str = Field(
+        default="none",
+        pattern=r"^(bearer|basic|api_key|sinas_token|oauth2_client_credentials|none)$",
+    )
     secret: Optional[str] = None
     header: Optional[str] = None
     position: Optional[str] = Field(default=None, pattern=r"^(header|query)$")
     param_name: Optional[str] = None
+
+    # OAuth 2.0 client-credentials grant (type="oauth2_client_credentials").
+    # `secret` holds the name of the Secret containing the client secret.
+    token_url: Optional[str] = None
+    client_id: Optional[str] = None
+    scopes: Optional[list[str]] = None
+    # How to present client credentials to the token endpoint:
+    # "basic" = HTTP Basic (client_secret_basic), "body" = form fields (client_secret_post).
+    client_auth_method: Optional[str] = Field(default=None, pattern=r"^(basic|body)$")
+    # Extra params sent with the token request (e.g. {"audience": "..."}).
+    token_params: Optional[dict[str, str]] = None
 
 
 class ConnectorRetry(BaseModel):

--- a/backend/app/schemas/connector.py
+++ b/backend/app/schemas/connector.py
@@ -21,18 +21,22 @@ class OperationConfig(BaseModel):
 class ConnectorAuth(BaseModel):
     type: str = Field(
         default="none",
-        pattern=r"^(bearer|basic|api_key|sinas_token|oauth2_client_credentials|none)$",
+        pattern=r"^(bearer|basic|api_key|sinas_token|oauth2_client_credentials|oauth2_authorization_code|none)$",
     )
     secret: Optional[str] = None
     header: Optional[str] = None
     position: Optional[str] = Field(default=None, pattern=r"^(header|query)$")
     param_name: Optional[str] = None
 
-    # OAuth 2.0 client-credentials grant (type="oauth2_client_credentials").
+    # OAuth 2.0 grants (client-credentials and authorization-code).
     # `secret` holds the name of the Secret containing the client secret.
     token_url: Optional[str] = None
     client_id: Optional[str] = None
     scopes: Optional[list[str]] = None
+    # Authorization-code grant only (type="oauth2_authorization_code"): the provider's
+    # authorization endpoint the user's browser is redirected to. Tokens are stored
+    # per-user (see ConnectorOAuthToken) rather than shared.
+    authorize_url: Optional[str] = None
     # How to present client credentials to the token endpoint:
     # "basic" = HTTP Basic (client_secret_basic), "body" = form fields (client_secret_post).
     client_auth_method: Optional[str] = Field(default=None, pattern=r"^(basic|body)$")
@@ -98,6 +102,18 @@ class ConnectorTestResponse(BaseModel):
     headers: dict[str, str]
     body: Any
     elapsed_ms: float
+
+
+class OAuthAuthorizeResponse(BaseModel):
+    """Where to redirect the user's browser to begin the authorization-code flow."""
+    authorize_url: str
+
+
+class OAuthStatusResponse(BaseModel):
+    """Whether the current user has a stored OAuth token for a connector."""
+    connected: bool
+    expires_at: Optional[datetime] = None
+    scope: Optional[str] = None
 
 
 class OpenAPIImportRequest(BaseModel):

--- a/backend/app/schemas/connector.py
+++ b/backend/app/schemas/connector.py
@@ -131,3 +131,5 @@ class OpenAPIImportResponse(BaseModel):
     spec_title: Optional[str] = None
     spec_description: Optional[str] = None
     spec_base_url: Optional[str] = None
+    # Auth derived from the spec's securitySchemes (minus secrets); None if not mappable.
+    suggested_auth: Optional[dict[str, Any]] = None

--- a/backend/app/services/config_apply/resources.py
+++ b/backend/app/services/config_apply/resources.py
@@ -24,6 +24,7 @@ from app.models.secret import Secret
 from app.models.skill import Skill
 from app.models.store import Store
 
+from app.schemas.config import CONNECTOR_AUTH_FIELD_MAP
 from app.services.config_apply.normalizers import normalize_store_references, should_skip_existing
 
 logger = logging.getLogger(__name__)
@@ -65,18 +66,10 @@ async def apply_connectors(
                     "response_mapping": op.responseMapping,
                 })
 
+            # Map camelCase config keys → snake_case stored keys via the single field map.
             auth = {
-                "type": conn_config.auth.type,
-                "secret": conn_config.auth.secret,
-                "header": conn_config.auth.header,
-                "position": conn_config.auth.position,
-                "param_name": conn_config.auth.paramName,
-                "token_url": conn_config.auth.tokenUrl,
-                "client_id": conn_config.auth.clientId,
-                "scopes": conn_config.auth.scopes,
-                "client_auth_method": conn_config.auth.clientAuthMethod,
-                "authorize_url": conn_config.auth.authorizeUrl,
-                "token_params": conn_config.auth.tokenParams,
+                snake: getattr(conn_config.auth, camel)
+                for camel, snake in CONNECTOR_AUTH_FIELD_MAP
             }
             # Remove None values from auth
             auth = {k: v for k, v in auth.items() if v is not None}

--- a/backend/app/services/config_apply/resources.py
+++ b/backend/app/services/config_apply/resources.py
@@ -71,6 +71,12 @@ async def apply_connectors(
                 "header": conn_config.auth.header,
                 "position": conn_config.auth.position,
                 "param_name": conn_config.auth.paramName,
+                "token_url": conn_config.auth.tokenUrl,
+                "client_id": conn_config.auth.clientId,
+                "scopes": conn_config.auth.scopes,
+                "client_auth_method": conn_config.auth.clientAuthMethod,
+                "authorize_url": conn_config.auth.authorizeUrl,
+                "token_params": conn_config.auth.tokenParams,
             }
             # Remove None values from auth
             auth = {k: v for k, v in auth.items() if v is not None}

--- a/backend/app/services/connector_openapi.py
+++ b/backend/app/services/connector_openapi.py
@@ -9,6 +9,81 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+def _map_security_scheme(scheme: dict, requested_scopes: Optional[list[str]]) -> Optional[dict[str, Any]]:
+    """Map one OpenAPI securityScheme to a connector auth config (no secrets)."""
+    stype = (scheme.get("type") or "").lower()
+
+    if stype == "apikey":
+        param_name = scheme.get("name")
+        location = scheme.get("in")
+        if location == "header":
+            return {"type": "api_key", "position": "header", "header": param_name or "X-Api-Key"}
+        if location == "query":
+            return {"type": "api_key", "position": "query", "param_name": param_name or "api_key"}
+        return None  # cookie apiKey is not supported by connectors
+
+    if stype == "http":
+        http_scheme = (scheme.get("scheme") or "").lower()
+        if http_scheme == "bearer":
+            return {"type": "bearer"}
+        if http_scheme == "basic":
+            return {"type": "basic"}
+        return None
+
+    if stype == "oauth2":
+        flows = scheme.get("flows") or {}
+        # Prefer per-user authorization-code, then machine-to-machine client-credentials.
+        if isinstance(flows.get("authorizationCode"), dict):
+            flow = flows["authorizationCode"]
+            return {
+                "type": "oauth2_authorization_code",
+                "authorize_url": flow.get("authorizationUrl"),
+                "token_url": flow.get("tokenUrl"),
+                "scopes": requested_scopes or list((flow.get("scopes") or {}).keys()),
+            }
+        if isinstance(flows.get("clientCredentials"), dict):
+            flow = flows["clientCredentials"]
+            return {
+                "type": "oauth2_client_credentials",
+                "token_url": flow.get("tokenUrl"),
+                "scopes": requested_scopes or list((flow.get("scopes") or {}).keys()),
+            }
+        return None  # implicit/password flows aren't supported server-side
+
+    return None  # openIdConnect and unknown types
+
+
+def extract_auth(spec: dict) -> Optional[dict[str, Any]]:
+    """Derive a suggested connector auth config from a spec's securitySchemes.
+
+    Returns the auth config in the connector's stored (snake_case) shape, minus any
+    secret/client_id (those aren't in the spec — the user supplies them). Returns None
+    if the spec declares no mappable scheme. When the top-level `security` requirement
+    names specific schemes/scopes, those are preferred over the raw scheme definitions.
+    """
+    schemes = ((spec.get("components") or {}).get("securitySchemes")) or {}
+    if not schemes:
+        return None
+
+    # Scheme name -> required scopes, from the top-level security requirement (if any).
+    requested: dict[str, list[str]] = {}
+    for requirement in (spec.get("security") or []):
+        if isinstance(requirement, dict):
+            for scheme_name, scopes in requirement.items():
+                requested[scheme_name] = scopes or []
+
+    # Try requested schemes first, then any remaining declared scheme.
+    ordered_names = list(requested.keys()) + [n for n in schemes if n not in requested]
+    for name in ordered_names:
+        scheme = schemes.get(name)
+        if not isinstance(scheme, dict):
+            continue
+        mapped = _map_security_scheme(scheme, requested.get(name))
+        if mapped:
+            return {k: v for k, v in mapped.items() if v is not None and v != []}
+    return None
+
+
 def parse_openapi_spec(raw: str) -> dict[str, Any]:
     """Parse JSON or YAML OpenAPI spec string."""
     try:

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -1,6 +1,7 @@
 """Connector service — executes HTTP operations in-process."""
 import asyncio
 import base64
+import json
 import logging
 import re
 import time
@@ -20,6 +21,15 @@ from app.models.connector_oauth_token import ConnectorOAuthToken
 from app.models.secret import Secret
 
 logger = logging.getLogger(__name__)
+
+
+class ConnectorAuthError(Exception):
+    """Raised when a connector's auth cannot be resolved and the request must NOT be sent.
+
+    Distinct from a transport/HTTP error: this means we deliberately refuse to send an
+    unauthenticated request (e.g. an OAuth user token is missing or expired). The message
+    is safe to surface to the caller and usually tells them to reconnect their account.
+    """
 
 # Connection pool limits
 MAX_CONNECTIONS = 200          # Total across all hosts
@@ -41,6 +51,10 @@ class ConnectorService:
         self._oauth_tokens: dict[str, tuple[str, float]] = {}
         # Per-cache-key locks to avoid stampeding the token endpoint on concurrent misses
         self._oauth_locks: dict[str, asyncio.Lock] = {}
+        # Per-(connector, user) locks: single-flight the authorization-code refresh within
+        # this process so a fan-out of concurrent calls doesn't open N DB sessions all
+        # blocking on the same row lock (pool exhaustion). See _refresh_authorization_code_token.
+        self._refresh_locks: dict[str, asyncio.Lock] = {}
 
     def _get_client(self) -> httpx.AsyncClient:
         """Get or create the shared httpx client with connection pooling."""
@@ -186,13 +200,21 @@ class ConnectorService:
         if auth_type == "oauth2_client_credentials":
             token = await self._get_client_credentials_token(db, auth_config, user_id)
             if not token:
-                return {}, {}
+                # Fail closed: sending the request unauthenticated would surface the
+                # provider's raw 401 as a "successful" result. Make the failure explicit.
+                raise ConnectorAuthError(
+                    "Could not obtain an OAuth token for this connector. "
+                    "Check the connector's token URL, client ID, and client secret."
+                )
             return {"Authorization": f"Bearer {token}"}, {}
 
         if auth_type == "oauth2_authorization_code":
             token = await self._get_authorization_code_token(db, connector_id, auth_config, user_id)
             if not token:
-                return {}, {}
+                raise ConnectorAuthError(
+                    "This connector is not connected for your account, or its authorization "
+                    "has expired. Reconnect the connector and try again."
+                )
             return {"Authorization": f"Bearer {token}"}, {}
 
         # All other types require a secret
@@ -212,7 +234,10 @@ class ConnectorService:
             encoded = base64.b64encode(secret_value.encode()).decode()
             return {"Authorization": f"Basic {encoded}"}, {}
         elif auth_type == "api_key":
-            if auth_config.get("position") == "query":
+            # Header is the default and the historical behavior; only an explicit
+            # position="query" sends the key as a query parameter. (Case-insensitive so a
+            # stray "Query" doesn't silently fall back to header.)
+            if str(auth_config.get("position") or "header").lower() == "query":
                 param_name = auth_config.get("param_name") or "api_key"
                 return {}, {param_name: secret_value}
             header_name = auth_config.get("header") or "X-Api-Key"
@@ -267,10 +292,25 @@ class ConnectorService:
         scopes = auth_config.get("scopes") or []
         scope_str = " ".join(scopes) if isinstance(scopes, list) else str(scopes)
         client_auth_method = auth_config.get("client_auth_method") or "body"
+        token_params = auth_config.get("token_params")
 
-        # Distinct creds/scope/endpoint get distinct cache entries. user_id is included
-        # because a private secret override yields a different (per-user) token.
-        cache_key = f"{user_id or 'shared'}|{token_url}|{client_id}|{scope_str}"
+        # Distinct creds/scope/endpoint/extra-params get distinct cache entries — anything
+        # that changes the minted token must be in the key or two connectors would alias
+        # each other's tokens (e.g. same client_id but different `audience` in token_params,
+        # or a secret rotated to a different Secret name). user_id is included because a
+        # private secret override yields a different (per-user) token.
+        token_params_key = json.dumps(token_params, sort_keys=True) if isinstance(token_params, dict) else ""
+        cache_key = "|".join(
+            [
+                user_id or "shared",
+                token_url,
+                client_id,
+                scope_str,
+                client_auth_method,
+                secret_name,
+                token_params_key,
+            ]
+        )
 
         # Fast path: a still-valid cached token.
         cached = self._oauth_tokens.get(cache_key)
@@ -422,14 +462,22 @@ class ConnectorService:
             row.scope = payload["scope"]
         if payload.get("token_type"):
             row.token_type = payload["token_type"]
+
         expires_in = payload.get("expires_in")
         try:
             ttl = int(expires_in) if expires_in is not None else None
         except (TypeError, ValueError):
             ttl = None
-        row.expires_at = (
-            datetime.now(timezone.utc) + timedelta(seconds=ttl) if ttl is not None else None
-        )
+
+        if ttl is not None:
+            row.expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl)
+        elif row.encrypted_refresh_token:
+            # No expiry given but we CAN refresh: assume a conservative lifetime so the
+            # token is proactively refreshed, rather than trusted forever and then failing
+            # with a dead bearer that never triggers a refresh (RFC 6749 lets refresh
+            # responses omit expires_in). Never overwrite a known expiry with None here.
+            row.expires_at = datetime.now(timezone.utc) + timedelta(seconds=OAUTH_DEFAULT_TTL)
+        # else: no expiry and no way to refresh — leave expires_at as-is (best effort).
 
     async def exchange_authorization_code(
         self, db: AsyncSession, connector: Connector, user_id: str, code: str, code_verifier: str
@@ -526,15 +574,19 @@ class ConnectorService:
     ) -> Optional[str]:
         """Refresh a per-user token under a row lock, in its own short-lived transaction.
 
-        `SELECT ... FOR UPDATE` on the single (connector, user) row serializes concurrent
-        refreshers across processes/containers. We re-check validity under the lock so a
-        request that lost the race uses the winner's freshly-stored token instead of
-        issuing a second (refresh-token-rotating) refresh. The lock is held only for the
-        token POST and released on commit — it does not span the caller's execution.
+        Two layers of serialization:
+        - A process-local asyncio lock keyed by (connector, user) single-flights the refresh
+          within this process, so a fan-out of concurrent calls doesn't each open a DB
+          session and block on the row lock (which would pin N pool connections for up to
+          the token POST's 30s timeout). Losers wait on the asyncio lock — holding no DB
+          connection — then the double-check below returns the winner's freshly-stored token.
+        - `SELECT ... FOR UPDATE` on the single (connector, user) row then serializes across
+          processes/containers so a rotating refresh token isn't spent twice.
         """
         from app.core.database import AsyncSessionLocal
 
-        async with AsyncSessionLocal() as session:
+        lock = self._refresh_locks.setdefault(f"{connector_id}|{user_id}", asyncio.Lock())
+        async with lock, AsyncSessionLocal() as session:
             async with session.begin():
                 result = await session.execute(
                     select(ConnectorOAuthToken)

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -4,15 +4,19 @@ import base64
 import logging
 import re
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+from urllib.parse import urlencode
 
 import httpx
 from jinja2 import Template
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.encryption import encryption_service
 from app.models.connector import Connector
+from app.models.connector_oauth_token import ConnectorOAuthToken
 from app.models.secret import Secret
 
 logger = logging.getLogger(__name__)
@@ -71,7 +75,9 @@ class ConnectorService:
             raise ValueError(f"Operation '{operation_name}' not found on connector '{connector.namespace}/{connector.name}'")
 
         # Resolve auth (private secrets override shared for this user)
-        auth_headers, auth_query = await self._resolve_auth(db, connector.auth, user_token, user_id)
+        auth_headers, auth_query = await self._resolve_auth(
+            db, connector.auth, user_token, user_id, connector_id=connector.id
+        )
 
         # Build request
         method = operation["method"]
@@ -159,7 +165,7 @@ class ConnectorService:
 
     async def _resolve_auth(
         self, db: AsyncSession, auth_config: dict[str, Any], user_token: Optional[str],
-        user_id: Optional[str] = None,
+        user_id: Optional[str] = None, connector_id: Optional[Any] = None,
     ) -> tuple[dict[str, str], dict[str, str]]:
         """Resolve auth config into (headers, query_params). Private secrets override shared.
 
@@ -179,6 +185,12 @@ class ConnectorService:
 
         if auth_type == "oauth2_client_credentials":
             token = await self._get_client_credentials_token(db, auth_config, user_id)
+            if not token:
+                return {}, {}
+            return {"Authorization": f"Bearer {token}"}, {}
+
+        if auth_type == "oauth2_authorization_code":
+            token = await self._get_authorization_code_token(db, connector_id, auth_config, user_id)
             if not token:
                 return {}, {}
             return {"Authorization": f"Bearer {token}"}, {}
@@ -328,6 +340,201 @@ class ConnectorService:
                 f"Obtained OAuth client-credentials token from {token_url} (ttl={ttl}s)"
             )
             return access_token
+
+    # ------------------------------------------------------------------
+    # OAuth 2.0 authorization-code grant (per-user tokens)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def oauth_redirect_uri() -> str:
+        """Public callback URL the provider redirects the browser back to.
+
+        Must exactly match the redirect URI registered with the OAuth provider.
+        """
+        domain = settings.domain
+        path = "/auth/connectors/oauth/callback"
+        if not domain or domain.lower() in ("localhost", "127.0.0.1"):
+            return f"http://localhost:{settings.backend_port}{path}"
+        return f"https://{domain}{path}"
+
+    def build_authorize_url(
+        self, auth_config: dict[str, Any], state: str, code_challenge: str
+    ) -> Optional[str]:
+        """Build the provider authorization URL to redirect the user's browser to."""
+        authorize_url = auth_config.get("authorize_url")
+        client_id = auth_config.get("client_id")
+        if not authorize_url or not client_id:
+            return None
+        scopes = auth_config.get("scopes") or []
+        scope_str = " ".join(scopes) if isinstance(scopes, list) else str(scopes)
+        params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": self.oauth_redirect_uri(),
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        if scope_str:
+            params["scope"] = scope_str
+        sep = "&" if "?" in authorize_url else "?"
+        return f"{authorize_url}{sep}{urlencode(params)}"
+
+    async def _post_token_request(
+        self, token_url: str, data: dict[str, str], client_id: str,
+        client_secret: str, client_auth_method: str,
+    ) -> Optional[dict[str, Any]]:
+        """POST a token request (code exchange or refresh) and return the parsed JSON."""
+        headers = {"Accept": "application/json"}
+        if client_auth_method == "basic":
+            encoded = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+            headers["Authorization"] = f"Basic {encoded}"
+        else:  # "body" — client_secret_post
+            data = {**data, "client_id": client_id, "client_secret": client_secret}
+
+        try:
+            async with self._semaphore:
+                client = self._get_client()
+                resp = await client.post(token_url, data=data, headers=headers, timeout=30.0)
+        except Exception as e:
+            logger.error(f"OAuth token request to {token_url} failed: {e}")
+            return None
+
+        if resp.status_code != 200:
+            logger.error(
+                f"OAuth token endpoint {token_url} returned {resp.status_code}: {resp.text[:200]}"
+            )
+            return None
+        try:
+            return resp.json()
+        except Exception:
+            logger.error(f"OAuth token endpoint {token_url} returned a non-JSON body")
+            return None
+
+    def _store_token_fields(self, row: ConnectorOAuthToken, payload: dict[str, Any]) -> None:
+        """Copy a token-endpoint payload onto a ConnectorOAuthToken row (encrypting tokens)."""
+        row.encrypted_access_token = encryption_service.encrypt(payload["access_token"])
+        # Providers may omit refresh_token on refresh; keep the existing one if so.
+        new_refresh = payload.get("refresh_token")
+        if new_refresh:
+            row.encrypted_refresh_token = encryption_service.encrypt(new_refresh)
+        if payload.get("scope"):
+            row.scope = payload["scope"]
+        if payload.get("token_type"):
+            row.token_type = payload["token_type"]
+        expires_in = payload.get("expires_in")
+        try:
+            ttl = int(expires_in) if expires_in is not None else None
+        except (TypeError, ValueError):
+            ttl = None
+        row.expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=ttl) if ttl is not None else None
+        )
+
+    async def exchange_authorization_code(
+        self, db: AsyncSession, connector: Connector, user_id: str, code: str, code_verifier: str
+    ) -> bool:
+        """Exchange an authorization code for tokens and persist them for this user."""
+        auth_config = connector.auth or {}
+        token_url = auth_config.get("token_url")
+        client_id = auth_config.get("client_id")
+        secret_name = auth_config.get("secret")
+        if not token_url or not client_id or not secret_name:
+            logger.warning("oauth2_authorization_code requires token_url, client_id, and secret")
+            return False
+
+        client_secret = await self._resolve_secret_value(db, secret_name, user_id)
+        if client_secret is None:
+            logger.warning(f"OAuth client secret '{secret_name}' not found")
+            return False
+
+        payload = await self._post_token_request(
+            token_url,
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self.oauth_redirect_uri(),
+                "code_verifier": code_verifier,
+            },
+            client_id,
+            client_secret,
+            auth_config.get("client_auth_method") or "body",
+        )
+        if not payload or not payload.get("access_token"):
+            return False
+
+        row = await self._get_token_row(db, connector.id, user_id)
+        if row is None:
+            row = ConnectorOAuthToken(connector_id=connector.id, user_id=user_id, encrypted_access_token="")
+            db.add(row)
+        self._store_token_fields(row, payload)
+        await db.flush()
+        logger.info(f"Stored OAuth token for connector {connector.namespace}/{connector.name} user={user_id}")
+        return True
+
+    async def _get_token_row(
+        self, db: AsyncSession, connector_id: Any, user_id: str
+    ) -> Optional[ConnectorOAuthToken]:
+        result = await db.execute(
+            select(ConnectorOAuthToken).where(
+                and_(
+                    ConnectorOAuthToken.connector_id == connector_id,
+                    ConnectorOAuthToken.user_id == user_id,
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _get_authorization_code_token(
+        self, db: AsyncSession, connector_id: Any, auth_config: dict[str, Any], user_id: Optional[str]
+    ) -> Optional[str]:
+        """Return a valid access token for this user, refreshing if it has (nearly) expired."""
+        if not connector_id or not user_id:
+            logger.warning("oauth2_authorization_code auth requires a connector and user context")
+            return None
+
+        row = await self._get_token_row(db, connector_id, user_id)
+        if row is None:
+            logger.warning(f"No OAuth token stored for connector {connector_id} user {user_id}")
+            return None
+
+        # Still valid (with skew)? Use it.
+        if row.expires_at is not None:
+            skew = timedelta(seconds=OAUTH_TOKEN_TTL_SKEW)
+            if row.expires_at - skew > datetime.now(timezone.utc):
+                return encryption_service.decrypt(row.encrypted_access_token)
+        elif row.encrypted_access_token:
+            # No expiry known — assume the stored token is usable.
+            return encryption_service.decrypt(row.encrypted_access_token)
+
+        # Expired (or expiring): try to refresh.
+        if not row.encrypted_refresh_token:
+            logger.warning(f"OAuth token for connector {connector_id} expired and has no refresh token")
+            return None
+
+        token_url = auth_config.get("token_url")
+        client_id = auth_config.get("client_id")
+        secret_name = auth_config.get("secret")
+        client_secret = await self._resolve_secret_value(db, secret_name, user_id) if secret_name else None
+        if not token_url or not client_id or client_secret is None:
+            logger.warning("OAuth refresh requires token_url, client_id, and secret")
+            return None
+
+        refresh_token = encryption_service.decrypt(row.encrypted_refresh_token)
+        payload = await self._post_token_request(
+            token_url,
+            {"grant_type": "refresh_token", "refresh_token": refresh_token},
+            client_id,
+            client_secret,
+            auth_config.get("client_auth_method") or "body",
+        )
+        if not payload or not payload.get("access_token"):
+            logger.warning(f"OAuth refresh failed for connector {connector_id} user {user_id}")
+            return None
+
+        self._store_token_fields(row, payload)
+        await db.flush()
+        return encryption_service.decrypt(row.encrypted_access_token)
 
     def _render_path(self, path_template: str, parameters: dict[str, Any]) -> str:
         """Render Jinja2 path template with parameters."""

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -71,7 +71,7 @@ class ConnectorService:
             raise ValueError(f"Operation '{operation_name}' not found on connector '{connector.namespace}/{connector.name}'")
 
         # Resolve auth (private secrets override shared for this user)
-        auth_headers = await self._resolve_auth(db, connector.auth, user_token, user_id)
+        auth_headers, auth_query = await self._resolve_auth(db, connector.auth, user_token, user_id)
 
         # Build request
         method = operation["method"]
@@ -95,6 +95,10 @@ class ConnectorService:
             json_body = non_path_params
         elif mapping == "path_and_query":
             query_params = non_path_params
+
+        # Auth may contribute query params (e.g. an api_key with position="query")
+        if auth_query:
+            query_params = {**(query_params or {}), **auth_query}
 
         # Execute with retry, respecting concurrency limit
         retry_config = connector.retry or {}
@@ -156,46 +160,53 @@ class ConnectorService:
     async def _resolve_auth(
         self, db: AsyncSession, auth_config: dict[str, Any], user_token: Optional[str],
         user_id: Optional[str] = None,
-    ) -> dict[str, str]:
-        """Resolve auth config to HTTP headers. Private secrets override shared."""
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Resolve auth config into (headers, query_params). Private secrets override shared.
+
+        Most auth types contribute a header; an api_key with position="query" contributes
+        a query parameter instead. The query dict is empty for all other types.
+        """
         auth_type = auth_config.get("type", "none")
 
         if auth_type == "none":
-            return {}
+            return {}, {}
 
         if auth_type == "sinas_token":
             if not user_token:
                 logger.warning("sinas_token auth requested but no user token available")
-                return {}
-            return {"Authorization": f"Bearer {user_token}"}
+                return {}, {}
+            return {"Authorization": f"Bearer {user_token}"}, {}
 
         if auth_type == "oauth2_client_credentials":
             token = await self._get_client_credentials_token(db, auth_config, user_id)
             if not token:
-                return {}
-            return {"Authorization": f"Bearer {token}"}
+                return {}, {}
+            return {"Authorization": f"Bearer {token}"}, {}
 
         # All other types require a secret
         secret_name = auth_config.get("secret")
         if not secret_name:
             logger.warning(f"Auth type '{auth_type}' requires a secret but none configured")
-            return {}
+            return {}, {}
 
         secret_value = await self._resolve_secret_value(db, secret_name, user_id)
         if secret_value is None:
             logger.warning(f"Secret '{secret_name}' not found for connector auth")
-            return {}
+            return {}, {}
 
         if auth_type == "bearer":
-            return {"Authorization": f"Bearer {secret_value}"}
+            return {"Authorization": f"Bearer {secret_value}"}, {}
         elif auth_type == "basic":
             encoded = base64.b64encode(secret_value.encode()).decode()
-            return {"Authorization": f"Basic {encoded}"}
+            return {"Authorization": f"Basic {encoded}"}, {}
         elif auth_type == "api_key":
-            header_name = auth_config.get("header", "X-Api-Key")
-            return {header_name: secret_value}
+            if auth_config.get("position") == "query":
+                param_name = auth_config.get("param_name") or "api_key"
+                return {}, {param_name: secret_value}
+            header_name = auth_config.get("header") or "X-Api-Key"
+            return {header_name: secret_value}, {}
 
-        return {}
+        return {}, {}
 
     async def _resolve_secret_value(
         self, db: AsyncSession, secret_name: str, user_id: Optional[str] = None

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -22,6 +22,10 @@ MAX_CONNECTIONS = 200          # Total across all hosts
 MAX_CONNECTIONS_PER_HOST = 20  # Per individual host
 MAX_CONCURRENT_REQUESTS = 100  # Semaphore limit
 
+# OAuth 2.0 client-credentials token caching
+OAUTH_TOKEN_TTL_SKEW = 60      # Refresh this many seconds before the token actually expires
+OAUTH_DEFAULT_TTL = 3600       # Assumed lifetime when the token response omits expires_in
+
 
 class ConnectorService:
     """Executes connector operations in-process via httpx with connection pooling."""
@@ -29,6 +33,10 @@ class ConnectorService:
     def __init__(self):
         self._client: Optional[httpx.AsyncClient] = None
         self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+        # OAuth client-credentials token cache: cache_key -> (access_token, expires_at_monotonic)
+        self._oauth_tokens: dict[str, tuple[str, float]] = {}
+        # Per-cache-key locks to avoid stampeding the token endpoint on concurrent misses
+        self._oauth_locks: dict[str, asyncio.Lock] = {}
 
     def _get_client(self) -> httpx.AsyncClient:
         """Get or create the shared httpx client with connection pooling."""
@@ -161,13 +169,38 @@ class ConnectorService:
                 return {}
             return {"Authorization": f"Bearer {user_token}"}
 
+        if auth_type == "oauth2_client_credentials":
+            token = await self._get_client_credentials_token(db, auth_config, user_id)
+            if not token:
+                return {}
+            return {"Authorization": f"Bearer {token}"}
+
         # All other types require a secret
         secret_name = auth_config.get("secret")
         if not secret_name:
             logger.warning(f"Auth type '{auth_type}' requires a secret but none configured")
             return {}
 
-        # Private secret overrides shared
+        secret_value = await self._resolve_secret_value(db, secret_name, user_id)
+        if secret_value is None:
+            logger.warning(f"Secret '{secret_name}' not found for connector auth")
+            return {}
+
+        if auth_type == "bearer":
+            return {"Authorization": f"Bearer {secret_value}"}
+        elif auth_type == "basic":
+            encoded = base64.b64encode(secret_value.encode()).decode()
+            return {"Authorization": f"Basic {encoded}"}
+        elif auth_type == "api_key":
+            header_name = auth_config.get("header", "X-Api-Key")
+            return {header_name: secret_value}
+
+        return {}
+
+    async def _resolve_secret_value(
+        self, db: AsyncSession, secret_name: str, user_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Resolve a Secret by name to its decrypted value. Private overrides shared."""
         secret = None
         if user_id:
             result = await db.execute(
@@ -186,21 +219,104 @@ class ConnectorService:
             secret = result.scalar_one_or_none()
 
         if not secret:
-            logger.warning(f"Secret '{secret_name}' not found for connector auth")
-            return {}
+            return None
 
-        secret_value = encryption_service.decrypt(secret.encrypted_value)
+        return encryption_service.decrypt(secret.encrypted_value)
 
-        if auth_type == "bearer":
-            return {"Authorization": f"Bearer {secret_value}"}
-        elif auth_type == "basic":
-            encoded = base64.b64encode(secret_value.encode()).decode()
-            return {"Authorization": f"Basic {encoded}"}
-        elif auth_type == "api_key":
-            header_name = auth_config.get("header", "X-Api-Key")
-            return {header_name: secret_value}
+    async def _get_client_credentials_token(
+        self, db: AsyncSession, auth_config: dict[str, Any], user_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Fetch (and cache) an OAuth 2.0 client-credentials access token.
 
-        return {}
+        The client secret is resolved from the Secret named by `auth_config["secret"]`
+        (private overrides shared, same as other auth types). Tokens are cached in-process
+        keyed by (user, endpoint, client, scope) until shortly before they expire.
+        """
+        token_url = auth_config.get("token_url")
+        client_id = auth_config.get("client_id")
+        secret_name = auth_config.get("secret")
+        if not token_url or not client_id or not secret_name:
+            logger.warning(
+                "oauth2_client_credentials auth requires token_url, client_id, and secret"
+            )
+            return None
+
+        scopes = auth_config.get("scopes") or []
+        scope_str = " ".join(scopes) if isinstance(scopes, list) else str(scopes)
+        client_auth_method = auth_config.get("client_auth_method") or "body"
+
+        # Distinct creds/scope/endpoint get distinct cache entries. user_id is included
+        # because a private secret override yields a different (per-user) token.
+        cache_key = f"{user_id or 'shared'}|{token_url}|{client_id}|{scope_str}"
+
+        # Fast path: a still-valid cached token.
+        cached = self._oauth_tokens.get(cache_key)
+        if cached and cached[1] > time.monotonic():
+            return cached[0]
+
+        lock = self._oauth_locks.setdefault(cache_key, asyncio.Lock())
+        async with lock:
+            # Re-check under the lock — another coroutine may have refreshed while we waited.
+            cached = self._oauth_tokens.get(cache_key)
+            if cached and cached[1] > time.monotonic():
+                return cached[0]
+
+            client_secret = await self._resolve_secret_value(db, secret_name, user_id)
+            if client_secret is None:
+                logger.warning(f"OAuth client secret '{secret_name}' not found")
+                return None
+
+            data = {"grant_type": "client_credentials"}
+            if scope_str:
+                data["scope"] = scope_str
+            extra = auth_config.get("token_params")
+            if isinstance(extra, dict):
+                data.update({k: str(v) for k, v in extra.items()})
+
+            headers = {"Accept": "application/json"}
+            if client_auth_method == "basic":
+                encoded = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+                headers["Authorization"] = f"Basic {encoded}"
+            else:  # "body" — client_secret_post
+                data["client_id"] = client_id
+                data["client_secret"] = client_secret
+
+            try:
+                async with self._semaphore:
+                    client = self._get_client()
+                    resp = await client.post(token_url, data=data, headers=headers, timeout=30.0)
+            except Exception as e:
+                logger.error(f"OAuth token request to {token_url} failed: {e}")
+                return None
+
+            if resp.status_code != 200:
+                logger.error(
+                    f"OAuth token endpoint {token_url} returned {resp.status_code}: {resp.text[:200]}"
+                )
+                return None
+
+            try:
+                payload = resp.json()
+            except Exception:
+                logger.error(f"OAuth token endpoint {token_url} returned a non-JSON body")
+                return None
+
+            access_token = payload.get("access_token")
+            if not access_token:
+                logger.error(f"OAuth token endpoint {token_url} response missing access_token")
+                return None
+
+            expires_in = payload.get("expires_in")
+            try:
+                ttl = int(expires_in) if expires_in is not None else OAUTH_DEFAULT_TTL
+            except (TypeError, ValueError):
+                ttl = OAUTH_DEFAULT_TTL
+            expires_at = time.monotonic() + max(ttl - OAUTH_TOKEN_TTL_SKEW, 1)
+            self._oauth_tokens[cache_key] = (access_token, expires_at)
+            logger.info(
+                f"Obtained OAuth client-credentials token from {token_url} (ttl={ttl}s)"
+            )
+            return access_token
 
     def _render_path(self, path_template: str, parameters: dict[str, Any]) -> str:
         """Render Jinja2 path template with parameters."""

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -485,10 +485,24 @@ class ConnectorService:
         )
         return result.scalar_one_or_none()
 
+    def _token_still_valid(self, row: ConnectorOAuthToken) -> bool:
+        """True if the stored access token is safe to use now (skew-aware)."""
+        if row.expires_at is None:
+            # No expiry known — assume the stored token is usable.
+            return bool(row.encrypted_access_token)
+        skew = timedelta(seconds=OAUTH_TOKEN_TTL_SKEW)
+        return row.expires_at - skew > datetime.now(timezone.utc)
+
     async def _get_authorization_code_token(
         self, db: AsyncSession, connector_id: Any, auth_config: dict[str, Any], user_id: Optional[str]
     ) -> Optional[str]:
-        """Return a valid access token for this user, refreshing if it has (nearly) expired."""
+        """Return a valid access token for this user, refreshing if it has (nearly) expired.
+
+        The common case (a still-valid token) takes NO lock and reads on the caller's
+        session, so concurrent executions never serialize. Only an actual refresh takes a
+        short row lock (see _refresh_authorization_code_token) to keep concurrent refreshers
+        of the same (connector, user) from racing on a rotating refresh token.
+        """
         if not connector_id or not user_id:
             logger.warning("oauth2_authorization_code auth requires a connector and user context")
             return None
@@ -498,43 +512,74 @@ class ConnectorService:
             logger.warning(f"No OAuth token stored for connector {connector_id} user {user_id}")
             return None
 
-        # Still valid (with skew)? Use it.
-        if row.expires_at is not None:
-            skew = timedelta(seconds=OAUTH_TOKEN_TTL_SKEW)
-            if row.expires_at - skew > datetime.now(timezone.utc):
-                return encryption_service.decrypt(row.encrypted_access_token)
-        elif row.encrypted_access_token:
-            # No expiry known — assume the stored token is usable.
+        if self._token_still_valid(row):
             return encryption_service.decrypt(row.encrypted_access_token)
 
-        # Expired (or expiring): try to refresh.
         if not row.encrypted_refresh_token:
             logger.warning(f"OAuth token for connector {connector_id} expired and has no refresh token")
             return None
 
-        token_url = auth_config.get("token_url")
-        client_id = auth_config.get("client_id")
-        secret_name = auth_config.get("secret")
-        client_secret = await self._resolve_secret_value(db, secret_name, user_id) if secret_name else None
-        if not token_url or not client_id or client_secret is None:
-            logger.warning("OAuth refresh requires token_url, client_id, and secret")
-            return None
+        return await self._refresh_authorization_code_token(connector_id, auth_config, user_id)
 
-        refresh_token = encryption_service.decrypt(row.encrypted_refresh_token)
-        payload = await self._post_token_request(
-            token_url,
-            {"grant_type": "refresh_token", "refresh_token": refresh_token},
-            client_id,
-            client_secret,
-            auth_config.get("client_auth_method") or "body",
-        )
-        if not payload or not payload.get("access_token"):
-            logger.warning(f"OAuth refresh failed for connector {connector_id} user {user_id}")
-            return None
+    async def _refresh_authorization_code_token(
+        self, connector_id: Any, auth_config: dict[str, Any], user_id: str
+    ) -> Optional[str]:
+        """Refresh a per-user token under a row lock, in its own short-lived transaction.
 
-        self._store_token_fields(row, payload)
-        await db.flush()
-        return encryption_service.decrypt(row.encrypted_access_token)
+        `SELECT ... FOR UPDATE` on the single (connector, user) row serializes concurrent
+        refreshers across processes/containers. We re-check validity under the lock so a
+        request that lost the race uses the winner's freshly-stored token instead of
+        issuing a second (refresh-token-rotating) refresh. The lock is held only for the
+        token POST and released on commit — it does not span the caller's execution.
+        """
+        from app.core.database import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                result = await session.execute(
+                    select(ConnectorOAuthToken)
+                    .where(
+                        and_(
+                            ConnectorOAuthToken.connector_id == connector_id,
+                            ConnectorOAuthToken.user_id == user_id,
+                        )
+                    )
+                    .with_for_update()
+                )
+                row = result.scalar_one_or_none()
+                if row is None:
+                    return None
+
+                # Double-checked locking: a sibling request may have just refreshed.
+                if self._token_still_valid(row):
+                    return encryption_service.decrypt(row.encrypted_access_token)
+                if not row.encrypted_refresh_token:
+                    return None
+
+                token_url = auth_config.get("token_url")
+                client_id = auth_config.get("client_id")
+                secret_name = auth_config.get("secret")
+                client_secret = (
+                    await self._resolve_secret_value(session, secret_name, user_id) if secret_name else None
+                )
+                if not token_url or not client_id or client_secret is None:
+                    logger.warning("OAuth refresh requires token_url, client_id, and secret")
+                    return None
+
+                refresh_token = encryption_service.decrypt(row.encrypted_refresh_token)
+                payload = await self._post_token_request(
+                    token_url,
+                    {"grant_type": "refresh_token", "refresh_token": refresh_token},
+                    client_id,
+                    client_secret,
+                    auth_config.get("client_auth_method") or "body",
+                )
+                if not payload or not payload.get("access_token"):
+                    logger.warning(f"OAuth refresh failed for connector {connector_id} user {user_id}")
+                    return None
+
+                self._store_token_fields(row, payload)
+                return payload["access_token"]
 
     def _render_path(self, path_template: str, parameters: dict[str, Any]) -> str:
         """Render Jinja2 path template with parameters."""

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -332,36 +332,13 @@ class ConnectorService:
             data = {"grant_type": "client_credentials"}
             if scope_str:
                 data["scope"] = scope_str
-            extra = auth_config.get("token_params")
-            if isinstance(extra, dict):
-                data.update({k: str(v) for k, v in extra.items()})
+            if isinstance(token_params, dict):
+                data.update({k: str(v) for k, v in token_params.items()})
 
-            headers = {"Accept": "application/json"}
-            if client_auth_method == "basic":
-                encoded = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
-                headers["Authorization"] = f"Basic {encoded}"
-            else:  # "body" — client_secret_post
-                data["client_id"] = client_id
-                data["client_secret"] = client_secret
-
-            try:
-                async with self._semaphore:
-                    client = self._get_client()
-                    resp = await client.post(token_url, data=data, headers=headers, timeout=30.0)
-            except Exception as e:
-                logger.error(f"OAuth token request to {token_url} failed: {e}")
-                return None
-
-            if resp.status_code != 200:
-                logger.error(
-                    f"OAuth token endpoint {token_url} returned {resp.status_code}: {resp.text[:200]}"
-                )
-                return None
-
-            try:
-                payload = resp.json()
-            except Exception:
-                logger.error(f"OAuth token endpoint {token_url} returned a non-JSON body")
+            payload = await self._post_token_request(
+                token_url, data, client_id, client_secret, client_auth_method
+            )
+            if not payload:
                 return None
 
             access_token = payload.get("access_token")
@@ -369,10 +346,8 @@ class ConnectorService:
                 logger.error(f"OAuth token endpoint {token_url} response missing access_token")
                 return None
 
-            expires_in = payload.get("expires_in")
-            try:
-                ttl = int(expires_in) if expires_in is not None else OAUTH_DEFAULT_TTL
-            except (TypeError, ValueError):
+            ttl = self._parse_expires_in(payload.get("expires_in"))
+            if ttl is None:
                 ttl = OAUTH_DEFAULT_TTL
             expires_at = time.monotonic() + max(ttl - OAUTH_TOKEN_TTL_SKEW, 1)
             self._oauth_tokens[cache_key] = (access_token, expires_at)
@@ -391,11 +366,7 @@ class ConnectorService:
 
         Must exactly match the redirect URI registered with the OAuth provider.
         """
-        domain = settings.domain
-        path = "/auth/connectors/oauth/callback"
-        if not domain or domain.lower() in ("localhost", "127.0.0.1"):
-            return f"http://localhost:{settings.backend_port}{path}"
-        return f"https://{domain}{path}"
+        return f"{settings.public_base_url}/auth/connectors/oauth/callback"
 
     def build_authorize_url(
         self, auth_config: dict[str, Any], state: str, code_challenge: str
@@ -451,6 +422,16 @@ class ConnectorService:
             logger.error(f"OAuth token endpoint {token_url} returned a non-JSON body")
             return None
 
+    @staticmethod
+    def _parse_expires_in(expires_in: Any) -> Optional[int]:
+        """Coerce a token response's `expires_in` to an int, or None if absent/invalid."""
+        if expires_in is None:
+            return None
+        try:
+            return int(expires_in)
+        except (TypeError, ValueError):
+            return None
+
     def _store_token_fields(self, row: ConnectorOAuthToken, payload: dict[str, Any]) -> None:
         """Copy a token-endpoint payload onto a ConnectorOAuthToken row (encrypting tokens)."""
         row.encrypted_access_token = encryption_service.encrypt(payload["access_token"])
@@ -463,11 +444,7 @@ class ConnectorService:
         if payload.get("token_type"):
             row.token_type = payload["token_type"]
 
-        expires_in = payload.get("expires_in")
-        try:
-            ttl = int(expires_in) if expires_in is not None else None
-        except (TypeError, ValueError):
-            ttl = None
+        ttl = self._parse_expires_in(payload.get("expires_in"))
 
         if ttl is not None:
             row.expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl)

--- a/backend/app/services/connector_service.py
+++ b/backend/app/services/connector_service.py
@@ -108,13 +108,21 @@ class ConnectorService:
         non_path_params = {k: v for k, v in parameters.items() if k not in path_param_names}
 
         if mapping == "json":
-            json_body = non_path_params
+            json_body = non_path_params or None
         elif mapping == "query":
             query_params = non_path_params
         elif mapping == "path_and_json":
-            json_body = non_path_params
+            json_body = non_path_params or None
         elif mapping == "path_and_query":
             query_params = non_path_params
+
+        # A GET/HEAD must not carry a request body. Even an empty `{}` makes httpx set
+        # Content-Type/Content-Length, which strict gateways (e.g. the Google Frontend in
+        # front of the Spotify API) reject as a malformed request. If a GET operation
+        # mapped params to the body, send them as query params instead.
+        if method.upper() in ("GET", "HEAD") and json_body is not None:
+            query_params = {**(query_params or {}), **json_body}
+            json_body = None
 
         # Auth may contribute query params (e.g. an api_key with position="query")
         if auth_query:

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -5,6 +5,8 @@ Used by both config_export.py (full config export) and package_service.py
 """
 from typing import Any, Optional
 
+from app.schemas.config import CONNECTOR_AUTH_FIELD_MAP
+
 
 def _remove_none_values(d: dict) -> dict:
     """Remove None values from dictionary recursively."""
@@ -167,18 +169,10 @@ def serialize_connector(conn) -> dict:
         "name": conn.name,
         "description": conn.description,
         "baseUrl": conn.base_url,
+        # Map snake_case stored keys → camelCase config keys via the single field map.
         "auth": _remove_none_values({
-            "type": auth.get("type", "none"),
-            "secret": auth.get("secret"),
-            "header": auth.get("header"),
-            "position": auth.get("position"),
-            "paramName": auth.get("param_name"),
-            "tokenUrl": auth.get("token_url"),
-            "clientId": auth.get("client_id"),
-            "scopes": auth.get("scopes"),
-            "clientAuthMethod": auth.get("client_auth_method"),
-            "authorizeUrl": auth.get("authorize_url"),
-            "tokenParams": auth.get("token_params"),
+            **{camel: auth.get(snake) for camel, snake in CONNECTOR_AUTH_FIELD_MAP},
+            "type": auth.get("type", "none"),  # type always present in export
         }),
         "headers": conn.headers if conn.headers else None,
         "retry": _remove_none_values({

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -173,6 +173,12 @@ def serialize_connector(conn) -> dict:
             "header": auth.get("header"),
             "position": auth.get("position"),
             "paramName": auth.get("param_name"),
+            "tokenUrl": auth.get("token_url"),
+            "clientId": auth.get("client_id"),
+            "scopes": auth.get("scopes"),
+            "clientAuthMethod": auth.get("client_auth_method"),
+            "authorizeUrl": auth.get("authorize_url"),
+            "tokenParams": auth.get("token_params"),
         }),
         "headers": conn.headers if conn.headers else None,
         "retry": _remove_none_values({

--- a/backend/tests/unit/test_connector_oauth.py
+++ b/backend/tests/unit/test_connector_oauth.py
@@ -1,0 +1,107 @@
+"""Unit tests for connector OAuth token handling.
+
+Covers the two regressions most likely to recur:
+  - token expiry storage (a missing expires_in must not make a refreshable token
+    look valid forever) — the #2 fix.
+  - fail-closed auth: an unresolvable OAuth token must raise, not silently send an
+    unauthenticated request — the #5 fix.
+
+These avoid the DB/HTTP layers: _store_token_fields takes a plain row + payload, and
+the OAuth auth branches short-circuit before touching the DB when no user/connector
+context is present.
+"""
+
+import types
+
+import pytest
+
+from app.services.connector_service import (
+    ConnectorAuthError,
+    OAUTH_DEFAULT_TTL,
+    connector_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _identity_encryption(monkeypatch):
+    """Make encrypt a no-op so _store_token_fields doesn't need a real Fernet key."""
+    fake = types.SimpleNamespace(
+        encrypt=lambda v: v, decrypt=lambda v: v
+    )
+    monkeypatch.setattr("app.services.connector_service.encryption_service", fake)
+
+
+def _row(**kw):
+    row = types.SimpleNamespace(
+        encrypted_access_token="",
+        encrypted_refresh_token="",
+        scope=None,
+        token_type=None,
+        expires_at=None,
+    )
+    for k, v in kw.items():
+        setattr(row, k, v)
+    return row
+
+
+def test_expires_in_present_sets_expiry():
+    row = _row()
+    connector_service._store_token_fields(
+        row, {"access_token": "a", "refresh_token": "r", "expires_in": 3600}
+    )
+    assert row.expires_at is not None
+
+
+def test_missing_expires_in_with_refresh_token_gets_conservative_ttl():
+    # The bug: without expires_in the token was treated as valid forever and never
+    # refreshed. It must instead get a bounded expiry so the refresh path runs.
+    row = _row()
+    connector_service._store_token_fields(
+        row, {"access_token": "a", "refresh_token": "r"}  # no expires_in
+    )
+    assert row.expires_at is not None
+    assert connector_service._token_still_valid(row) is True  # valid now...
+    # ...but bounded — an expiry roughly OAUTH_DEFAULT_TTL out, not None/forever.
+    from datetime import datetime, timezone
+
+    remaining = (row.expires_at - datetime.now(timezone.utc)).total_seconds()
+    assert 0 < remaining <= OAUTH_DEFAULT_TTL + 5
+
+
+def test_refresh_without_expires_in_does_not_clobber_known_expiry():
+    # A refresh response omitting expires_in must not overwrite a known expiry with None
+    # (which would permanently disable future refreshes).
+    from datetime import datetime, timedelta, timezone
+
+    known = datetime.now(timezone.utc) + timedelta(hours=2)
+    row = _row(encrypted_refresh_token="r", expires_at=known)
+    connector_service._store_token_fields(row, {"access_token": "a2"})  # refresh, no expires_in
+    assert row.expires_at is not None
+
+
+def test_no_expiry_no_refresh_token_left_untouched():
+    row = _row(encrypted_refresh_token="")
+    connector_service._store_token_fields(row, {"access_token": "a"})  # no expires_in, no refresh
+    assert row.expires_at is None  # best-effort: usable, nothing to refresh with
+
+
+@pytest.mark.asyncio
+async def test_oauth_authcode_missing_context_raises():
+    # No connector/user context → token unresolvable → must fail closed, not return {}.
+    with pytest.raises(ConnectorAuthError):
+        await connector_service._resolve_auth(
+            db=None,
+            auth_config={"type": "oauth2_authorization_code"},
+            user_token=None,
+            user_id=None,
+            connector_id=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_none_auth_still_returns_empty():
+    # Regression guard: raising must be scoped to OAuth failures, not all auth.
+    headers, query = await connector_service._resolve_auth(
+        db=None, auth_config={"type": "none"}, user_token=None
+    )
+    assert headers == {} and query == {}

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -1293,3 +1293,30 @@ class APIClient {
 
 
 export const apiClient = new APIClient();
+
+/**
+ * Extract a human-readable string from an API error.
+ *
+ * FastAPI returns `detail` as a plain string for HTTPExceptions but as an ARRAY of
+ * `{loc, msg, ...}` objects for 422 validation errors. Rendering that array directly
+ * as a React child throws (React error #31), so every place that surfaces an API error
+ * must funnel through here to guarantee a string.
+ */
+export function getApiErrorMessage(err: any, fallback = 'Something went wrong'): string {
+  const detail = err?.response?.data?.detail ?? err?.response?.data?.message;
+  if (typeof detail === 'string' && detail) return detail;
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map((e: any) => {
+        const loc = Array.isArray(e?.loc)
+          ? e.loc.filter((p: any) => p !== 'body').join('.')
+          : '';
+        const msg = typeof e?.msg === 'string' ? e.msg : '';
+        return loc && msg ? `${loc}: ${msg}` : msg || loc;
+      })
+      .filter(Boolean);
+    if (msgs.length) return msgs.join('; ');
+  }
+  if (detail && typeof detail === 'object' && typeof detail.msg === 'string') return detail.msg;
+  return err?.message || fallback;
+}

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -575,6 +575,20 @@ class APIClient {
     return response.data;
   }
 
+  async beginConnectorOAuth(namespace: string, name: string): Promise<{ authorize_url: string }> {
+    const response = await this.configClient.post(`/connectors/${namespace}/${name}/oauth/authorize`);
+    return response.data;
+  }
+
+  async getConnectorOAuthStatus(namespace: string, name: string): Promise<{ connected: boolean; expires_at: string | null; scope: string | null }> {
+    const response = await this.configClient.get(`/connectors/${namespace}/${name}/oauth/status`);
+    return response.data;
+  }
+
+  async disconnectConnectorOAuth(namespace: string, name: string): Promise<void> {
+    await this.configClient.delete(`/connectors/${namespace}/${name}/oauth/token`);
+  }
+
   // Store management (admin CRUD)
   async listStores(params?: { namespace?: string }): Promise<any[]> {
     const response = await this.configClient.get('/stores', { params });

--- a/console/src/pages/ConnectorEditor.tsx
+++ b/console/src/pages/ConnectorEditor.tsx
@@ -150,7 +150,17 @@ export function ConnectorEditor() {
         if (slug) updates.name = slug;
       }
       if (data.spec_description && !formData.description) updates.description = data.spec_description;
-      if (Object.keys(updates).length > 0) setFormData(prev => ({ ...prev, ...updates }));
+      const hasAuthSuggestion = !!data.suggested_auth;
+      if (Object.keys(updates).length > 0 || hasAuthSuggestion) {
+        setFormData(prev => {
+          const next = { ...prev, ...updates };
+          // Prefill auth from the spec's securitySchemes, but never clobber a chosen type.
+          if (hasAuthSuggestion && prev.auth.type === 'none') {
+            next.auth = { ...prev.auth, ...data.suggested_auth };
+          }
+          return next;
+        });
+      }
     },
   });
 

--- a/console/src/pages/ConnectorEditor.tsx
+++ b/console/src/pages/ConnectorEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '../lib/api';
+import { apiClient, getApiErrorMessage } from '../lib/api';
 import { useToast } from '../lib/toast-context';
 import {
   Save, ArrowLeft, Plus, Trash2, Play, X, ChevronDown, ChevronRight,
@@ -197,7 +197,7 @@ export function ConnectorEditor() {
     mutationFn: ({ op, params }: { op: string; params: any }) =>
       apiClient.testConnectorOperation(formData.namespace, formData.name, op, params),
     onSuccess: (data: any) => setTestResult(data),
-    onError: (err: any) => setTestResult({ error: err?.response?.data?.detail || 'Request failed' }),
+    onError: (err: any) => setTestResult({ error: getApiErrorMessage(err, 'Request failed') }),
   });
 
   const handleSave = () => {
@@ -247,7 +247,7 @@ export function ConnectorEditor() {
       },
       onError: (err: any) => {
         popup.close();
-        showError(err?.response?.data?.detail || 'Could not start the connection.');
+        showError(getApiErrorMessage(err, 'Could not start the connection.'));
       },
     });
   };
@@ -255,7 +255,7 @@ export function ConnectorEditor() {
   const disconnectMutation = useMutation({
     mutationFn: () => apiClient.disconnectConnectorOAuth(formData.namespace, formData.name),
     onSuccess: () => { showSuccess('Account disconnected'); refetchOAuthStatus(); },
-    onError: (err: any) => showError(err?.response?.data?.detail || 'Could not disconnect the account.'),
+    onError: (err: any) => showError(getApiErrorMessage(err, 'Could not disconnect the account.')),
   });
 
   const addOperation = () => {
@@ -362,7 +362,7 @@ export function ConnectorEditor() {
       {saveMutation.isError && (
         <div className="p-3 bg-red-900/20 border border-red-800 rounded-lg">
           <p className="text-sm text-red-400">
-            {(saveMutation.error as any)?.response?.data?.detail || 'Failed to save'}
+            {getApiErrorMessage(saveMutation.error, 'Failed to save')}
           </p>
         </div>
       )}
@@ -729,7 +729,7 @@ export function ConnectorEditor() {
                 )}
                 {importParseMutation.isError && (
                   <div className="p-3 bg-red-900/20 border border-red-800 rounded-lg">
-                    <p className="text-sm text-red-400">{(importParseMutation.error as any)?.response?.data?.detail || 'Failed to parse spec'}</p>
+                    <p className="text-sm text-red-400">{getApiErrorMessage(importParseMutation.error, 'Failed to parse spec')}</p>
                   </div>
                 )}
                 <div className="flex justify-end gap-2">

--- a/console/src/pages/ConnectorEditor.tsx
+++ b/console/src/pages/ConnectorEditor.tsx
@@ -17,10 +17,11 @@ const AUTH_TYPES = [
   { value: 'basic', label: 'Basic Auth' },
   { value: 'api_key', label: 'API Key' },
   { value: 'oauth2_client_credentials', label: 'OAuth 2.0 (Client Credentials)' },
+  { value: 'oauth2_authorization_code', label: 'OAuth 2.0 (Authorization Code)' },
   { value: 'sinas_token', label: 'Sinas Token' },
 ];
 // Auth types that resolve a stored Secret (for OAuth this is the client secret).
-const SECRET_AUTH_TYPES = ['bearer', 'basic', 'api_key', 'oauth2_client_credentials'];
+const SECRET_AUTH_TYPES = ['bearer', 'basic', 'api_key', 'oauth2_client_credentials', 'oauth2_authorization_code'];
 const methodColors: Record<string, string> = {
   GET: 'bg-green-900/30 text-green-400',
   POST: 'bg-blue-900/30 text-blue-400',
@@ -56,7 +57,7 @@ export function ConnectorEditor() {
     namespace: 'default', name: '', description: '', base_url: '',
     auth: {
       type: 'none' as string, secret: '', header: 'X-Api-Key', position: 'header', param_name: 'api_key',
-      token_url: '', client_id: '', scopes: [] as string[], client_auth_method: 'body',
+      token_url: '', client_id: '', scopes: [] as string[], client_auth_method: 'body', authorize_url: '',
     },
     headers: {} as Record<string, string>,
     retry: { max_attempts: 1, backoff: 'none' },
@@ -105,7 +106,7 @@ export function ConnectorEditor() {
         base_url: connector.base_url,
         auth: {
           type: 'none', secret: '', header: 'X-Api-Key', position: 'header', param_name: 'api_key',
-          token_url: '', client_id: '', scopes: [], client_auth_method: 'body', ...connector.auth,
+          token_url: '', client_id: '', scopes: [], client_auth_method: 'body', authorize_url: '', ...connector.auth,
         },
         headers: connector.headers || {},
         retry: { max_attempts: 1, backoff: 'none', ...connector.retry },
@@ -163,6 +164,39 @@ export function ConnectorEditor() {
   const handleSave = () => {
     saveMutation.mutate(formData);
   };
+
+  // OAuth (authorization-code) per-user connection status
+  const isAuthCode = formData.auth.type === 'oauth2_authorization_code';
+  const { data: oauthStatus, refetch: refetchOAuthStatus } = useQuery({
+    queryKey: ['connector-oauth-status', namespace, name],
+    queryFn: () => apiClient.getConnectorOAuthStatus(namespace!, name!),
+    enabled: !isNew && isAuthCode,
+    retry: false,
+  });
+
+  // Refresh status when the popup reports back that authorization finished.
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.data?.type === 'connector-oauth') {
+        if (e.data.status === 'success') showSuccess('Account connected');
+        refetchOAuthStatus();
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [refetchOAuthStatus, showSuccess]);
+
+  const connectMutation = useMutation({
+    mutationFn: () => apiClient.beginConnectorOAuth(formData.namespace, formData.name),
+    onSuccess: (data: { authorize_url: string }) => {
+      window.open(data.authorize_url, 'connector-oauth', 'width=600,height=760');
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => apiClient.disconnectConnectorOAuth(formData.namespace, formData.name),
+    onSuccess: () => { showSuccess('Account disconnected'); refetchOAuthStatus(); },
+  });
 
   const addOperation = () => {
     const ops = [...formData.operations, emptyOp()];
@@ -393,6 +427,74 @@ export function ConnectorEditor() {
             <p className="text-xs text-gray-500">
               The client secret is exchanged for a short-lived access token, cached until shortly before it expires, and sent as a Bearer token.
             </p>
+          </div>
+        )}
+        {isAuthCode && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="label">Authorize URL</label>
+                <input type="text" value={formData.auth.authorize_url} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, authorize_url: e.target.value } })}
+                  className="input w-full font-mono" placeholder="https://provider.com/oauth/authorize" />
+              </div>
+              <div>
+                <label className="label">Token URL</label>
+                <input type="text" value={formData.auth.token_url} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, token_url: e.target.value } })}
+                  className="input w-full font-mono" placeholder="https://provider.com/oauth/token" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="label">Client ID</label>
+                <input type="text" value={formData.auth.client_id} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, client_id: e.target.value } })}
+                  className="input w-full font-mono" />
+              </div>
+              <div>
+                <label className="label">Client Auth Method</label>
+                <select value={formData.auth.client_auth_method} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, client_auth_method: e.target.value } })}
+                  className="input w-full">
+                  <option value="body">Request Body (client_secret_post)</option>
+                  <option value="basic">HTTP Basic (client_secret_basic)</option>
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="label">Scopes</label>
+              <input type="text"
+                value={(formData.auth.scopes || []).join(' ')}
+                onChange={e => setFormData({ ...formData, auth: { ...formData.auth, scopes: e.target.value.split(/\s+/).filter(Boolean) } })}
+                className="input w-full font-mono" placeholder="openid email profile (space-separated)" />
+            </div>
+            <p className="text-xs text-gray-500">
+              Each user authorizes their own account; tokens are stored per-user and refreshed automatically.
+              Register this redirect URI with the provider: <span className="font-mono text-gray-400">https://&lt;your-domain&gt;/auth/connectors/oauth/callback</span>
+            </p>
+            {isNew ? (
+              <p className="text-xs text-yellow-500/80">Save the connector before connecting an account.</p>
+            ) : (
+              <div className="flex items-center gap-3 pt-1">
+                {oauthStatus?.connected ? (
+                  <>
+                    <span className="text-sm text-green-400">
+                      Connected{oauthStatus.expires_at ? ` · expires ${new Date(oauthStatus.expires_at).toLocaleString()}` : ''}
+                    </span>
+                    <button onClick={() => connectMutation.mutate()} disabled={connectMutation.isPending} className="btn btn-secondary btn-sm">
+                      Reconnect
+                    </button>
+                    <button onClick={() => disconnectMutation.mutate()} disabled={disconnectMutation.isPending} className="btn btn-secondary btn-sm text-red-400">
+                      Disconnect
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span className="text-sm text-gray-500">Not connected</span>
+                    <button onClick={() => connectMutation.mutate()} disabled={connectMutation.isPending} className="btn btn-primary btn-sm">
+                      {connectMutation.isPending ? 'Opening...' : 'Connect Account'}
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
           </div>
         )}
         {formData.auth.type === 'sinas_token' && (

--- a/console/src/pages/ConnectorEditor.tsx
+++ b/console/src/pages/ConnectorEditor.tsx
@@ -22,6 +22,35 @@ const AUTH_TYPES = [
 ];
 // Auth types that resolve a stored Secret (for OAuth this is the client secret).
 const SECRET_AUTH_TYPES = ['bearer', 'basic', 'api_key', 'oauth2_client_credentials', 'oauth2_authorization_code'];
+
+// Keep only the auth fields that matter for the chosen type. The editor carries a full
+// set of auth defaults in state for convenience, but persisting them all would write
+// empty OAuth fields (tokenUrl:"", scopes:[], clientAuthMethod:"body", ...) onto every
+// connector — polluting config export / GitOps diffs for non-OAuth connectors.
+function pruneAuthForSave(auth: any): Record<string, any> {
+  const type = auth?.type || 'none';
+  const out: Record<string, any> = { type };
+  if (type === 'none' || type === 'sinas_token') return out;
+  if (auth.secret) out.secret = auth.secret;
+  if (type === 'bearer' || type === 'basic') return out;
+  if (type === 'api_key') {
+    const position = auth.position === 'query' ? 'query' : 'header';
+    out.position = position;
+    if (position === 'query') out.param_name = auth.param_name || 'api_key';
+    else out.header = auth.header || 'X-Api-Key';
+    return out;
+  }
+  if (type === 'oauth2_client_credentials' || type === 'oauth2_authorization_code') {
+    if (auth.token_url) out.token_url = auth.token_url;
+    if (auth.client_id) out.client_id = auth.client_id;
+    if (auth.scopes?.length) out.scopes = auth.scopes;
+    if (auth.client_auth_method) out.client_auth_method = auth.client_auth_method;
+    if (auth.token_params && Object.keys(auth.token_params).length) out.token_params = auth.token_params;
+    if (type === 'oauth2_authorization_code' && auth.authorize_url) out.authorize_url = auth.authorize_url;
+    return out;
+  }
+  return out;
+}
 const methodColors: Record<string, string> = {
   GET: 'bg-green-900/30 text-green-400',
   POST: 'bg-blue-900/30 text-blue-400',
@@ -51,7 +80,7 @@ export function ConnectorEditor() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const isNew = namespace === 'new' && name === 'new';
-  const { showSuccess } = useToast();
+  const { showSuccess, showError } = useToast();
 
   const [formData, setFormData] = useState({
     namespace: 'default', name: '', description: '', base_url: '',
@@ -172,7 +201,7 @@ export function ConnectorEditor() {
   });
 
   const handleSave = () => {
-    saveMutation.mutate(formData);
+    saveMutation.mutate({ ...formData, auth: pruneAuthForSave(formData.auth) });
   };
 
   // OAuth (authorization-code) per-user connection status
@@ -187,25 +216,46 @@ export function ConnectorEditor() {
   // Refresh status when the popup reports back that authorization finished.
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
+      // Only trust messages from our own origin (the callback page posts to it).
+      if (e.origin !== window.location.origin) return;
       if (e.data?.type === 'connector-oauth') {
         if (e.data.status === 'success') showSuccess('Account connected');
+        else if (e.data.status === 'error') showError('Authorization was not completed');
         refetchOAuthStatus();
       }
     };
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [refetchOAuthStatus, showSuccess]);
+  }, [refetchOAuthStatus, showSuccess, showError]);
 
   const connectMutation = useMutation({
     mutationFn: () => apiClient.beginConnectorOAuth(formData.namespace, formData.name),
-    onSuccess: (data: { authorize_url: string }) => {
-      window.open(data.authorize_url, 'connector-oauth', 'width=600,height=760');
-    },
   });
+
+  // Open the popup synchronously in the click handler (a popup opened later, from the
+  // mutation's async onSuccess, is outside the user-gesture window and gets blocked).
+  // We pre-open a blank window now and point it at the provider once the URL arrives.
+  const handleConnect = () => {
+    const popup = window.open('', 'connector-oauth', 'width=600,height=760');
+    if (!popup) {
+      showError('Please allow popups for this site, then click Connect again.');
+      return;
+    }
+    connectMutation.mutate(undefined, {
+      onSuccess: (data: { authorize_url: string }) => {
+        popup.location.href = data.authorize_url;
+      },
+      onError: (err: any) => {
+        popup.close();
+        showError(err?.response?.data?.detail || 'Could not start the connection.');
+      },
+    });
+  };
 
   const disconnectMutation = useMutation({
     mutationFn: () => apiClient.disconnectConnectorOAuth(formData.namespace, formData.name),
     onSuccess: () => { showSuccess('Account disconnected'); refetchOAuthStatus(); },
+    onError: (err: any) => showError(err?.response?.data?.detail || 'Could not disconnect the account.'),
   });
 
   const addOperation = () => {
@@ -488,7 +538,7 @@ export function ConnectorEditor() {
                     <span className="text-sm text-green-400">
                       Connected{oauthStatus.expires_at ? ` · expires ${new Date(oauthStatus.expires_at).toLocaleString()}` : ''}
                     </span>
-                    <button onClick={() => connectMutation.mutate()} disabled={connectMutation.isPending} className="btn btn-secondary btn-sm">
+                    <button onClick={handleConnect} disabled={connectMutation.isPending} className="btn btn-secondary btn-sm">
                       Reconnect
                     </button>
                     <button onClick={() => disconnectMutation.mutate()} disabled={disconnectMutation.isPending} className="btn btn-secondary btn-sm text-red-400">
@@ -498,7 +548,7 @@ export function ConnectorEditor() {
                 ) : (
                   <>
                     <span className="text-sm text-gray-500">Not connected</span>
-                    <button onClick={() => connectMutation.mutate()} disabled={connectMutation.isPending} className="btn btn-primary btn-sm">
+                    <button onClick={handleConnect} disabled={connectMutation.isPending} className="btn btn-primary btn-sm">
                       {connectMutation.isPending ? 'Opening...' : 'Connect Account'}
                     </button>
                   </>

--- a/console/src/pages/ConnectorEditor.tsx
+++ b/console/src/pages/ConnectorEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient, getApiErrorMessage } from '../lib/api';
+import { apiClient, getApiErrorMessage, API_BASE_URL } from '../lib/api';
 import { useToast } from '../lib/toast-context';
 import {
   Save, ArrowLeft, Plus, Trash2, Play, X, ChevronDown, ChevronRight,
@@ -215,9 +215,12 @@ export function ConnectorEditor() {
 
   // Refresh status when the popup reports back that authorization finished.
   useEffect(() => {
+    // The callback page is served by the API (which may be a different origin than the
+    // console in local dev). Trust the message only from the API origin or our own.
+    let apiOrigin = window.location.origin;
+    try { apiOrigin = new URL(API_BASE_URL, window.location.origin).origin; } catch { /* keep default */ }
     const onMessage = (e: MessageEvent) => {
-      // Only trust messages from our own origin (the callback page posts to it).
-      if (e.origin !== window.location.origin) return;
+      if (e.origin !== window.location.origin && e.origin !== apiOrigin) return;
       if (e.data?.type === 'connector-oauth') {
         if (e.data.status === 'success') showSuccess('Account connected');
         else if (e.data.status === 'error') showError('Authorization was not completed');

--- a/console/src/pages/ConnectorEditor.tsx
+++ b/console/src/pages/ConnectorEditor.tsx
@@ -16,8 +16,11 @@ const AUTH_TYPES = [
   { value: 'bearer', label: 'Bearer Token' },
   { value: 'basic', label: 'Basic Auth' },
   { value: 'api_key', label: 'API Key' },
+  { value: 'oauth2_client_credentials', label: 'OAuth 2.0 (Client Credentials)' },
   { value: 'sinas_token', label: 'Sinas Token' },
 ];
+// Auth types that resolve a stored Secret (for OAuth this is the client secret).
+const SECRET_AUTH_TYPES = ['bearer', 'basic', 'api_key', 'oauth2_client_credentials'];
 const methodColors: Record<string, string> = {
   GET: 'bg-green-900/30 text-green-400',
   POST: 'bg-blue-900/30 text-blue-400',
@@ -51,7 +54,10 @@ export function ConnectorEditor() {
 
   const [formData, setFormData] = useState({
     namespace: 'default', name: '', description: '', base_url: '',
-    auth: { type: 'none' as string, secret: '', header: 'X-Api-Key', position: 'header', param_name: 'api_key' },
+    auth: {
+      type: 'none' as string, secret: '', header: 'X-Api-Key', position: 'header', param_name: 'api_key',
+      token_url: '', client_id: '', scopes: [] as string[], client_auth_method: 'body',
+    },
     headers: {} as Record<string, string>,
     retry: { max_attempts: 1, backoff: 'none' },
     timeout_seconds: 30,
@@ -97,7 +103,10 @@ export function ConnectorEditor() {
         name: connector.name,
         description: connector.description || '',
         base_url: connector.base_url,
-        auth: { type: 'none', secret: '', header: 'X-Api-Key', position: 'header', param_name: 'api_key', ...connector.auth },
+        auth: {
+          type: 'none', secret: '', header: 'X-Api-Key', position: 'header', param_name: 'api_key',
+          token_url: '', client_id: '', scopes: [], client_auth_method: 'body', ...connector.auth,
+        },
         headers: connector.headers || {},
         retry: { max_attempts: 1, backoff: 'none', ...connector.retry },
         timeout_seconds: connector.timeout_seconds,
@@ -314,9 +323,9 @@ export function ConnectorEditor() {
               {AUTH_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
             </select>
           </div>
-          {['bearer', 'basic', 'api_key'].includes(formData.auth.type) && (
+          {SECRET_AUTH_TYPES.includes(formData.auth.type) && (
             <div>
-              <label className="label">Secret</label>
+              <label className="label">{formData.auth.type === 'oauth2_client_credentials' ? 'Client Secret' : 'Secret'}</label>
               <select value={formData.auth.secret} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, secret: e.target.value } })}
                 className="input w-full">
                 <option value="">Select a secret...</option>
@@ -328,11 +337,6 @@ export function ConnectorEditor() {
         {formData.auth.type === 'api_key' && (
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="label">Header Name</label>
-              <input type="text" value={formData.auth.header} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, header: e.target.value } })}
-                className="input w-full" />
-            </div>
-            <div>
               <label className="label">Position</label>
               <select value={formData.auth.position} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, position: e.target.value } })}
                 className="input w-full">
@@ -340,6 +344,55 @@ export function ConnectorEditor() {
                 <option value="query">Query Parameter</option>
               </select>
             </div>
+            {formData.auth.position === 'query' ? (
+              <div>
+                <label className="label">Query Param Name</label>
+                <input type="text" value={formData.auth.param_name} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, param_name: e.target.value } })}
+                  className="input w-full" placeholder="api_key" />
+              </div>
+            ) : (
+              <div>
+                <label className="label">Header Name</label>
+                <input type="text" value={formData.auth.header} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, header: e.target.value } })}
+                  className="input w-full" placeholder="X-Api-Key" />
+              </div>
+            )}
+          </div>
+        )}
+        {formData.auth.type === 'oauth2_client_credentials' && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="label">Token URL</label>
+                <input type="text" value={formData.auth.token_url} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, token_url: e.target.value } })}
+                  className="input w-full font-mono" placeholder="https://idp.example.com/oauth/token" />
+              </div>
+              <div>
+                <label className="label">Client ID</label>
+                <input type="text" value={formData.auth.client_id} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, client_id: e.target.value } })}
+                  className="input w-full font-mono" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="label">Scopes</label>
+                <input type="text"
+                  value={(formData.auth.scopes || []).join(' ')}
+                  onChange={e => setFormData({ ...formData, auth: { ...formData.auth, scopes: e.target.value.split(/\s+/).filter(Boolean) } })}
+                  className="input w-full font-mono" placeholder="read write (space-separated)" />
+              </div>
+              <div>
+                <label className="label">Client Auth Method</label>
+                <select value={formData.auth.client_auth_method} onChange={e => setFormData({ ...formData, auth: { ...formData.auth, client_auth_method: e.target.value } })}
+                  className="input w-full">
+                  <option value="body">Request Body (client_secret_post)</option>
+                  <option value="basic">HTTP Basic (client_secret_basic)</option>
+                </select>
+              </div>
+            </div>
+            <p className="text-xs text-gray-500">
+              The client secret is exchanged for a short-lived access token, cached until shortly before it expires, and sent as a Bearer token.
+            </p>
           </div>
         )}
         {formData.auth.type === 'sinas_token' && (

--- a/console/src/pages/Secrets.tsx
+++ b/console/src/pages/Secrets.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '../lib/api';
+import { apiClient, getApiErrorMessage } from '../lib/api';
 import { Plus, Trash2, Edit2, KeyRound, X, Eye, EyeOff } from 'lucide-react';
 
 interface Secret {
@@ -256,7 +256,7 @@ export function Secrets() {
               {saveMutation.isError && (
                 <div className="p-3 bg-red-900/20 border border-red-800 rounded-lg">
                   <p className="text-sm text-red-400">
-                    {(saveMutation.error as any)?.response?.data?.detail || 'Failed to save secret'}
+                    {getApiErrorMessage(saveMutation.error, 'Failed to save secret')}
                   </p>
                 </div>
               )}


### PR DESCRIPTION
Implements OAuth 2.0 for Connectors (#66), plus two adjacent gaps found along the way. Draft — no automated tests yet (see below).

## What's in it

**OAuth 2.0 — client-credentials (machine-to-machine)**
- New auth type `oauth2_client_credentials`: exchanges client_id/secret for a short-lived bearer token, cached in-process until shortly before expiry. Supports `client_secret_post` and `client_secret_basic`.
- Client secret reuses the existing `Secret` store (private-overrides-shared).

**OAuth 2.0 — authorization-code (per-user "Connect your account")**
- New auth type `oauth2_authorization_code`. Config (authorize/token URL, client_id, scopes, auth method) lives on the connector's `auth` JSON; the client secret is a `Secret` reference.
- Per-user tokens in a new `connector_oauth_tokens` table (one row per connector+user); access/refresh tokens encrypted via the existing `encryption_service`, `expires_at`/`scope` in plain columns for refresh decisions.
- Flow: authenticated `POST /connectors/{ns}/{name}/oauth/authorize` mints a PKCE challenge + single-use Redis state and returns the provider URL; public `GET /auth/connectors/oauth/callback` recovers the user from state, exchanges the code, stores tokens, and returns a popup-closing page. `GET .../oauth/status` and `DELETE .../oauth/token` manage the connection.
- Redirect URI is driven by the `DOMAIN` env var (`https://{DOMAIN}/auth/connectors/oauth/callback`); localhost only as dev fallback.
- **Concurrency:** the valid-token path takes no lock (fully parallel). Only an actual refresh takes `SELECT … FOR UPDATE` on the single (connector, user) row, in its own short-lived transaction, with a double-check under the lock — so concurrent refreshers across workers/containers can't race a rotating refresh token, and nothing else serializes.

**Adjacent fixes**
- Implemented the previously-dormant `position`/`param_name` on `api_key` auth (send the key as a query param, not just a header).
- OAuth auth fields now round-trip through package/YAML config (export → `config apply`); they were being silently dropped.
- OpenAPI import now derives a **suggested auth** config from `components.securitySchemes` (apiKey/http/oauth2 flows) and the console prefills it — without clobbering a chosen type. Secrets/client_id are never derived.

**Console**
- Auth editor gains OAuth (client-credentials & authorization-code) fields and the query-param api_key path.
- Authorization-code connectors get a Connect / Reconnect / Disconnect panel with live status (opens the consent popup, listens for the callback via postMessage).

## Verification
Ran the full stack from this branch: migration applies to a single alembic head (also merges two pre-existing open heads), `connector_oauth_tokens` created with CASCADE FKs + unique (connector_id, user_id), backend boots clean, public callback + auth-guarded endpoints respond correctly, config round-trip preserves OAuth fields, and securityScheme→auth mapping verified across scheme types.

## Not done / follow-ups
- **No automated tests yet** (parked pending test-setup decisions).
- **No live end-to-end handshake** against a real provider — only structural + error paths exercised.
- Token refresh is coordinated per-row via DB lock; no global rate-limiting of token endpoints.
- Whether the client-secret `Secret` itself ships inside a package (vs. referenced by name) is unchanged/pre-existing.

## Migration note
The migration `0a1u2t3h4t5k` also merges the two open alembic heads (`b1a2t3c4h5e6`, `20260131_states`) into one mergepoint.
