### PR TITLE
Kubernetes deployment: k8s_pod sandbox executor, inprocess trusted executor, Helm chart (#69)

### DIFF
--- a/backend/app/api/v1/endpoints/containers.py
+++ b/backend/app/api/v1/endpoints/containers.py
@@ -27,9 +27,20 @@ async def reload_pool_packages(
     db: AsyncSession = Depends(get_db),
 ):
     """
-    Reinstall all approved packages in idle sandbox containers.
+    Apply approved-package changes to the sandbox.
+
+    - docker_pool: reinstall packages in idle containers and restart them.
+    - docker_ephemeral: rebuild the baked sandbox image (containers are
+      per-execution, so there is nothing to reload).
     Admin only.
     """
+    from app.core.config import settings
+
+    if settings.sandbox_executor == "docker_ephemeral":
+        from app.services.sandbox_image import build_sandbox_image
+
+        tag = await build_sandbox_image(db)
+        return {"status": "rebuilt", "image": tag}
 
     result = await container_pool.reload_packages(db)
     return result

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,6 +87,19 @@ class Settings(BaseSettings):
     smtp_server_host: str = "0.0.0.0"
     smtp_server_port: int = 2525  # Port for incoming email SMTP server
 
+    # Executor selection — see `app/services/executor/` for the abstraction.
+    # - sandbox_executor: backend for untrusted code (per-function untrusted
+    #   functions and agent codeExecution). Must isolate per execution.
+    #     "docker_pool"      — long-lived Docker container pool (current default)
+    #     "docker_ephemeral" — Docker `run --rm` per execution (planned, step 3)
+    #     "k8s_pod"          — k8s Pod per execution (planned, step 5)
+    #     "disabled"         — sandbox features rejected; deploy is trusted-only
+    # - trusted_executor: backend for admin-approved code (Function.shared_pool=True).
+    #     "docker_shared" — dedicated long-lived Docker workers (current default)
+    #     "inprocess"     — run inside queue-worker process (planned, step 4)
+    sandbox_executor: str = "docker_pool"
+    trusted_executor: str = "docker_shared"
+
     # Function execution (always uses Docker for isolation)
     function_timeout: int = 300  # 5 minutes (max execution time)
     max_function_memory: int = 512  # MB (Docker memory limit)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,8 @@
+import json
 import os
 from typing import Optional
 
-from pydantic import field_validator, model_validator
+from pydantic import ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 VALID_AUTH_MODES = {"otp", "password", "password+otp"}
@@ -108,6 +109,59 @@ class Settings(BaseSettings):
     k8s_sandbox_service_account: str = ""  # SA for sandbox pods; "" = namespace default
     k8s_sandbox_pod_ready_timeout: int = 120  # seconds to wait for a sandbox pod to become Ready
     k8s_sandbox_install_dependencies: bool = True  # pip install Dependency specs into each pod (skip if baked into k8s_sandbox_image)
+
+    # Scheduling for sandbox pods — deliberately dumb/generic so the actual
+    # policy (spread one-client-per-node vs. pack many clients per node,
+    # etc.) lives entirely in the Helm chart's values, not in app code. This
+    # app only applies whatever it's handed:
+    #   - k8s_release_name: stamped as app.kubernetes.io/instance on the pod,
+    #     so chart-authored affinity rules (either direction) have something
+    #     to match on. "" = no label.
+    #   - k8s_sandbox_node_selector / k8s_sandbox_tolerations: verbatim
+    #     nodeSelector / tolerations, JSON-encoded.
+    #   - k8s_sandbox_affinity: a verbatim K8s `affinity` object (podAffinity
+    #     to pack onto the same node as other pods matching a label,
+    #     podAntiAffinity to spread, nodeAffinity, or any combination),
+    #     JSON-encoded. The chart decides which shape to send — e.g. required
+    #     podAntiAffinity for a paid/isolated plan, required podAffinity
+    #     keyed on a shared "plan=free" label to force free-tier clients onto
+    #     the same node, or "{}" for no constraint. Changing that policy is a
+    #     chart values change, not an app change.
+    # All empty/no-op by default — matches today's behavior on generic
+    # clusters with no per-client scheduling policy.
+    k8s_release_name: str = ""
+    k8s_sandbox_node_selector: str = "{}"  # JSON object, e.g. {"role": "shared"}
+    k8s_sandbox_tolerations: str = "[]"  # JSON list of Toleration dicts
+    k8s_sandbox_affinity: str = "{}"  # JSON k8s Affinity object (podAffinity/podAntiAffinity/nodeAffinity)
+
+    @field_validator("k8s_sandbox_node_selector", "k8s_sandbox_affinity")
+    @classmethod
+    def _validate_k8s_json_object(cls, v: str, info: ValidationInfo) -> str:
+        # Fail at startup, not on the first sandbox execution: a bad value
+        # here would otherwise surface as an unhandled JSONDecodeError deep
+        # inside pod creation instead of a clear config error.
+        try:
+            parsed = json.loads(v)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"{info.field_name} must be valid JSON: {e}") from e
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"{info.field_name} must be a JSON object, got {type(parsed).__name__}"
+            )
+        return v
+
+    @field_validator("k8s_sandbox_tolerations")
+    @classmethod
+    def _validate_k8s_tolerations(cls, v: str) -> str:
+        try:
+            parsed = json.loads(v)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"k8s_sandbox_tolerations must be valid JSON: {e}") from e
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"k8s_sandbox_tolerations must be a JSON array, got {type(parsed).__name__}"
+            )
+        return v
 
     # Function execution (always uses Docker for isolation)
     function_timeout: int = 300  # 5 minutes (max execution time)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -91,14 +91,23 @@ class Settings(BaseSettings):
     # - sandbox_executor: backend for untrusted code (per-function untrusted
     #   functions and agent codeExecution). Must isolate per execution.
     #     "docker_pool"      — long-lived Docker container pool (current default)
-    #     "docker_ephemeral" — Docker `run --rm` per execution (planned, step 3)
-    #     "k8s_pod"          — k8s Pod per execution (planned, step 5)
+    #     "docker_ephemeral" — single-use Docker container per execution
+    #     "k8s_pod"          — single-use k8s Pod per execution (for k8s deploys)
     #     "disabled"         — sandbox features rejected; deploy is trusted-only
     # - trusted_executor: backend for admin-approved code (Function.shared_pool=True).
     #     "docker_shared" — dedicated long-lived Docker workers (current default)
-    #     "inprocess"     — run inside queue-worker process (planned, step 4)
+    #     "inprocess"     — run inside the calling process; no Docker socket needed
     sandbox_executor: str = "docker_pool"
     trusted_executor: str = "docker_shared"
+
+    # k8s_pod sandbox executor (only read when sandbox_executor="k8s_pod").
+    # Runs in-cluster: credentials come from the pod's ServiceAccount, which
+    # needs create/get/delete + exec on pods in `k8s_sandbox_namespace`.
+    k8s_sandbox_namespace: str = ""  # "" = this pod's namespace (POD_NAMESPACE env or serviceaccount file)
+    k8s_sandbox_image: str = ""  # "" = function_container_image; must be pullable by the cluster
+    k8s_sandbox_service_account: str = ""  # SA for sandbox pods; "" = namespace default
+    k8s_sandbox_pod_ready_timeout: int = 120  # seconds to wait for a sandbox pod to become Ready
+    k8s_sandbox_install_dependencies: bool = True  # pip install Dependency specs into each pod (skip if baked into k8s_sandbox_image)
 
     # Function execution (always uses Docker for isolation)
     function_timeout: int = 300  # 5 minutes (max execution time)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,27 +72,30 @@ async def lifespan(app: FastAPI):
     # Discover existing Docker containers so /api/v1/containers and /workers
     # endpoints can report accurate state.  The workers/pool are *created* by
     # the arq worker process or explicit scale calls; here we only discover.
-    try:
-        from app.services.container_pool import container_pool
+    # Skipped entirely for non-Docker executors (k8s / single-container).
+    if settings.sandbox_executor == "docker_pool":
+        try:
+            from app.services.container_pool import container_pool
 
-        await container_pool._discover_existing_containers()
-        container_pool._initialized = True
-        print(
-            f"✅ Discovered {len(container_pool.idle)} sandbox containers"
-        )
-    except Exception as e:
-        print(f"⚠️  Container pool discovery skipped: {e}")
+            await container_pool._discover_existing_containers()
+            container_pool._initialized = True
+            print(
+                f"✅ Discovered {len(container_pool.idle)} sandbox containers"
+            )
+        except Exception as e:
+            print(f"⚠️  Container pool discovery skipped: {e}")
 
-    try:
-        from app.services.shared_worker_manager import shared_worker_manager
+    if settings.trusted_executor == "docker_shared":
+        try:
+            from app.services.shared_worker_manager import shared_worker_manager
 
-        await shared_worker_manager._discover_existing_workers()
-        shared_worker_manager._initialized = True
-        print(
-            f"✅ Discovered {len(shared_worker_manager.workers)} shared containers"
-        )
-    except Exception as e:
-        print(f"⚠️  Shared worker discovery skipped: {e}")
+            await shared_worker_manager._discover_existing_workers()
+            shared_worker_manager._initialized = True
+            print(
+                f"✅ Discovered {len(shared_worker_manager.workers)} shared containers"
+            )
+        except Exception as e:
+            print(f"⚠️  Shared worker discovery skipped: {e}")
 
     # Apply ClickHouse storage/TTL migration
     try:

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -226,25 +226,28 @@ async def function_worker_startup(ctx: dict) -> None:
 
     # Discover shared worker containers (created by scheduler).
     # Retry a few times — the scheduler may still be starting up.
-    from app.services.shared_worker_manager import shared_worker_manager
+    # Skipped for non-Docker executors (k8s / single-container).
+    if settings.trusted_executor == "docker_shared":
+        from app.services.shared_worker_manager import shared_worker_manager
 
-    for attempt in range(10):
-        await shared_worker_manager._discover_existing_workers()
-        if shared_worker_manager.workers:
-            break
-        if attempt < 9:
-            print(f"⏳ No shared containers found, waiting for scheduler... ({attempt + 1}/10)")
-            await asyncio.sleep(3)
+        for attempt in range(10):
+            await shared_worker_manager._discover_existing_workers()
+            if shared_worker_manager.workers:
+                break
+            if attempt < 9:
+                print(f"⏳ No shared containers found, waiting for scheduler... ({attempt + 1}/10)")
+                await asyncio.sleep(3)
 
-    shared_worker_manager._initialized = True
-    print(f"✅ Discovered {len(shared_worker_manager.workers)} shared containers")
+        shared_worker_manager._initialized = True
+        print(f"✅ Discovered {len(shared_worker_manager.workers)} shared containers")
 
     # Discover existing sandbox containers (created by backend leader)
-    from app.services.container_pool import container_pool
+    if settings.sandbox_executor == "docker_pool":
+        from app.services.container_pool import container_pool
 
-    await container_pool._discover_existing_containers()
-    container_pool._initialized = True
-    print(f"✅ Discovered {len(container_pool.idle)} sandbox containers")
+        await container_pool._discover_existing_containers()
+        container_pool._initialized = True
+        print(f"✅ Discovered {len(container_pool.idle)} sandbox containers")
 
     # Start heartbeat
     worker_id = str(uuid.uuid4())
@@ -281,11 +284,12 @@ async def agent_worker_startup(ctx: dict) -> None:
     from app.core.database import AsyncSessionLocal  # noqa: F401
 
     # Discover sandbox containers (needed for code execution tool)
-    from app.services.container_pool import container_pool
+    if settings.sandbox_executor == "docker_pool":
+        from app.services.container_pool import container_pool
 
-    await container_pool._discover_existing_containers()
-    container_pool._initialized = True
-    print(f"✅ Agent worker discovered {len(container_pool.idle)} sandbox containers")
+        await container_pool._discover_existing_containers()
+        container_pool._initialized = True
+        print(f"✅ Agent worker discovered {len(container_pool.idle)} sandbox containers")
 
     # Start heartbeat
     worker_id = str(uuid.uuid4())

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -242,7 +242,20 @@ async def main() -> None:
 
     # --- Sandbox containers ---
     async with AsyncSessionLocal() as db:
-        await container_pool.initialize(db)
+        if settings.sandbox_executor == "docker_pool":
+            await container_pool.initialize(db)
+        elif settings.sandbox_executor == "docker_ephemeral":
+            # No warm pool — untrusted code runs in a fresh container per
+            # execution. Pre-build the baked sandbox image so the first
+            # execution doesn't pay the build (it self-corrects otherwise).
+            from app.services.sandbox_image import build_sandbox_image
+
+            try:
+                await build_sandbox_image(db)
+            except Exception as e:
+                logger.warning(
+                    "Sandbox image pre-build failed (will build on demand): %s", e
+                )
 
     # --- Shared containers ---
     await shared_worker_manager.initialize()

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -258,7 +258,8 @@ async def main() -> None:
                 )
 
     # --- Shared containers ---
-    await shared_worker_manager.initialize()
+    if settings.trusted_executor == "docker_shared":
+        await shared_worker_manager.initialize()
 
     # --- APScheduler ---
     await scheduler.start()

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -91,6 +91,7 @@ async def execute(
     Routes to the configured sandbox executor:
     - docker_pool: a reusable container from the warm pool.
     - docker_ephemeral: a fresh single-use container from the baked image.
+    - k8s_pod: a fresh single-use Kubernetes pod.
 
     Returns:
         {"stdout": str, "stderr": str, "result": any, "duration_ms": int}
@@ -129,6 +130,39 @@ async def execute(
             "duration_ms": int((time.time() - start_time) * 1000),
             "error": str(exc),
         }
+
+    if settings.sandbox_executor == "disabled":
+        return _error(
+            RuntimeError(
+                "Code execution is disabled on this deployment (SANDBOX_EXECUTOR=disabled)."
+            )
+        )
+
+    # k8s: a fresh single-use pod per execution (no pool).
+    if settings.sandbox_executor == "k8s_pod":
+        from app.core.database import AsyncSessionLocal
+        from app.services.executor._k8s_runtime import (
+            create_sandbox_pod,
+            delete_sandbox_pod,
+            run_payload_in_pod,
+        )
+
+        try:
+            async with AsyncSessionLocal() as db:
+                name, namespace = await create_sandbox_pod(
+                    db, execution_id=execution_id
+                )
+            try:
+                wire = await run_payload_in_pod(
+                    name, namespace, payload, effective_timeout
+                )
+                return _shape_code_result(
+                    wire, int((time.time() - start_time) * 1000)
+                )
+            finally:
+                await delete_sandbox_pod(name, namespace)
+        except Exception as e:
+            return _error(e)
 
     # Ephemeral: a fresh single-use container from the baked image (no pool).
     if settings.sandbox_executor == "docker_ephemeral":
@@ -263,6 +297,13 @@ sys.exit(1)
             "duration_ms": duration_ms,
         }
 
+    return _shape_code_result(result_data, duration_ms)
+
+
+def _shape_code_result(
+    result_data: dict[str, Any], duration_ms: int
+) -> dict[str, Any]:
+    """Map a wire result dict to the code-execution tool's result shape."""
     if result_data.get("status") == "failed":
         return {
             "stdout": result_data.get("stdout", ""),

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -86,84 +86,139 @@ async def execute(
     chat_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """
-    Execute Python code in a sandbox container.
+    Execute Python code in a sandbox container (untrusted execution).
 
-    Uses the container_pool (untrusted execution) — LLM-generated code
-    must run in isolated, capability-dropped containers.
+    Routes to the configured sandbox executor:
+    - docker_pool: a reusable container from the warm pool.
+    - docker_ephemeral: a fresh single-use container from the baked image.
 
     Returns:
         {"stdout": str, "stderr": str, "result": any, "duration_ms": int}
     """
-    from app.services.container_pool import container_pool
-
     effective_timeout = timeout or settings.code_execution_timeout
     execution_id = str(uuid.uuid4())
     start_time = time.time()
 
-    # Wrap the user code so we capture the result of the last expression
-    # We use a wrapper that exec's the code and captures the last expression
+    # Wrap the user code so we capture stdout and the last expression result.
     wrapper_code = _build_wrapper(code)
 
-    # Acquire a container from the pool
+    payload = {
+        "action": "execute_inline",
+        "function_code": wrapper_code,
+        "execution_id": execution_id,
+        "function_namespace": "_code_execution",
+        "function_name": "handler",
+        "timeout": effective_timeout,
+        "input_data": {},
+        "context": {
+            "user_id": user_id or "",
+            "user_email": "",
+            "access_token": "",
+            "execution_id": execution_id,
+            "trigger_type": "code_execution",
+            "chat_id": chat_id or "",
+        },
+    }
+
+    def _error(exc: Exception) -> dict[str, Any]:
+        logger.error(f"Code execution error: {exc}")
+        return {
+            "stdout": "",
+            "stderr": str(exc),
+            "result": None,
+            "duration_ms": int((time.time() - start_time) * 1000),
+            "error": str(exc),
+        }
+
+    # Ephemeral: a fresh single-use container from the baked image (no pool).
+    if settings.sandbox_executor == "docker_ephemeral":
+        from app.core.database import AsyncSessionLocal
+        from app.services.executor._ephemeral_runtime import (
+            create_ephemeral_container,
+            remove_ephemeral_container,
+        )
+
+        try:
+            async with AsyncSessionLocal() as db:
+                _client, container, name = await create_ephemeral_container(
+                    db, execution_id=execution_id
+                )
+            try:
+                return await _run_code_payload(
+                    container, payload, execution_id, effective_timeout, start_time
+                )
+            finally:
+                await remove_ephemeral_container(container, name)
+        except Exception as e:
+            return _error(e)
+
+    # Default: a reusable container from the warm pool.
+    from app.services.container_pool import container_pool
+
     pc = await container_pool.acquire()
     logger.info(f"Acquired sandbox container {pc.name} for code execution (chat={chat_id})")
-
     tainted = False
     try:
         container = await asyncio.to_thread(container_pool.client.containers.get, pc.name)
+        result = await _run_code_payload(
+            container, payload, execution_id, effective_timeout, start_time
+        )
+        # Discard the container if the run errored (avoid handing leaked state on).
+        if result.get("error") is not None:
+            tainted = True
+        return result
+    except Exception as e:
+        tainted = True
+        return _error(e)
+    finally:
+        await asyncio.to_thread(container_pool.release, pc.name, tainted=tainted)
 
-        payload = {
-            "action": "execute_inline",
-            "function_code": wrapper_code,
-            "execution_id": execution_id,
-            "function_namespace": "_code_execution",
-            "function_name": "handler",
-            "timeout": effective_timeout,
-            "input_data": {},
-            "context": {
-                "user_id": user_id or "",
-                "user_email": "",
-                "access_token": "",
-                "execution_id": execution_id,
-                "trigger_type": "code_execution",
-                "chat_id": chat_id or "",
-            },
-        }
 
-        # Per-execution file paths
-        eid = execution_id
-        request_filename = f"exec_request_{eid}.json"
-        trigger_file = f"/tmp/exec_trigger_{eid}"
-        result_file = f"/tmp/exec_result_{eid}.json"
+async def _run_code_payload(
+    container,
+    payload: dict[str, Any],
+    execution_id: str,
+    effective_timeout: int,
+    start_time: float,
+) -> dict[str, Any]:
+    """Run a code-execution payload in `container` and parse the result.
 
-        # Write payload into the container via stdin pipe
-        payload_bytes = json.dumps(payload).encode("utf-8")
-        request_path = f"/tmp/{request_filename}"
-        api = container.client.api
-        exec_id = api.exec_create(
-            container.id,
-            [
-                "python3", "-c",
-                f'import sys; open("{request_path}","wb").write(sys.stdin.buffer.read())',
-            ],
-            stdin=True,
-            stdout=True,
-            stderr=True,
-        )["Id"]
-        sock = api.exec_start(exec_id, socket=True)
-        sock._sock.sendall(payload_bytes)
-        import socket as _sock_mod
-        sock._sock.shutdown(_sock_mod.SHUT_WR)
-        sock.read()
-        sock.close()
+    Shared by the pooled and ephemeral code-execution paths; only the container
+    lifecycle around this call differs. Raises on Docker/infra errors (callers
+    convert those to an error result).
+    """
+    import socket as _sock_mod
 
-        # Trigger execution and wait for result
-        exec_result = await asyncio.to_thread(
-            container.exec_run,
-            cmd=[
-                "python3",
-                "-c",
-                f"""
+    eid = execution_id
+    request_path = f"/tmp/exec_request_{eid}.json"
+    trigger_file = f"/tmp/exec_trigger_{eid}"
+    result_file = f"/tmp/exec_result_{eid}.json"
+
+    # Write the request into the container via a stdin pipe.
+    payload_bytes = json.dumps(payload).encode("utf-8")
+    api = container.client.api
+    exec_id = api.exec_create(
+        container.id,
+        [
+            "python3", "-c",
+            f'import sys; open("{request_path}","wb").write(sys.stdin.buffer.read())',
+        ],
+        stdin=True,
+        stdout=True,
+        stderr=True,
+    )["Id"]
+    sock = api.exec_start(exec_id, socket=True)
+    sock._sock.sendall(payload_bytes)
+    sock._sock.shutdown(_sock_mod.SHUT_WR)
+    sock.read()
+    sock.close()
+
+    exec_result = await asyncio.to_thread(
+        container.exec_run,
+        cmd=[
+            "python3",
+            "-c",
+            f"""
 import sys, json, time, os
 with open("{trigger_file}", "w") as f:
     f.write("1")
@@ -180,67 +235,49 @@ while time.time() - start < max_wait:
 print(json.dumps({{"status": "failed", "error": "Execution timed out"}}))
 sys.exit(1)
 """,
-            ],
-            stdout=True,
-            stderr=True,
-        )
+        ],
+        stdout=True,
+        stderr=True,
+    )
 
-        duration_ms = int((time.time() - start_time) * 1000)
+    duration_ms = int((time.time() - start_time) * 1000)
 
-        if exec_result.exit_code != 0:
-            tainted = True
-            stderr_output = exec_result.output.decode("utf-8", errors="replace") if exec_result.output else ""
-            return {
-                "stdout": "",
-                "stderr": stderr_output,
-                "result": None,
-                "duration_ms": duration_ms,
-                "error": "Code execution failed",
-            }
-
-        # Parse result
-        raw_output = exec_result.output.decode("utf-8", errors="replace") if exec_result.output else "{}"
-        try:
-            result_data = json.loads(raw_output.strip())
-        except json.JSONDecodeError:
-            return {
-                "stdout": raw_output,
-                "stderr": "",
-                "result": None,
-                "duration_ms": duration_ms,
-            }
-
-        if result_data.get("status") == "failed":
-            tainted = True
-            return {
-                "stdout": result_data.get("stdout", ""),
-                "stderr": result_data.get("stderr", result_data.get("error", "")),
-                "result": None,
-                "duration_ms": duration_ms,
-                "error": result_data.get("error", "Execution failed"),
-            }
-
-        return {
-            "stdout": result_data.get("stdout", ""),
-            "stderr": result_data.get("stderr", ""),
-            "result": result_data.get("result"),
-            "duration_ms": duration_ms,
-        }
-
-    except Exception as e:
-        tainted = True
-        duration_ms = int((time.time() - start_time) * 1000)
-        logger.error(f"Code execution error: {e}")
+    if exec_result.exit_code != 0:
+        stderr_output = exec_result.output.decode("utf-8", errors="replace") if exec_result.output else ""
         return {
             "stdout": "",
-            "stderr": str(e),
+            "stderr": stderr_output,
             "result": None,
             "duration_ms": duration_ms,
-            "error": str(e),
+            "error": "Code execution failed",
         }
 
-    finally:
-        await asyncio.to_thread(container_pool.release, pc.name, tainted=tainted)
+    raw_output = exec_result.output.decode("utf-8", errors="replace") if exec_result.output else "{}"
+    try:
+        result_data = json.loads(raw_output.strip())
+    except json.JSONDecodeError:
+        return {
+            "stdout": raw_output,
+            "stderr": "",
+            "result": None,
+            "duration_ms": duration_ms,
+        }
+
+    if result_data.get("status") == "failed":
+        return {
+            "stdout": result_data.get("stdout", ""),
+            "stderr": result_data.get("stderr", result_data.get("error", "")),
+            "result": None,
+            "duration_ms": duration_ms,
+            "error": result_data.get("error", "Execution failed"),
+        }
+
+    return {
+        "stdout": result_data.get("stdout", ""),
+        "stderr": result_data.get("stderr", ""),
+        "result": result_data.get("result"),
+        "duration_ms": duration_ms,
+    }
 
 
 def _build_wrapper(user_code: str) -> str:

--- a/backend/app/services/container_pool.py
+++ b/backend/app/services/container_pool.py
@@ -41,7 +41,10 @@ class ContainerPool:
     """
 
     def __init__(self):
-        self.client = docker.from_env()
+        # Docker client and networks are resolved lazily so this module can be
+        # imported (and the singleton constructed) in socket-free deployments
+        # (sandbox_executor != "docker_pool", e.g. k8s or single-container).
+        self._client = None
         self.idle: deque[PooledContainer] = deque()
         self.in_use: dict[str, PooledContainer] = {}
         self._creating_names: set[str] = set()  # names currently being created (race guard)
@@ -50,8 +53,26 @@ class ContainerPool:
         self._replenish_task: Optional[asyncio.Task] = None
         self._health_task: Optional[asyncio.Task] = None
         self._replenish_event = asyncio.Event()
-        self.docker_network = self._detect_network()
-        self.sandbox_network = self._ensure_sandbox_network()
+        self._docker_network: Optional[str] = None
+        self._sandbox_network: Optional[str] = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = docker.from_env()
+        return self._client
+
+    @property
+    def docker_network(self) -> str:
+        if self._docker_network is None:
+            self._docker_network = self._detect_network()
+        return self._docker_network
+
+    @property
+    def sandbox_network(self) -> str:
+        if self._sandbox_network is None:
+            self._sandbox_network = self._ensure_sandbox_network()
+        return self._sandbox_network
 
     def _detect_network(self) -> str:
         """Auto-detect Docker network."""

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -17,6 +17,7 @@ from app.core.database import AsyncSessionLocal
 from app.models.execution import Execution, ExecutionStatus
 from app.models.function import Function
 from app.services.clickhouse_logger import clickhouse_logger
+from app.services.executor.base import ExecutionResult, ResultStatus
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ class FunctionExecutor:
         chat_id: str | None,
         db: AsyncSession,
         timeout: int | None = None,
-    ) -> dict[str, Any]:
+    ) -> ExecutionResult:
         """
         Execute function in shared worker pool (separate worker containers).
 
@@ -301,6 +302,10 @@ class FunctionExecutor:
 
                 start_time = time.time()
 
+                # Executor role — drives where an awaiting-input execution is
+                # resumed (persisted as a "role:handle" prefix in container_id).
+                role = "trusted" if function.shared_pool else "sandbox"
+
                 # Route execution based on shared_pool setting
                 if function.shared_pool:
                     # Execute in shared worker container pool
@@ -352,11 +357,14 @@ class FunctionExecutor:
                     container_elapsed = time.time() - container_start
                     print(f"⏱️  [TIMING] Sandbox container execution completed in {container_elapsed:.3f}s")
 
-                # Handle awaiting_input from shared containers
-                if exec_result.get("status") == "awaiting_input":
+                # Handle awaiting_input (only the trusted/shared path can pause;
+                # sandbox mode raises on input()).
+                if exec_result.status is ResultStatus.AWAITING_INPUT:
                     execution.status = ExecutionStatus.AWAITING_INPUT
-                    execution.input_prompt = exec_result.get("prompt")
-                    execution.container_id = exec_result.get("container_name")
+                    execution.input_prompt = exec_result.prompt
+                    # "role:handle" — role picks the executor at resume time;
+                    # handle is the executor's opaque resume token.
+                    execution.container_id = f"{role}:{exec_result.handle}"
                     await db.commit()
                     return {
                         "status": "awaiting_input",
@@ -364,16 +372,16 @@ class FunctionExecutor:
                         "prompt": execution.input_prompt,
                     }
 
-                if exec_result.get("status") == "failed":
-                    err = FunctionExecutionError(exec_result.get("error", "Unknown error"))
+                if exec_result.status is ResultStatus.FAILED:
+                    err = FunctionExecutionError(exec_result.error or "Unknown error")
                     # The container captured the function's real internal traceback.
                     # Attach it so the except handler persists it instead of the
                     # backend's own (useless) stack pointing at this raise.
-                    err.container_traceback = exec_result.get("traceback")
+                    err.container_traceback = exec_result.traceback
                     raise err
 
-                result = exec_result.get("result")
-                duration_ms = exec_result.get("duration_ms", 0)
+                result = exec_result.result
+                duration_ms = exec_result.duration_ms
 
                 # Validate output
                 if function.output_schema:
@@ -461,10 +469,11 @@ class FunctionExecutor:
         resume_value: Any,
     ) -> dict[str, Any]:
         """
-        Resume a paused execution by writing the resume value directly
-        to the container where the function is waiting on input().
+        Resume a paused (AWAITING_INPUT) execution with a human-provided value.
 
-        Bypasses the queue — the function thread is already running.
+        Routing and persistence live here; the actual resume mechanism is
+        delegated to the executor that produced the pause, via the opaque
+        handle stored on the execution. Bypasses the queue.
         """
         async with AsyncSessionLocal() as db:
             result = await db.execute(
@@ -480,100 +489,40 @@ class FunctionExecutor:
                     f"Execution {execution_id} is not awaiting input (status={execution.status})"
                 )
 
-            container_id = execution.container_id
-            if not container_id:
+            if not execution.container_id:
                 raise FunctionExecutionError(
-                    f"Execution {execution_id} has no container_id — cannot resume"
+                    f"Execution {execution_id} has no resume handle — cannot resume"
                 )
 
-            # Write resume file into the container
-            import docker
+            # container_id holds "role:handle". Treat a bare value (no ":") as a
+            # trusted handle, for executions paused before this format existed.
+            role, sep, handle = execution.container_id.partition(":")
+            if not sep:
+                role, handle = "trusted", execution.container_id
 
-            client = docker.from_env()
-            try:
-                container = client.containers.get(container_id)
-            except docker.errors.NotFound:
-                # Container gone — mark execution as failed
+            executor = self.sandbox_executor if role == "sandbox" else self.trusted_executor
+            if executor is None:
                 execution.status = ExecutionStatus.FAILED
-                execution.error = "Container no longer available (restarted?)"
+                execution.error = "Sandbox execution is disabled; cannot resume this execution."
                 execution.completed_at = datetime.utcnow()
                 await db.commit()
-                raise FunctionExecutionError(
-                    f"Container {container_id} not found — execution cannot be resumed"
-                )
-
-            # Write resume data into the container via stdin pipe
-            resume_payload = json.dumps({"value": resume_value}).encode("utf-8")
-            resume_file = f"/tmp/exec_resume_{execution_id}.json"
-
-            api = container.client.api
-            exec_id = api.exec_create(
-                container.id,
-                [
-                    "python3", "-c",
-                    f'import sys; open("{resume_file}","wb").write(sys.stdin.buffer.read())',
-                ],
-                stdin=True,
-                stdout=True,
-                stderr=True,
-            )["Id"]
-            sock = api.exec_start(exec_id, socket=True)
-            sock._sock.sendall(resume_payload)
-            import socket as _sock_mod
-            sock._sock.shutdown(_sock_mod.SHUT_WR)
-            sock.read()
-            sock.close()
+                raise FunctionExecutionError(execution.error)
 
             execution.status = ExecutionStatus.RUNNING
             await db.commit()
 
-            # Poll for result from the container
-            result_file = f"/tmp/exec_result_{execution_id}.json"
-            function_timeout = settings.function_timeout
-
-            exec_result = await asyncio.to_thread(
-                container.exec_run,
-                cmd=[
-                    "python3",
-                    "-c",
-                    f"""
-import sys, json, time, os
-max_wait = {function_timeout}
-start = time.time()
-while time.time() - start < max_wait:
-    try:
-        with open("{result_file}", "r") as f:
-            result = json.load(f)
-            print(json.dumps(result))
-            sys.exit(0)
-    except FileNotFoundError:
-        time.sleep(0.1)
-        continue
-print(json.dumps({{"error": "Resume timeout after {function_timeout}s"}}))
-sys.exit(1)
-""",
-                ],
-                demux=True,
+            res = await executor.resume(
+                handle=handle,
+                resume_value=resume_value,
+                execution_id=execution_id,
+                timeout=settings.function_timeout,
             )
 
-            stdout, stderr = exec_result.output
-            stdout_str = stdout.decode() if stdout else ""
-
-            if exec_result.exit_code != 0:
-                stderr_str = stderr.decode() if stderr else ""
-                error_msg = stderr_str or stdout_str or f"Exit code {exec_result.exit_code}"
-                execution.status = ExecutionStatus.FAILED
-                execution.error = error_msg
-                execution.completed_at = datetime.utcnow()
-                await db.commit()
-                raise FunctionExecutionError(f"Resume failed: {error_msg}")
-
-            result_data = json.loads(stdout_str)
-
-            # Handle another awaiting_input (multiple input() calls)
-            if result_data.get("status") == "awaiting_input":
+            # Another input() call — stay paused, keep the (re-stamped) handle.
+            if res.status is ResultStatus.AWAITING_INPUT:
                 execution.status = ExecutionStatus.AWAITING_INPUT
-                execution.input_prompt = result_data.get("prompt")
+                execution.input_prompt = res.prompt
+                execution.container_id = f"{role}:{res.handle}"
                 await db.commit()
                 return {
                     "status": "awaiting_input",
@@ -581,31 +530,27 @@ sys.exit(1)
                     "prompt": execution.input_prompt,
                 }
 
-            if result_data.get("status") == "failed":
+            if res.status is ResultStatus.FAILED:
                 execution.status = ExecutionStatus.FAILED
-                execution.error = result_data.get("error", "Unknown error")
-                execution.traceback = result_data.get("traceback")
+                execution.error = res.error or "Unknown error"
+                execution.traceback = res.traceback
                 execution.completed_at = datetime.utcnow()
                 await db.commit()
-                raise FunctionExecutionError(result_data.get("error", "Unknown error"))
+                raise FunctionExecutionError(res.error or "Unknown error")
 
             # Completed
-            output = result_data.get("result")
-            duration_ms = result_data.get("duration_ms", 0)
-
             execution.status = ExecutionStatus.COMPLETED
-            execution.output_data = output
+            execution.output_data = res.result
             execution.completed_at = datetime.utcnow()
-            execution.duration_ms = duration_ms
+            execution.duration_ms = res.duration_ms
             execution.container_id = None
-
             await db.commit()
 
             await clickhouse_logger.log_execution_end(
-                execution_id, "completed", output, None, duration_ms
+                execution_id, "completed", res.result, None, res.duration_ms
             )
 
-            return output
+            return res.result
 
     async def enqueue_function(
         self,

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -5,7 +5,7 @@ import logging
 import time
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 import jsonschema
@@ -17,7 +17,6 @@ from app.core.database import AsyncSessionLocal
 from app.models.execution import Execution, ExecutionStatus
 from app.models.function import Function
 from app.services.clickhouse_logger import clickhouse_logger
-
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +38,7 @@ async def _fire_callback(
     user_email: str,
     status: str,  # "success" | "failure"
     result: Any,
-    error: Optional[str],
+    error: str | None,
     trigger_id: str,
     function_namespace: str,
     function_name: str,
@@ -72,7 +71,7 @@ async def _fire_callback(
     }
 
     status_label = "failed"
-    response_code: Optional[int] = None
+    response_code: int | None = None
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.post(
@@ -108,25 +107,39 @@ async def _fire_callback(
 class FunctionExecutor:
     def __init__(self):
         self.functions_cache: dict[str, Function] = {}
-        self._container_pool = None
+        # Executor selection is delegated to `app.services.executor.factory`,
+        # which resolves the configured impls from settings. We cache the
+        # resolved handles per-instance to avoid the factory call per
+        # execution. The sandbox handle is `None` when sandbox execution is
+        # disabled in this deployment; trusted is always required (it backs
+        # the admin-approved Function.shared_pool path).
+        self._sandbox_executor = None
+        self._sandbox_executor_resolved = False
+        self._trusted_executor = None
 
     @property
-    def container_pool(self):
-        """Lazy load container pool (replaces per-user containers)."""
-        if self._container_pool is None:
-            from app.services.container_pool import container_pool
+    def sandbox_executor(self):
+        """Resolved SandboxExecutor for untrusted code (or None if disabled).
 
-            self._container_pool = container_pool
-        return self._container_pool
+        Untrusted Function execution + agent `codeExecution` route here. A
+        `None` value means the deploy explicitly disabled the sandbox; callers
+        must surface a clear error rather than silently fall back to trusted.
+        """
+        if not self._sandbox_executor_resolved:
+            from app.services.executor import get_sandbox_executor
+
+            self._sandbox_executor = get_sandbox_executor()
+            self._sandbox_executor_resolved = True
+        return self._sandbox_executor
 
     @property
-    def worker_manager(self):
-        """Lazy load shared worker manager."""
-        if not hasattr(self, "_worker_manager") or self._worker_manager is None:
-            from app.services.shared_worker_manager import shared_worker_manager
+    def trusted_executor(self):
+        """Resolved TrustedExecutor for admin-approved `Function.shared_pool` code."""
+        if self._trusted_executor is None:
+            from app.services.executor import get_trusted_executor
 
-            self._worker_manager = shared_worker_manager
-        return self._worker_manager
+            self._trusted_executor = get_trusted_executor()
+        return self._trusted_executor
 
     async def validate_schema(self, data: Any, schema: dict[str, Any]) -> Any:
         """
@@ -151,9 +164,9 @@ class FunctionExecutor:
         user_email: str,
         access_token: str,
         trigger_type: str,
-        chat_id: Optional[str],
+        chat_id: str | None,
         db: AsyncSession,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
     ) -> dict[str, Any]:
         """
         Execute function in shared worker pool (separate worker containers).
@@ -162,7 +175,7 @@ class FunctionExecutor:
         Workers are separate containers from backend but shared across users.
         No per-user isolation - functions must be trusted.
         """
-        exec_result = await self.worker_manager.execute_function(
+        exec_result = await self.trusted_executor.execute(
             user_id=user_id,
             user_email=user_email,
             access_token=access_token,
@@ -222,8 +235,8 @@ class FunctionExecutor:
         trigger_type: str,
         trigger_id: str,
         user_id: str,
-        chat_id: Optional[str] = None,
-        callback_url: Optional[str] = None,
+        chat_id: str | None = None,
+        callback_url: str | None = None,
     ) -> dict[str, Any]:
         """Execute a function with input validation and tracking."""
         async with AsyncSessionLocal() as db:
@@ -313,8 +326,17 @@ class FunctionExecutor:
                     print(
                         f"⏱️  [TIMING] Executing {function_namespace}/{function_name} in sandbox container"
                     )
+                    sandbox = self.sandbox_executor
+                    if sandbox is None:
+                        raise FunctionExecutionError(
+                            f"Sandbox execution is disabled on this deployment "
+                            f"(sandbox_executor='disabled'); cannot run "
+                            f"untrusted function '{function_namespace}/{function_name}'. "
+                            f"Either set Function.shared_pool=True for admin-approved "
+                            f"functions, or enable a sandbox executor."
+                        )
                     container_start = time.time()
-                    exec_result = await self.container_pool.execute_function(
+                    exec_result = await sandbox.execute(
                         user_id=user_id,
                         user_email=user_email,
                         access_token=access_token,
@@ -594,7 +616,7 @@ sys.exit(1)
         trigger_type: str,
         trigger_id: str,
         user_id: str,
-        chat_id: Optional[str] = None,
+        chat_id: str | None = None,
     ) -> dict[str, Any]:
         """
         Enqueue a function for execution via the job queue.

--- a/backend/app/services/executor/__init__.py
+++ b/backend/app/services/executor/__init__.py
@@ -1,0 +1,31 @@
+"""Pluggable execution backends for function code.
+
+Two protocols, two security postures, one dispatch surface:
+
+- `SandboxExecutor` — runs untrusted code (per-function untrusted functions
+  and agent `codeExecution`). Implementations must isolate per execution
+  and prevent cross-user leakage of state, files, or env.
+- `TrustedExecutor` — runs admin-approved code (functions explicitly
+  flagged with `shared_pool=True`). No per-execution isolation guarantee;
+  performance is the priority.
+
+The choice between the two is made per function call by
+`execution_engine.execute_function` based on `Function.shared_pool`.
+The choice of which *implementation* to use for each role is a deploy
+setting (`settings.sandbox_executor`, `settings.trusted_executor`) and
+is resolved by `executor.factory.get_sandbox_executor` /
+`get_trusted_executor`.
+"""
+
+from app.services.executor.base import SandboxExecutor, TrustedExecutor
+from app.services.executor.factory import (
+    get_sandbox_executor,
+    get_trusted_executor,
+)
+
+__all__ = [
+    "SandboxExecutor",
+    "TrustedExecutor",
+    "get_sandbox_executor",
+    "get_trusted_executor",
+]

--- a/backend/app/services/executor/_docker_resume.py
+++ b/backend/app/services/executor/_docker_resume.py
@@ -1,0 +1,111 @@
+"""Docker-based resume, shared by the two Docker executor adapters.
+
+Lifted verbatim (behavior-wise) from the old
+`execution_engine.resume_execution` so the structural refactor is a pure
+move: write the resume value into the live container where the function
+thread is parked on input(), then poll that container for the result.
+
+This helper is DB-free — it does Docker I/O only and returns an
+`ExecutionResult`. The engine owns all `Execution` persistence.
+
+Both `DockerPoolSandboxExecutor` and `DockerSharedTrustedExecutor` delegate
+here; the resume mechanism is identical for both (a Docker container the app
+reaches via the shared daemon). `handle` is the container name/id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket as _socket_mod
+from typing import Any
+
+from app.services.executor.base import ExecutionResult, ResultStatus
+
+
+async def docker_resume(
+    *,
+    handle: str,
+    resume_value: Any,
+    execution_id: str,
+    timeout: int,
+) -> ExecutionResult:
+    """Resume a function parked on input() inside Docker container `handle`."""
+    import docker
+
+    client = docker.from_env()
+    try:
+        container = client.containers.get(handle)
+    except docker.errors.NotFound:
+        # The live container is gone (recycle / deploy / crash). The parked
+        # interpreter state went with it — the execution cannot be resumed.
+        return ExecutionResult.failed("Container no longer available (restarted?)")
+
+    # Write the resume value into the container via an exec stdin pipe.
+    resume_payload = json.dumps({"value": resume_value}).encode("utf-8")
+    resume_file = f"/tmp/exec_resume_{execution_id}.json"
+
+    api = container.client.api
+    exec_id = api.exec_create(
+        container.id,
+        [
+            "python3",
+            "-c",
+            f'import sys; open("{resume_file}","wb").write(sys.stdin.buffer.read())',
+        ],
+        stdin=True,
+        stdout=True,
+        stderr=True,
+    )["Id"]
+    sock = api.exec_start(exec_id, socket=True)
+    sock._sock.sendall(resume_payload)
+    sock._sock.shutdown(_socket_mod.SHUT_WR)
+    sock.read()
+    sock.close()
+
+    # Poll the container for the result the parked function produces.
+    result_file = f"/tmp/exec_result_{execution_id}.json"
+    exec_result = await asyncio.to_thread(
+        container.exec_run,
+        cmd=[
+            "python3",
+            "-c",
+            f"""
+import sys, json, time, os
+max_wait = {timeout}
+start = time.time()
+while time.time() - start < max_wait:
+    try:
+        with open("{result_file}", "r") as f:
+            result = json.load(f)
+            print(json.dumps(result))
+            sys.exit(0)
+    except FileNotFoundError:
+        time.sleep(0.1)
+        continue
+print(json.dumps({{"error": "Resume timeout after {timeout}s"}}))
+sys.exit(1)
+""",
+        ],
+        demux=True,
+    )
+
+    stdout, stderr = exec_result.output
+    stdout_str = stdout.decode() if stdout else ""
+
+    if exec_result.exit_code != 0:
+        stderr_str = stderr.decode() if stderr else ""
+        error_msg = stderr_str or stdout_str or f"Exit code {exec_result.exit_code}"
+        return ExecutionResult.failed(error_msg)
+
+    res = ExecutionResult.from_wire(json.loads(stdout_str))
+
+    # On a *subsequent* input() the container writes awaiting_input without a
+    # container_name (it doesn't know its own name). Re-stamp the handle so the
+    # next resume can find the same container.
+    if res.status is ResultStatus.AWAITING_INPUT and not res.handle:
+        from dataclasses import replace
+
+        res = replace(res, handle=handle)
+
+    return res

--- a/backend/app/services/executor/_ephemeral_runtime.py
+++ b/backend/app/services/executor/_ephemeral_runtime.py
@@ -1,0 +1,115 @@
+"""Shared lifecycle for single-use ephemeral sandbox containers.
+
+Used by `DockerEphemeralSandboxExecutor` (untrusted function execution) and
+`code_execution` (agent codeExecution). Both run the same `execute_inline`
+IPC against the container — only the payload and result shape differ — so only
+the container *lifecycle* (resolve baked image → create hardened container →
+remove) is shared here.
+
+Hardening mirrors `container_pool._do_create_container`, minus the
+unless-stopped restart policy (these containers are single-use). Docker SDK
+calls are blocking; callers wrap them via `asyncio.to_thread`. The SDK is
+imported lazily so this module is importable in socket-free contexts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_network_ready = False
+
+
+def _ensure_network(client) -> str:
+    import docker
+
+    global _network_ready
+    name = settings.sandbox_network
+    if _network_ready:
+        return name
+    try:
+        client.networks.get(name)
+    except docker.errors.NotFound:
+        client.networks.create(name, driver="bridge", labels={"sinas.type": "sandbox"})
+    _network_ready = True
+    return name
+
+
+def _run_config(image: str, name: str, network: str) -> dict[str, Any]:
+    return {
+        "image": image,
+        "name": name,
+        "detach": True,
+        "network": network,
+        "mem_limit": f"{settings.max_function_memory}m",
+        "nano_cpus": int(settings.max_function_cpu * 1_000_000_000),
+        "cap_drop": ["ALL"],
+        "cap_add": ["CHOWN", "SETUID", "SETGID"],
+        "security_opt": ["no-new-privileges:true"],
+        "pids_limit": 256,
+        "extra_hosts": {"host.docker.internal": "host-gateway"},
+        "tmpfs": {"/tmp": "size=100m,mode=1777"},
+        "environment": {
+            "PYTHONUNBUFFERED": "1",
+            "SANDBOX_CONTAINER": "true",
+            "SINAS_CONTAINER_MODE": "sandbox",
+        },
+        "labels": {"sinas.type": "sandbox-executor", "sinas.ephemeral": "true"},
+    }
+
+
+def _create(client, config: dict[str, Any]):
+    # Remove a stale container squatting on this name (e.g. a crashed prior run
+    # of the same execution_id), then create. Apply the storage limit, falling
+    # back if the storage driver doesn't support storage-opt.
+    import docker
+
+    try:
+        stale = client.containers.get(config["name"])
+        stale.remove(force=True)
+    except docker.errors.NotFound:
+        pass
+    try:
+        return client.containers.run(
+            **config, storage_opt={"size": settings.max_function_storage}
+        )
+    except Exception as e:
+        if "storage-opt" in str(e).lower() or "storage driver" in str(e).lower():
+            return client.containers.run(**config)
+        raise
+
+
+async def create_ephemeral_container(
+    db: AsyncSession, *, execution_id: str, name_prefix: str = "sinas-sbx"
+):
+    """Resolve the baked sandbox image, create a hardened single-use container,
+    and let its in-container executor daemon settle. Returns (client, container,
+    name). The caller is responsible for `remove_ephemeral_container`.
+    """
+    import docker
+
+    from app.services.sandbox_image import current_sandbox_image
+
+    image = await current_sandbox_image(db)
+    client = await asyncio.to_thread(docker.from_env)
+    network = await asyncio.to_thread(_ensure_network, client)
+    name = f"{name_prefix}-{execution_id}"
+    config = _run_config(image, name, network)
+    container = await asyncio.to_thread(_create, client, config)
+    # Daemon warmup — match the pool's post-create settle.
+    await asyncio.sleep(1)
+    return client, container, name
+
+
+async def remove_ephemeral_container(container, name: str) -> None:
+    try:
+        await asyncio.to_thread(container.remove, force=True)
+    except Exception as e:
+        logger.warning("Failed to remove ephemeral sandbox %s: %s", name, e)

--- a/backend/app/services/executor/_k8s_runtime.py
+++ b/backend/app/services/executor/_k8s_runtime.py
@@ -139,10 +139,29 @@ def _pod_manifest(name: str, image: str, deadline_seconds: int) -> dict[str, Any
     }
     if settings.k8s_sandbox_service_account:
         spec["serviceAccountName"] = settings.k8s_sandbox_service_account
+
+    labels = dict(_POD_LABELS)
+    if settings.k8s_release_name:
+        # Present so chart-authored affinity rules (either direction) have
+        # something to match on — this app doesn't decide spread vs. pack,
+        # it just labels the pod and applies whatever scheduling config it's
+        # handed (see k8s_sandbox_* settings docs in config.py).
+        labels["app.kubernetes.io/instance"] = settings.k8s_release_name
+
+    node_selector = json.loads(settings.k8s_sandbox_node_selector)
+    if node_selector:
+        spec["nodeSelector"] = node_selector
+    tolerations = json.loads(settings.k8s_sandbox_tolerations)
+    if tolerations:
+        spec["tolerations"] = tolerations
+    affinity = json.loads(settings.k8s_sandbox_affinity)
+    if affinity:
+        spec["affinity"] = affinity
+
     return {
         "apiVersion": "v1",
         "kind": "Pod",
-        "metadata": {"name": name, "labels": dict(_POD_LABELS)},
+        "metadata": {"name": name, "labels": labels},
         "spec": spec,
     }
 

--- a/backend/app/services/executor/_k8s_runtime.py
+++ b/backend/app/services/executor/_k8s_runtime.py
@@ -1,0 +1,406 @@
+"""Single-use sandbox Pods on Kubernetes.
+
+k8s counterpart of `executor._ephemeral_runtime`: create a hardened Pod from
+the executor image, speak the same request/trigger/result-file IPC against its
+in-container executor daemon, then delete the Pod. Used by
+`K8sPodSandboxExecutor` (untrusted function execution) and `code_execution`
+(agent codeExecution).
+
+Differences from the Docker runtimes, by nature of the platform:
+- No image build: the executor image must be pullable by the cluster
+  (`k8s_sandbox_image`, falling back to `function_container_image`). Extra
+  packages from the `Dependency` table are pip-installed into each pod at
+  create time (mirroring the pool's `_install_packages`) unless
+  `k8s_sandbox_install_dependencies=false` — set that when the packages are
+  baked into a custom image.
+- Network isolation is not created here: the Helm chart ships a NetworkPolicy
+  selecting `sinas.type=sandbox-executor` pods (internet egress only, no
+  cluster-internal traffic). The Docker `sandbox_network` has no per-pod
+  equivalent to create on the fly.
+- No pids_limit (a kubelet-level setting, not per-pod).
+- Credentials come from the surrounding pod's ServiceAccount, which needs
+  create/get/delete + exec on pods in the sandbox namespace. Sandbox pods
+  themselves get `automountServiceAccountToken: false`.
+
+The kubernetes client is blocking; callers run these helpers via
+`asyncio.to_thread`. The SDK is imported lazily so this module is importable
+in non-k8s deployments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_POD_LABELS = {"sinas.type": "sandbox-executor", "sinas.ephemeral": "true"}
+_DEPS_INSTALL_TIMEOUT = 300  # seconds for the in-pod pip install
+_clients: tuple[Any, Any] | None = None  # (CoreV1Api, stream_fn)
+
+
+def _get_clients() -> tuple[Any, Any]:
+    """CoreV1Api + exec-stream function. In-cluster config, kubeconfig fallback."""
+    global _clients
+    if _clients is None:
+        from kubernetes import client, config
+        from kubernetes.stream import stream
+
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            # Local development / testing against a kubeconfig context.
+            config.load_kube_config()
+        _clients = (client.CoreV1Api(), stream)
+    return _clients
+
+
+def resolve_namespace() -> str:
+    if settings.k8s_sandbox_namespace:
+        return settings.k8s_sandbox_namespace
+    ns = os.environ.get("POD_NAMESPACE")
+    if ns:
+        return ns
+    try:
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
+            return f.read().strip()
+    except OSError:
+        return "default"
+
+
+def _k8s_quantity(docker_size: str) -> str:
+    """Docker size string ('500m', '1g') → k8s quantity ('500Mi', '1Gi')."""
+    s = docker_size.strip()
+    lowered = s.lower()
+    if lowered.endswith(("ki", "mi", "gi")):
+        return s  # already a k8s quantity
+    for suffix, unit in (("g", "Gi"), ("m", "Mi"), ("k", "Ki")):
+        if lowered.endswith(suffix):
+            return f"{s[:-1]}{unit}"
+    return s
+
+
+def _pod_manifest(name: str, image: str, deadline_seconds: int) -> dict[str, Any]:
+    """Hardened single-use pod. Mirrors `_ephemeral_runtime._run_config`."""
+    spec: dict[str, Any] = {
+        "restartPolicy": "Never",
+        "automountServiceAccountToken": False,
+        "terminationGracePeriodSeconds": 1,
+        # Backstop against leaked pods if the deleting process dies mid-flight.
+        "activeDeadlineSeconds": deadline_seconds,
+        "containers": [
+            {
+                "name": "executor",
+                "image": image,
+                "imagePullPolicy": "IfNotPresent",
+                "env": [
+                    {"name": "PYTHONUNBUFFERED", "value": "1"},
+                    {"name": "SANDBOX_CONTAINER", "value": "true"},
+                    {"name": "SINAS_CONTAINER_MODE", "value": "sandbox"},
+                ],
+                "resources": {
+                    "requests": {
+                        "memory": f"{settings.max_function_memory}Mi",
+                        "cpu": str(settings.max_function_cpu),
+                    },
+                    "limits": {
+                        "memory": f"{settings.max_function_memory}Mi",
+                        "cpu": str(settings.max_function_cpu),
+                        "ephemeral-storage": _k8s_quantity(
+                            settings.max_function_storage
+                        ),
+                    },
+                },
+                "securityContext": {
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {
+                        "drop": ["ALL"],
+                        "add": ["CHOWN", "SETUID", "SETGID"],
+                    },
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+                "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
+            }
+        ],
+        "volumes": [
+            {
+                "name": "tmp",
+                "emptyDir": {"medium": "Memory", "sizeLimit": "100Mi"},
+            }
+        ],
+    }
+    if settings.k8s_sandbox_service_account:
+        spec["serviceAccountName"] = settings.k8s_sandbox_service_account
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": name, "labels": dict(_POD_LABELS)},
+        "spec": spec,
+    }
+
+
+def _exec_blocking(
+    name: str,
+    namespace: str,
+    command: list[str],
+    *,
+    stdin_payload: str | None = None,
+    timeout: float,
+) -> tuple[str, str, int]:
+    """Run a command in the pod's executor container; return (stdout, stderr, rc).
+
+    When `stdin_payload` is set, it is length-prefixed (`"<nbytes>\\n" + data`)
+    because the exec websocket cannot half-close stdin — the remote reader
+    counts bytes instead of waiting for EOF.
+    """
+    api, stream_fn = _get_clients()
+    resp = stream_fn(
+        api.connect_get_namespaced_pod_exec,
+        name,
+        namespace,
+        container="executor",
+        command=command,
+        stdin=stdin_payload is not None,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        _preload_content=False,
+    )
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    try:
+        if stdin_payload is not None:
+            nbytes = len(stdin_payload.encode("utf-8"))
+            resp.write_stdin(f"{nbytes}\n")
+            resp.write_stdin(stdin_payload)
+        deadline = time.time() + timeout
+        while resp.is_open() and time.time() < deadline:
+            resp.update(timeout=1)
+            if resp.peek_stdout():
+                stdout_parts.append(resp.read_stdout())
+            if resp.peek_stderr():
+                stderr_parts.append(resp.read_stderr())
+        try:
+            rc = resp.returncode
+        except Exception:
+            rc = None
+    finally:
+        resp.close()
+    if rc is None:
+        # Stream still open at the deadline (or no status frame): treat as
+        # success iff we got stdout — the payload scripts always print.
+        rc = 0 if stdout_parts else 124
+    return "".join(stdout_parts), "".join(stderr_parts), rc
+
+
+# Remote reader for the length-prefixed stdin protocol (see _exec_blocking).
+_STDIN_WRITER = """
+import sys
+line = b""
+while not line.endswith(b"\\n"):
+    c = sys.stdin.buffer.read(1)
+    if not c:
+        break
+    line += c
+n = int(line)
+data = b""
+while len(data) < n:
+    chunk = sys.stdin.buffer.read(n - len(data))
+    if not chunk:
+        break
+    data += chunk
+with open({path!r}, "wb") as f:
+    f.write(data)
+print("WROTE", len(data), flush=True)
+"""
+
+
+def _wait_ready_blocking(name: str, namespace: str, timeout: float) -> None:
+    api, _ = _get_clients()
+    deadline = time.time() + timeout
+    last_phase = "Unknown"
+    while time.time() < deadline:
+        pod = api.read_namespaced_pod(name=name, namespace=namespace)
+        last_phase = pod.status.phase or "Unknown"
+        if last_phase in ("Failed", "Succeeded"):
+            raise RuntimeError(
+                f"Sandbox pod {name} entered terminal phase {last_phase} before ready"
+            )
+        statuses = pod.status.container_statuses or []
+        if last_phase == "Running" and statuses and statuses[0].ready:
+            return
+        time.sleep(0.25)
+    raise TimeoutError(
+        f"Sandbox pod {name} not ready after {timeout}s (phase={last_phase})"
+    )
+
+
+async def create_sandbox_pod(
+    db: AsyncSession, *, execution_id: str, name_prefix: str = "sinas-sbx"
+) -> tuple[str, str]:
+    """Create a hardened single-use sandbox pod and wait until it is ready.
+
+    Returns (name, namespace). The caller is responsible for
+    `delete_sandbox_pod` — including on failure paths after this returns.
+    """
+    from app.services.sandbox_image import _dependency_specs
+
+    image = settings.k8s_sandbox_image or settings.function_container_image
+    namespace = resolve_namespace()
+    name = f"{name_prefix}-{execution_id}".lower()
+
+    specs = (
+        await _dependency_specs(db)
+        if settings.k8s_sandbox_install_dependencies
+        else []
+    )
+    deadline_seconds = (
+        settings.k8s_sandbox_pod_ready_timeout
+        + (_DEPS_INSTALL_TIMEOUT if specs else 0)
+        + settings.function_timeout
+        + 60
+    )
+    manifest = _pod_manifest(name, image, deadline_seconds)
+
+    api, _ = _get_clients()
+
+    def _create() -> None:
+        from kubernetes.client.exceptions import ApiException
+
+        try:
+            api.create_namespaced_pod(namespace=namespace, body=manifest)
+        except ApiException as e:
+            if e.status == 409:
+                # Stale pod squatting on this name (crashed prior run of the
+                # same execution_id) — replace it.
+                api.delete_namespaced_pod(
+                    name=name, namespace=namespace, grace_period_seconds=0
+                )
+                for _ in range(40):
+                    try:
+                        api.read_namespaced_pod(name=name, namespace=namespace)
+                        time.sleep(0.25)
+                    except ApiException as e2:
+                        if e2.status == 404:
+                            break
+                        raise
+                api.create_namespaced_pod(namespace=namespace, body=manifest)
+            else:
+                raise
+
+    await asyncio.to_thread(_create)
+    try:
+        await asyncio.to_thread(
+            _wait_ready_blocking,
+            name,
+            namespace,
+            settings.k8s_sandbox_pod_ready_timeout,
+        )
+        if specs:
+            stdout, stderr, rc = await asyncio.to_thread(
+                _exec_blocking,
+                name,
+                namespace,
+                ["pip", "install", "--no-cache-dir", *specs],
+                timeout=_DEPS_INSTALL_TIMEOUT,
+            )
+            if rc != 0:
+                raise RuntimeError(
+                    f"Dependency install failed in sandbox pod {name}: "
+                    f"{(stderr or stdout)[-2000:]}"
+                )
+    except Exception:
+        await delete_sandbox_pod(name, namespace)
+        raise
+    return name, namespace
+
+
+async def delete_sandbox_pod(name: str, namespace: str) -> None:
+    api, _ = _get_clients()
+
+    def _delete() -> None:
+        from kubernetes.client.exceptions import ApiException
+
+        try:
+            api.delete_namespaced_pod(
+                name=name, namespace=namespace, grace_period_seconds=0
+            )
+        except ApiException as e:
+            if e.status != 404:
+                raise
+
+    try:
+        await asyncio.to_thread(_delete)
+    except Exception as e:
+        logger.warning("Failed to delete sandbox pod %s: %s", name, e)
+
+
+async def run_payload_in_pod(
+    name: str,
+    namespace: str,
+    payload: dict[str, Any],
+    timeout: int,
+) -> dict[str, Any]:
+    """Run one execute_inline payload against the pod's executor daemon.
+
+    Same request/trigger/result-file protocol as the Docker runtimes. Returns
+    the parsed wire dict; raises on infra errors (exec failure, bad JSON).
+    """
+    eid = payload["execution_id"]
+    request_path = f"/tmp/exec_request_{eid}.json"
+    trigger_file = f"/tmp/exec_trigger_{eid}"
+    result_file = f"/tmp/exec_result_{eid}.json"
+
+    payload_json = json.dumps(payload)
+    writer = _STDIN_WRITER.format(path=request_path)
+    stdout, stderr, rc = await asyncio.to_thread(
+        _exec_blocking,
+        name,
+        namespace,
+        ["python3", "-c", writer],
+        stdin_payload=payload_json,
+        timeout=60,
+    )
+    expected = f"WROTE {len(payload_json.encode('utf-8'))}"
+    if expected not in stdout:
+        raise RuntimeError(
+            f"Failed to write request into sandbox pod {name}: "
+            f"rc={rc} stdout={stdout[-500:]!r} stderr={stderr[-500:]!r}"
+        )
+
+    poll_script = f"""
+import sys, json, time, os
+with open("{trigger_file}", "w") as f:
+    f.write("1")
+max_wait = {timeout}
+start = time.time()
+while time.time() - start < max_wait:
+    if os.path.exists("{result_file}"):
+        with open("{result_file}", "r") as f:
+            data = json.load(f)
+        print(json.dumps(data))
+        sys.exit(0)
+    time.sleep(0.1)
+print(json.dumps({{"status": "failed", "error": "Execution timeout after {timeout}s"}}))
+sys.exit(1)
+"""
+    stdout, stderr, rc = await asyncio.to_thread(
+        _exec_blocking,
+        name,
+        namespace,
+        ["python3", "-c", poll_script],
+        timeout=timeout + 30,
+    )
+    if not stdout.strip():
+        raise RuntimeError(
+            f"No result from sandbox pod {name}: rc={rc} stderr={stderr[-500:]!r}"
+        )
+    return json.loads(stdout.strip())

--- a/backend/app/services/executor/base.py
+++ b/backend/app/services/executor/base.py
@@ -1,0 +1,79 @@
+"""Executor Protocols.
+
+Both `SandboxExecutor` and `TrustedExecutor` expose the same `execute`
+shape — the call signature was historically identical between
+`container_pool.execute_function` and `shared_worker_manager.execute_function`,
+and we preserve that here. The two are kept as separate Protocols so that
+mypy / Pyright catch accidental misuse: a function that requires sandbox
+isolation cannot be silently routed to a trusted executor (and vice
+versa), even though both happen to satisfy the same call shape today.
+
+The result is still a `dict[str, Any]` for now, matching the current
+contract callers in `execution_engine` rely on (`status`,
+`awaiting_input`, `prompt`, `container_name`, etc.). A typed
+`ExecutionResult` may follow once we have a stable list of fields; we
+do not introduce one in this refactor to keep the diff a pure structural
+move.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@runtime_checkable
+class SandboxExecutor(Protocol):
+    """Runs untrusted function code. Per-execution isolation required.
+
+    Implementations must ensure that state written by one execution cannot
+    leak to a subsequent execution (file system, env vars, network
+    artifacts). Concrete impls today rely on Docker-level isolation; the
+    k8s impl will rely on Pod-level isolation; future impls may rely on
+    OS-level or VM-level sandboxing. The Protocol does not encode the
+    mechanism, only the contract.
+    """
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class TrustedExecutor(Protocol):
+    """Runs admin-approved function code (`Function.shared_pool=True`).
+
+    No per-execution isolation requirement. Implementations may run code
+    in-process, in a shared long-lived container, or any other shape that
+    optimizes for throughput. Callers must only route code here when an
+    admin has explicitly opted the function into the trusted pool.
+    """
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> dict[str, Any]: ...

--- a/backend/app/services/executor/base.py
+++ b/backend/app/services/executor/base.py
@@ -71,7 +71,9 @@ class ExecutionResult:
                 prompt=d.get("prompt"),
                 handle=d.get("container_name"),
             )
-        if status == "failed":
+        # Explicit failure, or a status-less error envelope (e.g. the poll
+        # script's own "Execution timeout" output) — never treat as success.
+        if status == "failed" or (status != "completed" and d.get("error")):
             return cls(
                 ResultStatus.FAILED,
                 error=d.get("error", "Unknown error"),

--- a/backend/app/services/executor/base.py
+++ b/backend/app/services/executor/base.py
@@ -1,26 +1,91 @@
-"""Executor Protocols.
+"""Executor Protocols and the typed result they return.
 
-Both `SandboxExecutor` and `TrustedExecutor` expose the same `execute`
-shape — the call signature was historically identical between
-`container_pool.execute_function` and `shared_worker_manager.execute_function`,
-and we preserve that here. The two are kept as separate Protocols so that
-mypy / Pyright catch accidental misuse: a function that requires sandbox
-isolation cannot be silently routed to a trusted executor (and vice
-versa), even though both happen to satisfy the same call shape today.
+Both `SandboxExecutor` and `TrustedExecutor` expose the same
+`execute` / `resume` shape — the call signature was historically identical
+between `container_pool` and `shared_worker_manager`, and we preserve that
+here. The two are kept as separate Protocols so that mypy / Pyright catch
+accidental misuse: a function that requires sandbox isolation cannot be
+silently routed to a trusted executor (and vice versa), even though both
+happen to satisfy the same call shape today.
 
-The result is still a `dict[str, Any]` for now, matching the current
-contract callers in `execution_engine` rely on (`status`,
-`awaiting_input`, `prompt`, `container_name`, etc.). A typed
-`ExecutionResult` may follow once we have a stable list of fields; we
-do not introduce one in this refactor to keep the diff a pure structural
-move.
+`ExecutionResult` is the typed in-process contract between an executor impl
+and `execution_engine`. The *wire* format spoken by the in-container executor
+is still a JSON dict; impls translate it via `ExecutionResult.from_wire`, so
+the executor image is unchanged by this refactor.
+
+The `handle` carried on an AWAITING_INPUT result is **opaque** to the engine:
+it is whatever the producing executor needs to resume (a Docker container
+name today; a `namespace/pod` for the future k8s impl; a durable execution
+key for a replay-based impl — see issue #79). The engine persists it and
+hands it back to `resume()` unchanged.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
 from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class ResultStatus(str, Enum):
+    """Outcome of an execute()/resume() call.
+
+    Distinct from `app.models.execution.ExecutionStatus` (the persisted
+    lifecycle state) — this is only the executor's view of one call's outcome.
+    """
+
+    COMPLETED = "completed"
+    AWAITING_INPUT = "awaiting_input"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Typed result of one execute()/resume() call."""
+
+    status: ResultStatus
+    # COMPLETED
+    result: Any = None
+    duration_ms: int = 0
+    # AWAITING_INPUT
+    prompt: str | None = None
+    handle: str | None = None  # opaque resume token, owned by the producing executor
+    # FAILED
+    error: str | None = None
+    traceback: str | None = None
+
+    @classmethod
+    def from_wire(cls, d: dict[str, Any]) -> "ExecutionResult":
+        """Translate the in-container executor's JSON dict into a typed result.
+
+        Mirrors how `execution_engine` historically interpreted the dict:
+        an explicit `awaiting_input`/`failed` status, otherwise success.
+        Keeps the wire format (and the executor image) unchanged.
+        """
+        status = d.get("status")
+        if status == "awaiting_input":
+            return cls(
+                ResultStatus.AWAITING_INPUT,
+                prompt=d.get("prompt"),
+                handle=d.get("container_name"),
+            )
+        if status == "failed":
+            return cls(
+                ResultStatus.FAILED,
+                error=d.get("error", "Unknown error"),
+                traceback=d.get("traceback"),
+            )
+        return cls(
+            ResultStatus.COMPLETED,
+            result=d.get("result"),
+            duration_ms=d.get("duration_ms", 0),
+        )
+
+    @classmethod
+    def failed(cls, error: str, traceback: str | None = None) -> "ExecutionResult":
+        return cls(ResultStatus.FAILED, error=error, traceback=traceback)
 
 
 @runtime_checkable
@@ -49,12 +114,34 @@ class SandboxExecutor(Protocol):
         chat_id: str | None,
         db: AsyncSession,
         timeout: int,
-    ) -> dict[str, Any]: ...
+    ) -> ExecutionResult: ...
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        """Resume an execution paused on input().
+
+        `handle` is the opaque token from a prior AWAITING_INPUT result. The
+        call is DB-free: the engine owns all `Execution` persistence and maps
+        the returned `ExecutionResult` to lifecycle state.
+
+        NOTE: a future durable/replay executor (issue #79) will additionally
+        need the execution *context* (original input_data + accumulated resume
+        history) to replay deterministically; that param can be added to this
+        Protocol when that impl lands. Today's live executors only need the
+        handle.
+        """
+        ...
 
 
 @runtime_checkable
 class TrustedExecutor(Protocol):
-    """Runs admin-approved function code (`Function.shared_pool=True`).
+    """Runs admin-approved code (`Function.shared_pool=True`).
 
     No per-execution isolation requirement. Implementations may run code
     in-process, in a shared long-lived container, or any other shape that
@@ -76,4 +163,13 @@ class TrustedExecutor(Protocol):
         chat_id: str | None,
         db: AsyncSession,
         timeout: int,
-    ) -> dict[str, Any]: ...
+    ) -> ExecutionResult: ...
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult: ...

--- a/backend/app/services/executor/docker_ephemeral_sandbox.py
+++ b/backend/app/services/executor/docker_ephemeral_sandbox.py
@@ -1,0 +1,243 @@
+"""SandboxExecutor: one ephemeral container per execution, baked package image.
+
+See ADR 2026-06-17-ephemeral-sandbox-baked-image.md. Untrusted code runs in a
+fresh container created from the pre-baked sandbox image, used exactly once,
+then removed. No pool, no reuse — so no cross-execution leak and none of the
+pool / discovery / replenish machinery.
+
+The container hardening and in-container IPC mirror `container_pool` exactly
+(same `container_executor` sandbox mode, same request/trigger/result-file
+protocol); only the lifecycle differs (create + run + remove instead of
+acquire/release). Docker SDK calls are blocking, so they run via
+`asyncio.to_thread`; the SDK is imported lazily.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import socket as _socket_mod
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.services.executor.base import ExecutionResult
+
+logger = logging.getLogger(__name__)
+
+
+class DockerEphemeralSandboxExecutor:
+    """Per-execution ephemeral Docker sandbox. Implements SandboxExecutor."""
+
+    def __init__(self) -> None:
+        self._network_ready = False
+
+    def _ensure_network(self, client) -> str:
+        import docker
+
+        name = settings.sandbox_network
+        if self._network_ready:
+            return name
+        try:
+            client.networks.get(name)
+        except docker.errors.NotFound:
+            client.networks.create(name, driver="bridge", labels={"sinas.type": "sandbox"})
+        self._network_ready = True
+        return name
+
+    def _run_config(self, image: str, name: str, network: str) -> dict[str, Any]:
+        # Mirrors container_pool._do_create_container hardening, minus the
+        # unless-stopped restart policy (this container is single-use).
+        return {
+            "image": image,
+            "name": name,
+            "detach": True,
+            "network": network,
+            "mem_limit": f"{settings.max_function_memory}m",
+            "nano_cpus": int(settings.max_function_cpu * 1_000_000_000),
+            "cap_drop": ["ALL"],
+            "cap_add": ["CHOWN", "SETUID", "SETGID"],
+            "security_opt": ["no-new-privileges:true"],
+            "pids_limit": 256,
+            "extra_hosts": {"host.docker.internal": "host-gateway"},
+            "tmpfs": {"/tmp": "size=100m,mode=1777"},
+            "environment": {
+                "PYTHONUNBUFFERED": "1",
+                "SANDBOX_CONTAINER": "true",
+                "SINAS_CONTAINER_MODE": "sandbox",
+            },
+            "labels": {"sinas.type": "sandbox-executor", "sinas.ephemeral": "true"},
+        }
+
+    def _create_container(self, client, config: dict[str, Any]):
+        # Remove a stale container squatting on this name (e.g. a crashed prior
+        # run of the same execution_id), then create. Apply the storage limit,
+        # falling back if the storage driver doesn't support storage-opt.
+        import docker
+
+        try:
+            stale = client.containers.get(config["name"])
+            stale.remove(force=True)
+        except docker.errors.NotFound:
+            pass
+        try:
+            return client.containers.run(
+                **config, storage_opt={"size": settings.max_function_storage}
+            )
+        except Exception as e:
+            if "storage-opt" in str(e).lower() or "storage driver" in str(e).lower():
+                return client.containers.run(**config)
+            raise
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> ExecutionResult:
+        import docker
+
+        from app.models.function import Function
+        from app.services.sandbox_image import current_sandbox_image
+
+        result = await db.execute(
+            select(Function).where(
+                Function.namespace == function_namespace,
+                Function.name == function_name,
+                Function.is_active == True,
+            )
+        )
+        function = result.scalar_one_or_none()
+        if not function:
+            return ExecutionResult.failed(
+                f"Function {function_namespace}/{function_name} not found"
+            )
+
+        image = await current_sandbox_image(db)
+        client = await asyncio.to_thread(docker.from_env)
+        network = await asyncio.to_thread(self._ensure_network, client)
+        name = f"sinas-sbx-{execution_id}"
+        effective_timeout = timeout or settings.function_timeout
+
+        config = self._run_config(image, name, network)
+        container = await asyncio.to_thread(self._create_container, client, config)
+        try:
+            # Daemon warmup — match the pool's post-create settle.
+            await asyncio.sleep(1)
+
+            payload = {
+                "action": "execute_inline",
+                "function_code": function.code,
+                "execution_id": execution_id,
+                "function_namespace": function_namespace,
+                "function_name": function_name,
+                "timeout": effective_timeout,
+                "input_data": input_data,
+                "context": {
+                    "user_id": user_id,
+                    "user_email": user_email,
+                    "access_token": access_token,
+                    "execution_id": execution_id,
+                    "trigger_type": trigger_type,
+                    "chat_id": chat_id,
+                },
+            }
+            eid = execution_id
+            request_path = f"/tmp/exec_request_{eid}.json"
+            trigger_file = f"/tmp/exec_trigger_{eid}"
+            result_file = f"/tmp/exec_result_{eid}.json"
+
+            # Write the request via a stdin pipe (put_archive writes the overlay
+            # layer, which is invisible under the tmpfs /tmp mount).
+            payload_bytes = json.dumps(payload).encode("utf-8")
+            api = container.client.api
+            exec_id = await asyncio.to_thread(
+                lambda: api.exec_create(
+                    container.id,
+                    [
+                        "python3",
+                        "-c",
+                        f'import sys; open("{request_path}","wb").write(sys.stdin.buffer.read())',
+                    ],
+                    stdin=True,
+                    stdout=True,
+                    stderr=True,
+                )["Id"]
+            )
+
+            def _pipe_request() -> None:
+                sock = api.exec_start(exec_id, socket=True)
+                sock._sock.sendall(payload_bytes)
+                sock._sock.shutdown(_socket_mod.SHUT_WR)
+                sock.read()
+                sock.close()
+
+            await asyncio.to_thread(_pipe_request)
+
+            exec_result = await asyncio.to_thread(
+                container.exec_run,
+                cmd=[
+                    "python3",
+                    "-c",
+                    f"""
+import sys, json, time, os
+with open("{trigger_file}", "w") as f:
+    f.write("1")
+max_wait = {effective_timeout}
+start = time.time()
+while time.time() - start < max_wait:
+    try:
+        with open("{result_file}", "r") as f:
+            result = json.load(f)
+            print(json.dumps(result))
+            sys.exit(0)
+    except FileNotFoundError:
+        time.sleep(0.1)
+        continue
+print(json.dumps({{"error": "Execution timeout after {effective_timeout}s", "status": "failed"}}))
+sys.exit(1)
+""",
+                ],
+                demux=True,
+            )
+
+            stdout, stderr = exec_result.output
+            stdout_str = stdout.decode() if stdout else ""
+            if exec_result.exit_code != 0:
+                stderr_str = stderr.decode() if stderr else ""
+                return ExecutionResult.failed(
+                    stderr_str or stdout_str or f"Exit code {exec_result.exit_code}"
+                )
+            return ExecutionResult.from_wire(json.loads(stdout_str))
+        finally:
+            try:
+                await asyncio.to_thread(container.remove, force=True)
+            except Exception as e:
+                logger.warning("Failed to remove ephemeral sandbox %s: %s", name, e)
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        # Sandbox mode disables input() (it raises), and an ephemeral container
+        # is gone after its single run — there is nothing to resume into. This
+        # satisfies the Protocol; durable HITL is tracked in issue #79.
+        return ExecutionResult.failed(
+            "Ephemeral sandbox does not support resume (input() is disabled in sandbox mode)."
+        )

--- a/backend/app/services/executor/docker_ephemeral_sandbox.py
+++ b/backend/app/services/executor/docker_ephemeral_sandbox.py
@@ -30,67 +30,12 @@ logger = logging.getLogger(__name__)
 
 
 class DockerEphemeralSandboxExecutor:
-    """Per-execution ephemeral Docker sandbox. Implements SandboxExecutor."""
+    """Per-execution ephemeral Docker sandbox. Implements SandboxExecutor.
 
-    def __init__(self) -> None:
-        self._network_ready = False
-
-    def _ensure_network(self, client) -> str:
-        import docker
-
-        name = settings.sandbox_network
-        if self._network_ready:
-            return name
-        try:
-            client.networks.get(name)
-        except docker.errors.NotFound:
-            client.networks.create(name, driver="bridge", labels={"sinas.type": "sandbox"})
-        self._network_ready = True
-        return name
-
-    def _run_config(self, image: str, name: str, network: str) -> dict[str, Any]:
-        # Mirrors container_pool._do_create_container hardening, minus the
-        # unless-stopped restart policy (this container is single-use).
-        return {
-            "image": image,
-            "name": name,
-            "detach": True,
-            "network": network,
-            "mem_limit": f"{settings.max_function_memory}m",
-            "nano_cpus": int(settings.max_function_cpu * 1_000_000_000),
-            "cap_drop": ["ALL"],
-            "cap_add": ["CHOWN", "SETUID", "SETGID"],
-            "security_opt": ["no-new-privileges:true"],
-            "pids_limit": 256,
-            "extra_hosts": {"host.docker.internal": "host-gateway"},
-            "tmpfs": {"/tmp": "size=100m,mode=1777"},
-            "environment": {
-                "PYTHONUNBUFFERED": "1",
-                "SANDBOX_CONTAINER": "true",
-                "SINAS_CONTAINER_MODE": "sandbox",
-            },
-            "labels": {"sinas.type": "sandbox-executor", "sinas.ephemeral": "true"},
-        }
-
-    def _create_container(self, client, config: dict[str, Any]):
-        # Remove a stale container squatting on this name (e.g. a crashed prior
-        # run of the same execution_id), then create. Apply the storage limit,
-        # falling back if the storage driver doesn't support storage-opt.
-        import docker
-
-        try:
-            stale = client.containers.get(config["name"])
-            stale.remove(force=True)
-        except docker.errors.NotFound:
-            pass
-        try:
-            return client.containers.run(
-                **config, storage_opt={"size": settings.max_function_storage}
-            )
-        except Exception as e:
-            if "storage-opt" in str(e).lower() or "storage driver" in str(e).lower():
-                return client.containers.run(**config)
-            raise
+    Container lifecycle (resolve baked image + create + remove) lives in
+    `executor._ephemeral_runtime` and is shared with the agent codeExecution
+    path; this class supplies the function-execution IPC.
+    """
 
     async def execute(
         self,
@@ -107,10 +52,11 @@ class DockerEphemeralSandboxExecutor:
         db: AsyncSession,
         timeout: int,
     ) -> ExecutionResult:
-        import docker
-
         from app.models.function import Function
-        from app.services.sandbox_image import current_sandbox_image
+        from app.services.executor._ephemeral_runtime import (
+            create_ephemeral_container,
+            remove_ephemeral_container,
+        )
 
         result = await db.execute(
             select(Function).where(
@@ -125,18 +71,11 @@ class DockerEphemeralSandboxExecutor:
                 f"Function {function_namespace}/{function_name} not found"
             )
 
-        image = await current_sandbox_image(db)
-        client = await asyncio.to_thread(docker.from_env)
-        network = await asyncio.to_thread(self._ensure_network, client)
-        name = f"sinas-sbx-{execution_id}"
         effective_timeout = timeout or settings.function_timeout
-
-        config = self._run_config(image, name, network)
-        container = await asyncio.to_thread(self._create_container, client, config)
+        client, container, name = await create_ephemeral_container(
+            db, execution_id=execution_id
+        )
         try:
-            # Daemon warmup — match the pool's post-create settle.
-            await asyncio.sleep(1)
-
             payload = {
                 "action": "execute_inline",
                 "function_code": function.code,
@@ -222,10 +161,7 @@ sys.exit(1)
                 )
             return ExecutionResult.from_wire(json.loads(stdout_str))
         finally:
-            try:
-                await asyncio.to_thread(container.remove, force=True)
-            except Exception as e:
-                logger.warning("Failed to remove ephemeral sandbox %s: %s", name, e)
+            await remove_ephemeral_container(container, name)
 
     async def resume(
         self,

--- a/backend/app/services/executor/docker_pool_sandbox.py
+++ b/backend/app/services/executor/docker_pool_sandbox.py
@@ -1,0 +1,54 @@
+"""SandboxExecutor backed by the legacy `container_pool`.
+
+Thin adapter. Delegates straight to the existing `container_pool`
+singleton. No behavior change — exists so the executor abstraction has
+a working default while we land the rest of the refactor.
+
+This impl will be replaced by `DockerEphemeralSandboxExecutor` in step 3
+of the migration, when we drop the long-lived pool in favor of
+`docker run --rm` per execution.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class DockerPoolSandboxExecutor:
+    """Adapts `app.services.container_pool.container_pool` to `SandboxExecutor`."""
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> dict[str, Any]:
+        # Imported lazily so `from app.services.executor import ...` does
+        # not pull the Docker SDK into modules that only need the
+        # Protocol types.
+        from app.services.container_pool import container_pool
+
+        return await container_pool.execute_function(
+            user_id=user_id,
+            user_email=user_email,
+            access_token=access_token,
+            function_namespace=function_namespace,
+            function_name=function_name,
+            input_data=input_data,
+            execution_id=execution_id,
+            trigger_type=trigger_type,
+            chat_id=chat_id,
+            db=db,
+            timeout=timeout,
+        )

--- a/backend/app/services/executor/docker_pool_sandbox.py
+++ b/backend/app/services/executor/docker_pool_sandbox.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.executor.base import ExecutionResult
+
 
 class DockerPoolSandboxExecutor:
     """Adapts `app.services.container_pool.container_pool` to `SandboxExecutor`."""
@@ -33,22 +35,43 @@ class DockerPoolSandboxExecutor:
         chat_id: str | None,
         db: AsyncSession,
         timeout: int,
-    ) -> dict[str, Any]:
+    ) -> ExecutionResult:
         # Imported lazily so `from app.services.executor import ...` does
         # not pull the Docker SDK into modules that only need the
         # Protocol types.
         from app.services.container_pool import container_pool
 
-        return await container_pool.execute_function(
-            user_id=user_id,
-            user_email=user_email,
-            access_token=access_token,
-            function_namespace=function_namespace,
-            function_name=function_name,
-            input_data=input_data,
+        return ExecutionResult.from_wire(
+            await container_pool.execute_function(
+                user_id=user_id,
+                user_email=user_email,
+                access_token=access_token,
+                function_namespace=function_namespace,
+                function_name=function_name,
+                input_data=input_data,
+                execution_id=execution_id,
+                trigger_type=trigger_type,
+                chat_id=chat_id,
+                db=db,
+                timeout=timeout,
+            )
+        )
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        # Untrusted code can't actually reach input() (sandbox mode raises),
+        # so this is here to satisfy the Protocol; it works regardless.
+        from app.services.executor._docker_resume import docker_resume
+
+        return await docker_resume(
+            handle=handle,
+            resume_value=resume_value,
             execution_id=execution_id,
-            trigger_type=trigger_type,
-            chat_id=chat_id,
-            db=db,
             timeout=timeout,
         )

--- a/backend/app/services/executor/docker_shared_trusted.py
+++ b/backend/app/services/executor/docker_shared_trusted.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.executor.base import ExecutionResult
+
 
 class DockerSharedTrustedExecutor:
     """Adapts `app.services.shared_worker_manager.shared_worker_manager` to `TrustedExecutor`."""
@@ -32,21 +34,40 @@ class DockerSharedTrustedExecutor:
         chat_id: str | None,
         db: AsyncSession,
         timeout: int,
-    ) -> dict[str, Any]:
+    ) -> ExecutionResult:
         # Lazy import so the Docker SDK is not imported by callers that
         # only need the abstraction.
         from app.services.shared_worker_manager import shared_worker_manager
 
-        return await shared_worker_manager.execute_function(
-            user_id=user_id,
-            user_email=user_email,
-            access_token=access_token,
-            function_namespace=function_namespace,
-            function_name=function_name,
-            input_data=input_data,
+        return ExecutionResult.from_wire(
+            await shared_worker_manager.execute_function(
+                user_id=user_id,
+                user_email=user_email,
+                access_token=access_token,
+                function_namespace=function_namespace,
+                function_name=function_name,
+                input_data=input_data,
+                execution_id=execution_id,
+                trigger_type=trigger_type,
+                chat_id=chat_id,
+                db=db,
+                timeout=timeout,
+            )
+        )
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        from app.services.executor._docker_resume import docker_resume
+
+        return await docker_resume(
+            handle=handle,
+            resume_value=resume_value,
             execution_id=execution_id,
-            trigger_type=trigger_type,
-            chat_id=chat_id,
-            db=db,
             timeout=timeout,
         )

--- a/backend/app/services/executor/docker_shared_trusted.py
+++ b/backend/app/services/executor/docker_shared_trusted.py
@@ -1,0 +1,52 @@
+"""TrustedExecutor backed by the legacy `shared_worker_manager`.
+
+Thin adapter. Delegates straight to the existing `shared_worker_manager`
+singleton. No behavior change.
+
+This impl will be replaced by `InProcessTrustedExecutor` in step 4 of
+the migration, at which point the dedicated shared-worker containers
+are no longer needed for trusted code paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class DockerSharedTrustedExecutor:
+    """Adapts `app.services.shared_worker_manager.shared_worker_manager` to `TrustedExecutor`."""
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> dict[str, Any]:
+        # Lazy import so the Docker SDK is not imported by callers that
+        # only need the abstraction.
+        from app.services.shared_worker_manager import shared_worker_manager
+
+        return await shared_worker_manager.execute_function(
+            user_id=user_id,
+            user_email=user_email,
+            access_token=access_token,
+            function_namespace=function_namespace,
+            function_name=function_name,
+            input_data=input_data,
+            execution_id=execution_id,
+            trigger_type=trigger_type,
+            chat_id=chat_id,
+            db=db,
+            timeout=timeout,
+        )

--- a/backend/app/services/executor/factory.py
+++ b/backend/app/services/executor/factory.py
@@ -41,10 +41,9 @@ def get_sandbox_executor() -> SandboxExecutor | None:
         return DockerEphemeralSandboxExecutor()
 
     if mode == "k8s_pod":
-        raise NotImplementedError(
-            "sandbox_executor='k8s_pod' is planned for step 5 of the executor "
-            "refactor; not yet implemented."
-        )
+        from app.services.executor.k8s_pod_sandbox import K8sPodSandboxExecutor
+
+        return K8sPodSandboxExecutor()
 
     if mode == "disabled":
         return None
@@ -65,10 +64,9 @@ def get_trusted_executor() -> TrustedExecutor:
         return DockerSharedTrustedExecutor()
 
     if mode == "inprocess":
-        raise NotImplementedError(
-            "trusted_executor='inprocess' is planned for step 4 of the executor "
-            "refactor; not yet implemented."
-        )
+        from app.services.executor.inprocess_trusted import InProcessTrustedExecutor
+
+        return InProcessTrustedExecutor()
 
     raise ValueError(f"Unknown trusted_executor mode: {mode!r}")
 

--- a/backend/app/services/executor/factory.py
+++ b/backend/app/services/executor/factory.py
@@ -1,0 +1,78 @@
+"""Executor factory.
+
+Returns the configured `SandboxExecutor` / `TrustedExecutor` impl based
+on `settings.sandbox_executor` / `settings.trusted_executor`.
+
+A small cache keeps a single instance of each impl per process. The
+existing legacy classes (`container_pool`, `shared_worker_manager`) are
+themselves module-level singletons; the adapter wrappers are stateless,
+so caching is just to avoid the trivial allocation.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.core.config import settings
+from app.services.executor.base import SandboxExecutor, TrustedExecutor
+
+
+@lru_cache(maxsize=1)
+def get_sandbox_executor() -> SandboxExecutor | None:
+    """Return the configured sandbox executor, or None when disabled.
+
+    When `None` is returned, callers must reject any request that would
+    route to the sandbox (untrusted Function + agent codeExecution).
+    """
+    mode = settings.sandbox_executor
+
+    if mode == "docker_pool":
+        from app.services.executor.docker_pool_sandbox import (
+            DockerPoolSandboxExecutor,
+        )
+
+        return DockerPoolSandboxExecutor()
+
+    if mode == "docker_ephemeral":
+        raise NotImplementedError(
+            "sandbox_executor='docker_ephemeral' is planned for step 3 of the "
+            "executor refactor; not yet implemented."
+        )
+
+    if mode == "k8s_pod":
+        raise NotImplementedError(
+            "sandbox_executor='k8s_pod' is planned for step 5 of the executor "
+            "refactor; not yet implemented."
+        )
+
+    if mode == "disabled":
+        return None
+
+    raise ValueError(f"Unknown sandbox_executor mode: {mode!r}")
+
+
+@lru_cache(maxsize=1)
+def get_trusted_executor() -> TrustedExecutor:
+    """Return the configured trusted executor."""
+    mode = settings.trusted_executor
+
+    if mode == "docker_shared":
+        from app.services.executor.docker_shared_trusted import (
+            DockerSharedTrustedExecutor,
+        )
+
+        return DockerSharedTrustedExecutor()
+
+    if mode == "inprocess":
+        raise NotImplementedError(
+            "trusted_executor='inprocess' is planned for step 4 of the executor "
+            "refactor; not yet implemented."
+        )
+
+    raise ValueError(f"Unknown trusted_executor mode: {mode!r}")
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the factory's LRU caches. Used by tests that override settings."""
+    get_sandbox_executor.cache_clear()
+    get_trusted_executor.cache_clear()

--- a/backend/app/services/executor/factory.py
+++ b/backend/app/services/executor/factory.py
@@ -34,10 +34,11 @@ def get_sandbox_executor() -> SandboxExecutor | None:
         return DockerPoolSandboxExecutor()
 
     if mode == "docker_ephemeral":
-        raise NotImplementedError(
-            "sandbox_executor='docker_ephemeral' is planned for step 3 of the "
-            "executor refactor; not yet implemented."
+        from app.services.executor.docker_ephemeral_sandbox import (
+            DockerEphemeralSandboxExecutor,
         )
+
+        return DockerEphemeralSandboxExecutor()
 
     if mode == "k8s_pod":
         raise NotImplementedError(

--- a/backend/app/services/executor/inprocess_trusted.py
+++ b/backend/app/services/executor/inprocess_trusted.py
@@ -1,0 +1,218 @@
+"""TrustedExecutor that runs admin-approved code in the calling process.
+
+Step 4 of the executor refactor: with `trusted_executor="inprocess"` (and
+`sandbox_executor` set to a non-Docker backend or "disabled"), no process in
+the deployment needs a Docker socket — this is what enables single-container
+and k8s deployments.
+
+Contract parity with the in-container executor's shared mode
+(`container_executor._execute_inline_shared`): code is compiled and exec'd
+into a bare namespace (json/datetime/uuid pre-imported), the entry point is
+`handler(input_data, context)` (legacy fallback: a callable named after the
+function), and the timeout is enforced by raising an async exception into the
+worker thread.
+
+Deliberate differences:
+- `input()` raises immediately — pause/resume HITL is not available on this
+  executor (durable HITL is issue #79); `resume()` always fails.
+- The code shares the worker process's environment and credentials. Routing
+  here carries the same trust decision an admin makes for `shared_pool=True`
+  today, minus the container boundary — deployments that require credential
+  isolation from trusted code (e.g. metered managed hosts) must keep a
+  container/pod-backed trusted executor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import datetime
+import json
+import logging
+import threading
+import time
+import traceback as tb_module
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.services.executor.base import ExecutionResult
+
+logger = logging.getLogger(__name__)
+
+
+class _FunctionTimeout(Exception):
+    pass
+
+
+def _no_input(prompt: str = "") -> str:
+    raise RuntimeError(
+        "input() is not available on the inprocess trusted executor "
+        "(pause/resume requires a container-backed executor; see issue #79)."
+    )
+
+
+def _raise_in_thread(thread_id: int, exc_type: type) -> None:
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_long(thread_id), ctypes.py_object(exc_type)
+    )
+
+
+def _run_handler(
+    *,
+    function_code: str,
+    function_namespace: str,
+    function_name: str,
+    input_data: dict[str, Any],
+    context: dict[str, Any],
+    timeout: int,
+) -> ExecutionResult:
+    """Blocking: compile, locate the entry point, and run it in a watched thread.
+
+    Runs inside `asyncio.to_thread`, so blocking on join() here holds one
+    executor-pool thread for the duration — the same occupancy the docker
+    exec round-trip had.
+    """
+    namespace: dict[str, Any] = {
+        "__builtins__": __builtins__,
+        "json": json,
+        "datetime": datetime,
+        "uuid": uuid,
+        "input": _no_input,
+    }
+
+    try:
+        compiled = compile(
+            function_code,
+            f"<function:{function_namespace}/{function_name}>",
+            "exec",
+        )
+        exec(compiled, namespace)
+    except Exception as e:
+        return ExecutionResult.failed(
+            f"Failed to load function code: {e}", tb_module.format_exc()
+        )
+
+    if "handler" in namespace and callable(namespace["handler"]):
+        func = namespace["handler"]
+    elif function_name in namespace and callable(namespace[function_name]):
+        func = namespace[function_name]
+        logger.warning(
+            "DEPRECATION: function %s/%s uses '%s' instead of 'handler'",
+            function_namespace, function_name, function_name,
+        )
+    else:
+        return ExecutionResult.failed(
+            f"No 'handler' function found in code for {function_namespace}/{function_name}"
+        )
+
+    outcome: dict[str, Any] = {}
+
+    def _target() -> None:
+        try:
+            outcome["result"] = func(input_data, context)
+        except _FunctionTimeout:
+            outcome["timeout"] = True
+        except Exception as e:
+            outcome["error"] = str(e)
+            outcome["traceback"] = tb_module.format_exc()
+
+    thread = threading.Thread(target=_target, daemon=True)
+    start = time.time()
+    thread.start()
+    timer = threading.Timer(
+        timeout, lambda: _raise_in_thread(thread.ident, _FunctionTimeout)
+    )
+    timer.daemon = True
+    timer.start()
+    thread.join(timeout=timeout + 5)
+    timer.cancel()
+    duration_ms = int((time.time() - start) * 1000)
+
+    if outcome.get("timeout") or thread.is_alive():
+        return ExecutionResult.failed(f"Function timed out after {timeout}s")
+    if "error" in outcome:
+        return ExecutionResult.failed(outcome["error"], outcome.get("traceback"))
+
+    result = outcome.get("result")
+    # The container path implicitly enforced JSON-serializable results (the
+    # result crossed a JSON wire); keep that contract.
+    try:
+        json.dumps(result)
+    except (TypeError, ValueError):
+        return ExecutionResult.failed(
+            f"Function returned a non-JSON-serializable result: {type(result).__name__}"
+        )
+    from app.services.executor.base import ResultStatus
+
+    return ExecutionResult(
+        ResultStatus.COMPLETED, result=result, duration_ms=duration_ms
+    )
+
+
+class InProcessTrustedExecutor:
+    """Runs `Function.shared_pool=True` code in this process. Implements TrustedExecutor."""
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> ExecutionResult:
+        from app.models.function import Function
+
+        result = await db.execute(
+            select(Function).where(
+                Function.namespace == function_namespace,
+                Function.name == function_name,
+                Function.is_active == True,
+            )
+        )
+        function = result.scalar_one_or_none()
+        if not function:
+            return ExecutionResult.failed(
+                f"Function {function_namespace}/{function_name} not found"
+            )
+
+        context = {
+            "user_id": user_id,
+            "user_email": user_email,
+            "access_token": access_token,
+            "execution_id": execution_id,
+            "trigger_type": trigger_type,
+            "chat_id": chat_id,
+        }
+        return await asyncio.to_thread(
+            _run_handler,
+            function_code=function.code,
+            function_namespace=function_namespace,
+            function_name=function_name,
+            input_data=input_data,
+            context=context,
+            timeout=timeout or settings.function_timeout,
+        )
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        return ExecutionResult.failed(
+            "The inprocess trusted executor does not support resume "
+            "(input()/HITL is unavailable; see issue #79)."
+        )

--- a/backend/app/services/executor/k8s_pod_sandbox.py
+++ b/backend/app/services/executor/k8s_pod_sandbox.py
@@ -1,0 +1,109 @@
+"""SandboxExecutor: one ephemeral Kubernetes Pod per execution.
+
+Step 5 of the executor refactor — the k8s-native sibling of
+`DockerEphemeralSandboxExecutor`. Untrusted code runs in a fresh hardened Pod
+created from the executor image, used exactly once, then deleted. Pod
+lifecycle and exec IPC live in `executor._k8s_runtime` and are shared with the
+agent codeExecution path; this class supplies the function-execution payload.
+
+Requires in-cluster ServiceAccount permissions: create/get/delete + exec on
+pods in the sandbox namespace (the Helm chart ships the Role/RoleBinding).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.services.executor.base import ExecutionResult
+
+logger = logging.getLogger(__name__)
+
+
+class K8sPodSandboxExecutor:
+    """Per-execution ephemeral k8s Pod. Implements SandboxExecutor."""
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> ExecutionResult:
+        from app.models.function import Function
+        from app.services.executor._k8s_runtime import (
+            create_sandbox_pod,
+            delete_sandbox_pod,
+            run_payload_in_pod,
+        )
+
+        result = await db.execute(
+            select(Function).where(
+                Function.namespace == function_namespace,
+                Function.name == function_name,
+                Function.is_active == True,
+            )
+        )
+        function = result.scalar_one_or_none()
+        if not function:
+            return ExecutionResult.failed(
+                f"Function {function_namespace}/{function_name} not found"
+            )
+
+        effective_timeout = timeout or settings.function_timeout
+        payload = {
+            "action": "execute_inline",
+            "function_code": function.code,
+            "execution_id": execution_id,
+            "function_namespace": function_namespace,
+            "function_name": function_name,
+            "timeout": effective_timeout,
+            "input_data": input_data,
+            "context": {
+                "user_id": user_id,
+                "user_email": user_email,
+                "access_token": access_token,
+                "execution_id": execution_id,
+                "trigger_type": trigger_type,
+                "chat_id": chat_id,
+            },
+        }
+
+        name, namespace = await create_sandbox_pod(db, execution_id=execution_id)
+        try:
+            wire = await run_payload_in_pod(
+                name, namespace, payload, effective_timeout
+            )
+            return ExecutionResult.from_wire(wire)
+        except Exception as e:
+            logger.error("k8s sandbox execution %s failed: %s", execution_id, e)
+            return ExecutionResult.failed(str(e))
+        finally:
+            await delete_sandbox_pod(name, namespace)
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        # Sandbox mode disables input() (it raises), and the pod is deleted
+        # after its single run — nothing to resume into. Durable HITL for
+        # sandboxed code is issue #79.
+        return ExecutionResult.failed(
+            "k8s pod sandbox does not support resume (input() is disabled in sandbox mode)."
+        )

--- a/backend/app/services/sandbox_image.py
+++ b/backend/app/services/sandbox_image.py
@@ -1,0 +1,177 @@
+"""Baked sandbox image: build & resolve the image untrusted code runs in.
+
+See ADR 2026-06-17-ephemeral-sandbox-baked-image.md.
+
+The image tag is a pure function of `hash(base_image + sorted dependency specs)`,
+derivable from the `Dependency` table (the source of truth). Redis caches the
+currently-built tag and holds a build lock; it is a cache, not authoritative
+state — on a miss any process recomputes the tag from the deps and rebuilds.
+
+Docker SDK calls are blocking, so they run via `asyncio.to_thread`. The SDK is
+imported lazily so this module is importable in socket-free contexts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import logging
+import shlex
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.redis import get_redis
+from app.models.dependency import Dependency
+
+logger = logging.getLogger(__name__)
+
+REDIS_TAG_KEY = "sinas:sandbox:image_tag"  # current built+ready tag
+REDIS_BUILD_LOCK = "sinas:sandbox:build_lock"  # build mutex
+_IMAGE_REPO = "sinas-sandbox"
+_BUILD_LOCK_TTL = 600  # seconds; an upper bound on a single image build
+_BUILD_WAIT_TIMEOUT = 600  # how long a non-builder waits for the builder
+
+
+def _pip_specs(deps: list[Dependency]) -> list[str]:
+    """Render Dependency rows to sorted pip requirement strings.
+
+    Mirrors the spec logic in `container_pool._install_packages` so the baked
+    image installs exactly what the pool would have installed.
+    """
+    specs: list[str] = []
+    for pkg in deps:
+        version = pkg.version
+        if version:
+            if any(version.startswith(op) for op in (">=", "<=", "~=", "!=", ">", "<")):
+                specs.append(f"{pkg.package_name}{version}")
+            else:
+                specs.append(f"{pkg.package_name}=={version}")
+        else:
+            specs.append(pkg.package_name)
+    return sorted(specs)
+
+
+async def _dependency_specs(db: AsyncSession) -> list[str]:
+    result = await db.execute(select(Dependency))
+    return _pip_specs(list(result.scalars().all()))
+
+
+def _tag_for(base_image: str, specs: list[str]) -> str:
+    """Deterministic tag from the base image + the (sorted) dependency set."""
+    h = hashlib.sha256()
+    h.update(base_image.encode())
+    h.update(b"\x00")
+    h.update("\n".join(specs).encode())
+    return f"{_IMAGE_REPO}:{h.hexdigest()[:16]}"
+
+
+def _render_dockerfile(base_image: str, specs: list[str]) -> bytes:
+    lines = [f"FROM {base_image}"]
+    if specs:
+        joined = " ".join(shlex.quote(s) for s in specs)
+        lines.append(f"RUN pip install --no-cache-dir {joined}")
+    return ("\n".join(lines) + "\n").encode()
+
+
+async def desired_tag(db: AsyncSession) -> str:
+    """The tag the current dependency set *should* resolve to (built or not)."""
+    return _tag_for(settings.function_container_image, await _dependency_specs(db))
+
+
+async def current_sandbox_image(db: AsyncSession) -> str:
+    """Tag of a ready-to-run baked sandbox image.
+
+    Self-correcting: compares the cached tag against the tag the *current*
+    dependency set should resolve to, and rebuilds on a miss or mismatch. This
+    means correctness does not depend on every dependency-mutation site
+    remembering to trigger a rebuild — a changed dependency set is detected here.
+    Normally the cache is warm (built proactively on dependency change), so this
+    is a cheap Redis GET + one indexed query on the hot path.
+    """
+    desired = await desired_tag(db)
+    redis = await get_redis()
+    cached = await redis.get(REDIS_TAG_KEY)
+    if cached == desired:
+        return cached
+    # Cold cache or the dependency set changed since the last build. Build the
+    # image for the current deps (idempotent: build_sandbox_image skips the
+    # build if the image already exists and just repoints the cache).
+    logger.info("Sandbox image not current (cached=%s desired=%s) — building", cached, desired)
+    return await build_sandbox_image(db)
+
+
+def _image_exists(client, tag: str) -> bool:
+    import docker
+
+    try:
+        client.images.get(tag)
+        return True
+    except docker.errors.ImageNotFound:
+        return False
+
+
+def _build_image(client, tag: str, base_image: str, specs: list[str]) -> None:
+    dockerfile = _render_dockerfile(base_image, specs)
+    logger.info("Building sandbox image %s (%d packages)", tag, len(specs))
+    client.images.build(fileobj=io.BytesIO(dockerfile), tag=tag, pull=False, rm=True)
+
+
+def _prune_old_images(client, keep_tag: str) -> None:
+    """Best-effort removal of superseded sinas-sandbox images."""
+    try:
+        for img in client.images.list(name=_IMAGE_REPO):
+            for t in list(img.tags):
+                if t.startswith(f"{_IMAGE_REPO}:") and t != keep_tag:
+                    try:
+                        client.images.remove(t, force=False, noprune=False)
+                    except Exception as e:  # in-use or shared layer — leave it
+                        logger.debug("Skip pruning %s: %s", t, e)
+    except Exception as e:
+        logger.debug("Image prune skipped: %s", e)
+
+
+async def build_sandbox_image(db: AsyncSession) -> str:
+    """Ensure the baked image for the current dependency set exists, then point
+    the Redis cache at it. Idempotent and concurrency-safe via a Redis lock.
+    Returns the tag.
+    """
+    import docker
+
+    base_image = settings.function_container_image
+    specs = await _dependency_specs(db)
+    tag = _tag_for(base_image, specs)
+    redis = await get_redis()
+    client = await asyncio.to_thread(docker.from_env)
+
+    # Already built? Just (re)point the cache and return.
+    if await asyncio.to_thread(_image_exists, client, tag):
+        await redis.set(REDIS_TAG_KEY, tag)
+        return tag
+
+    got_lock = await redis.set(REDIS_BUILD_LOCK, tag, nx=True, ex=_BUILD_LOCK_TTL)
+    if not got_lock:
+        # Another process is building. Wait for the image to appear; fall back
+        # to building ourselves (idempotent by tag) if it never does.
+        waited = 0.0
+        while waited < _BUILD_WAIT_TIMEOUT:
+            if await asyncio.to_thread(_image_exists, client, tag):
+                await redis.set(REDIS_TAG_KEY, tag)
+                return tag
+            await asyncio.sleep(1.0)
+            waited += 1.0
+        logger.warning("Build lock holder did not finish in %ss; building anyway", _BUILD_WAIT_TIMEOUT)
+
+    try:
+        if not await asyncio.to_thread(_image_exists, client, tag):
+            await asyncio.to_thread(_build_image, client, tag, base_image, specs)
+        # Atomic flip: only point the cache once the image is present.
+        await redis.set(REDIS_TAG_KEY, tag)
+        await asyncio.to_thread(_prune_old_images, client, tag)
+        logger.info("Sandbox image ready: %s", tag)
+        return tag
+    finally:
+        if got_lock:
+            await redis.delete(REDIS_BUILD_LOCK)

--- a/backend/app/services/shared_worker_manager.py
+++ b/backend/app/services/shared_worker_manager.py
@@ -26,13 +26,34 @@ class SharedWorkerManager:
     """
 
     def __init__(self):
-        self.client = docker.from_env()
+        # Docker client and networks are resolved lazily so this module can be
+        # imported (and the singleton constructed) in socket-free deployments
+        # (trusted_executor != "docker_shared", e.g. k8s or single-container).
+        self._client = None
         self.workers: dict[str, dict[str, Any]] = {}  # worker_id -> worker_info
         self.next_worker_index = 0  # For round-robin load balancing
         self._lock = asyncio.Lock()
         self._initialized = False
-        self.docker_network = self._detect_network()
-        self.sandbox_network = self._ensure_sandbox_network()
+        self._docker_network: Optional[str] = None
+        self._sandbox_network: Optional[str] = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = docker.from_env()
+        return self._client
+
+    @property
+    def docker_network(self) -> str:
+        if self._docker_network is None:
+            self._docker_network = self._detect_network()
+        return self._docker_network
+
+    @property
+    def sandbox_network(self) -> str:
+        if self._sandbox_network is None:
+            self._sandbox_network = self._ensure_sandbox_network()
+        return self._sandbox_network
 
     def _detect_network(self) -> str:
         """Auto-detect Docker network if set to 'auto', otherwise use configured value."""

--- a/backend/docs/adrs/2026-06-17-ephemeral-sandbox-baked-image.md
+++ b/backend/docs/adrs/2026-06-17-ephemeral-sandbox-baked-image.md
@@ -1,0 +1,154 @@
+# ADR: Ephemeral sandbox execution with a baked package image
+
+- **Status:** Proposed
+- **Date:** 2026-06-17
+- **Authors:** Kjeld Oostra
+- **Related code:**
+  - `app/services/container_pool.py` (the pool being replaced for the sandbox role)
+  - `app/services/executor/` (the seam this plugs into — see the 3a contract)
+  - `app/services/execution_engine.py` (routes untrusted execution to the sandbox executor)
+  - `app/services/code_execution.py` (agent `codeExecution`, currently bypasses the seam)
+  - `app/models/dependency.py` (the approved-package source of truth)
+  - `app/api/v1/endpoints/dependencies.py`, `app/services/config_apply/resources.py` (dependency mutation points)
+  - `app/api/v1/endpoints/containers.py`, `app/api/v1/endpoints/workers.py` (reload triggers)
+  - `Dockerfile.executor` (the sandbox base image)
+
+## Context
+
+Untrusted function code and agent `codeExecution` run in a **warm pool of reusable
+sandbox containers** (`container_pool`). Two problems with the pool, on what is and
+will remain the **primary deployment (docker-compose)**:
+
+1. **Container-reuse leak.** A pooled container is reused across up to
+   `sandbox_max_executions` (100) executions. Its `/tmp`, `site-packages`, env, and
+   process globals persist between runs. For untrusted, multi-tenant code this is a
+   cross-execution (potentially cross-user) contamination vector. Only the `tainted`
+   path discards a container; successful runs hand the same container to the next caller.
+
+2. **Pool fragility.** Pool state is in-memory **per process**. Only the `scheduler`
+   creates/replenishes containers (`scheduler/service.py` → `container_pool.initialize`);
+   consumers (backend, queue-worker, queue-agent) only `_discover_existing_containers()`
+   **once at startup**. If a consumer starts before the scheduler fills the pool, it
+   latches at `idle=0, in_use=0` and every execution fails with
+   *"No sandbox container available within 30s"*. (This is a recurring production incident.)
+
+Packages are **dynamic**: `Dependency` rows (admin-approved pip packages) are
+`pip install`-ed into each container at creation by `container_pool._install_packages`.
+The pool largely exists to amortize this install cost.
+
+## Decision
+
+Replace the warm reuse pool **for the sandbox (untrusted) role** with **single-use
+ephemeral containers backed by a pre-baked package image**:
+
+1. **Bake packages into a sandbox image.** When the `Dependency` set changes, build an
+   image `FROM` the executor base (`function_container_image`) that `pip install`s the
+   approved set (and, later, any system/apt deps). Tag it by a **content hash** of the
+   dependency set. Building is idempotent — if the tag already exists, skip.
+
+2. **One container per execution.** Untrusted execution does `docker run --rm` of the
+   current baked image, runs the function (unchanged in-container executor, sandbox
+   mode), and tears the container down. No pool, no reuse.
+   - **Leak fixed:** each execution gets a fresh container; copy-on-write means
+     `site-packages` self-writes (nltk data, caches) land in *that* container's writable
+     layer and die with it — isolated, no leak, and self-writing packages still work.
+   - **Bug class deleted:** no shared pool ⇒ no scheduler-owns-pool, no startup
+     discovery race, no replenish loop, no `idle=0` incidents.
+
+3. **Cross-process coordination via Redis (cache, not source of truth).** The tag is a
+   pure function of `hash(base_image + sorted dependency specs)` — derivable from the
+   `Dependency` table, which is the real source of truth. Redis caches the
+   currently-built tag (`sinas:sandbox:image_tag`) and holds a build lock
+   (`sinas:sandbox:build_lock`) to avoid concurrent identical builds. On a Redis miss any
+   process recomputes the tag from the deps and (re)builds — so no durability is required
+   and **no new Postgres table is added**. Workers read the cached tag at execution time
+   and run that image against the shared local daemon. No in-memory pool state to drift.
+
+4. **Opt-in.** Wire as `sandbox_executor="docker_ephemeral"` (the factory branch that
+   currently raises `NotImplementedError`). `docker_pool` stays the default until
+   ephemeral is proven on a real compose stack; flipping the default is a later step.
+
+5. **Route agent `codeExecution` through the seam.** `code_execution.py` currently calls
+   `container_pool.acquire()` directly, bypassing the executor abstraction. Route it
+   through `get_sandbox_executor()` so it benefits from ephemeral (and respects
+   `sandbox_executor="disabled"`).
+
+## Interface sketch
+
+```python
+# app/services/sandbox_image.py  (new)
+def dependency_set_hash(deps) -> str: ...          # stable hash of sorted name==version
+async def current_sandbox_image(db) -> str: ...     # read DB pointer (or compute+build)
+async def build_sandbox_image(db) -> str:           # generate Dockerfile, docker build,
+    """FROM {base}; (apt deps later); RUN pip install <deps>.
+    Tag sinas-sandbox:<hash>. Update DB pointer atomically only on success.
+    Keep serving the old tag if the build fails. GC superseded tags."""
+
+# app/services/executor/docker_ephemeral_sandbox.py  (new) — SandboxExecutor
+class DockerEphemeralSandboxExecutor:
+    async def execute(self, *, ...timeout) -> ExecutionResult:
+        image = await current_sandbox_image(db)
+        # docker run --rm <image> with the SAME hardening as the pool:
+        #   cap_drop ALL, no-new-privileges, pids_limit, mem/cpu limits,
+        #   tmpfs /tmp, sandbox network, extra_hosts. Single use.
+        ...
+    async def resume(self, *, handle, resume_value, execution_id, timeout):
+        # Sandbox mode can't reach input() (raises), so this never fires in
+        # practice; satisfies the Protocol. (Durable HITL is issue #79.)
+        ...
+
+# factory.py: the docker_ephemeral branch returns DockerEphemeralSandboxExecutor()
+```
+
+**Build trigger** — hook the existing dependency-change paths:
+`dependencies.py` (add/remove), `config_apply/resources.py` (declarative), and the
+`reload_packages` endpoints (`containers.py`, `workers.py`) call `build_sandbox_image`
+instead of reinstalling into pool containers.
+
+## Impact
+
+| Component | Change |
+|---|---|
+| `executor/factory.py` | Implement `docker_ephemeral` branch |
+| `executor/docker_ephemeral_sandbox.py` *(new)* | The ephemeral SandboxExecutor |
+| `services/sandbox_image.py` *(new)* | Hash + build + DB tag pointer + GC |
+| `execution_engine.py` | **No change** — already routes via the SandboxExecutor seam (post-3a) |
+| `code_execution.py` | Route agent codeExecution through `get_sandbox_executor()` |
+| `dependencies.py` / `config_apply/resources.py` / reload endpoints | Trigger image build on dependency change |
+| `scheduler/service.py` | Sandbox-pool init becomes a no-op in ephemeral mode |
+| `container_pool.py` | Untouched; only used when `sandbox_executor="docker_pool"` |
+| `Dockerfile.executor` | Unchanged — stays the base the baked image `FROM`s |
+| Redis | Cache of the current built image tag + build lock. No new Postgres table — the tag derives from the `Dependency` set (the source of truth) |
+
+## Open questions
+
+- ~~**Tag pointer storage:**~~ **Resolved:** Redis cache + build lock; tag derived from
+  the `Dependency` set (no new Postgres table).
+- **Build timing:** synchronous on the admin dependency-change action (simple; admin
+  waits) vs. background with status. Lean **sync for MVP** (infrequent admin op).
+- **Concurrency cap:** bound concurrent ephemeral containers (semaphore, default
+  `sandbox_max_size`) vs. rely on worker `max_jobs`.
+- **Cold-start latency:** plain ephemeral pays container-create (~hundreds of ms) per
+  execution. Acceptable for MVP? An optional **single-use warm buffer** is an orthogonal
+  later optimization if a workload needs sub-100ms starts.
+
+## What we'd NOT do (first cut)
+
+- Not touch the trusted/shared executor (`shared_worker_manager`) — separate concern
+  (the `inprocess` trusted executor, step 4).
+- Not change the in-container executor or the execution wire format.
+- Not make ephemeral the default — opt-in until validated on compose.
+- Not build the single-use warm buffer.
+- Not support await-input under ephemeral (sandbox can't await; durable HITL is #79).
+- Not solve multi-host image distribution (registry push/pull) — compose is single-host.
+- Not add system/apt-dep support yet (the `Dependency` model is pip-only today; baking
+  leaves room for it later).
+
+## Next steps (if accepted)
+
+1. `sandbox_image.py`: dependency hash + `build_sandbox_image` + DB tag pointer + GC.
+2. `DockerEphemeralSandboxExecutor` + factory wiring.
+3. Build triggers on dependency mutation / `reload_packages`.
+4. Route `code_execution.py` through the sandbox seam.
+5. No-op sandbox-pool init in ephemeral mode.
+6. Opt-in setting + docs; validate on a compose stack; then consider flipping the default.

--- a/backend/docs/adrs/2026-06-17-ephemeral-sandbox-baked-image.md
+++ b/backend/docs/adrs/2026-06-17-ephemeral-sandbox-baked-image.md
@@ -1,6 +1,6 @@
 # ADR: Ephemeral sandbox execution with a baked package image
 
-- **Status:** Proposed
+- **Status:** Accepted (runtime-validated on compose 2026-07-13: warm image build, function execution, agent codeExecution, no leftover containers)
 - **Date:** 2026-06-17
 - **Authors:** Kjeld Oostra
 - **Related code:**

--- a/backend/docs/adrs/2026-06-17-ephemeral-sandbox-baked-image.md
+++ b/backend/docs/adrs/2026-06-17-ephemeral-sandbox-baked-image.md
@@ -146,9 +146,11 @@ instead of reinstalling into pool containers.
 
 ## Next steps (if accepted)
 
-1. `sandbox_image.py`: dependency hash + `build_sandbox_image` + DB tag pointer + GC.
-2. `DockerEphemeralSandboxExecutor` + factory wiring.
-3. Build triggers on dependency mutation / `reload_packages`.
-4. Route `code_execution.py` through the sandbox seam.
-5. No-op sandbox-pool init in ephemeral mode.
-6. Opt-in setting + docs; validate on a compose stack; then consider flipping the default.
+1. ✅ `sandbox_image.py`: dependency hash + `build_sandbox_image` + Redis tag cache/lock + GC + self-correcting resolver.
+2. ✅ `DockerEphemeralSandboxExecutor` + factory wiring.
+3. ✅ Build triggers (reload endpoint + scheduler warm-build); correctness is self-correcting regardless.
+4. ✅ Route `code_execution.py` (agent codeExecution) through a shared ephemeral lifecycle (`executor/_ephemeral_runtime.py`), used by both the function executor and the code path.
+5. ✅ No-op sandbox-pool init in ephemeral mode (scheduler).
+6. ⬜ Docs (the `SANDBOX_EXECUTOR` env var); **runtime validation on a compose stack** (the gate before flipping the default).
+
+Unit coverage: `tests/unit/test_executor_result.py` covers the `from_wire` wire→typed translation (the contract boundary). The container IPC paths require a live Docker daemon to exercise.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "Jinja2>=3.1.0",
     "aiosmtpd>=1.4.0",
     "docker>=7.0.0",
+    "kubernetes>=29.0.0",
     "redis[hiredis]>=5.0.0",
     "arq>=0.25.0",
     "opentelemetry-api>=1.25.0",

--- a/backend/tests/unit/test_executor_result.py
+++ b/backend/tests/unit/test_executor_result.py
@@ -1,0 +1,68 @@
+"""Unit tests for the executor contract's wire translation.
+
+ExecutionResult.from_wire is the single boundary where the in-container
+executor's JSON dict becomes the typed result the engine consumes, so it must
+map every shape the container (and the poll scripts) can emit. See
+app/services/executor/base.py and ADR 2026-06-17-ephemeral-sandbox-baked-image.
+"""
+
+from app.services.executor.base import ExecutionResult, ResultStatus
+
+
+def test_completed_explicit_status():
+    r = ExecutionResult.from_wire({"result": {"x": 1}, "duration_ms": 42, "status": "completed"})
+    assert r.status is ResultStatus.COMPLETED
+    assert r.result == {"x": 1}
+    assert r.duration_ms == 42
+    assert r.error is None
+
+
+def test_completed_without_status():
+    # Success envelopes don't always carry an explicit status.
+    r = ExecutionResult.from_wire({"result": 7, "duration_ms": 3})
+    assert r.status is ResultStatus.COMPLETED
+    assert r.result == 7
+
+
+def test_failed_with_traceback():
+    r = ExecutionResult.from_wire({"status": "failed", "error": "boom", "traceback": "TB"})
+    assert r.status is ResultStatus.FAILED
+    assert r.error == "boom"
+    assert r.traceback == "TB"
+
+
+def test_failed_without_error_field_defaults_message():
+    r = ExecutionResult.from_wire({"status": "failed"})
+    assert r.status is ResultStatus.FAILED
+    assert r.error == "Unknown error"
+
+
+def test_status_less_error_envelope_maps_to_failed():
+    # The poll scripts emit {"error": "...timeout"} with no status — this must
+    # never be misread as a successful (result=None) completion.
+    r = ExecutionResult.from_wire({"error": "Execution timeout after 300s"})
+    assert r.status is ResultStatus.FAILED
+    assert r.error == "Execution timeout after 300s"
+
+
+def test_awaiting_input_maps_container_name_to_handle():
+    r = ExecutionResult.from_wire(
+        {"status": "awaiting_input", "prompt": "continue?", "container_name": "sinas-shared-1"}
+    )
+    assert r.status is ResultStatus.AWAITING_INPUT
+    assert r.prompt == "continue?"
+    assert r.handle == "sinas-shared-1"
+
+
+def test_awaiting_without_handle():
+    # A subsequent input() may omit container_name; the resume helper re-stamps it.
+    r = ExecutionResult.from_wire({"status": "awaiting_input", "prompt": "again?"})
+    assert r.status is ResultStatus.AWAITING_INPUT
+    assert r.handle is None
+
+
+def test_failed_constructor():
+    r = ExecutionResult.failed("nope")
+    assert r.status is ResultStatus.FAILED
+    assert r.error == "nope"
+    assert r.traceback is None

--- a/backend/tests/unit/test_inprocess_trusted.py
+++ b/backend/tests/unit/test_inprocess_trusted.py
@@ -1,0 +1,94 @@
+"""Unit tests for the inprocess trusted executor's code-running core.
+
+`_run_handler` is the contract-bearing piece: entry-point resolution, timeout
+enforcement, input() unavailability, and JSON-result parity with the
+in-container executor's shared mode. The DB-touching `execute()` wrapper is
+exercised by integration tests.
+"""
+
+import pytest
+
+from app.services.executor.base import ResultStatus
+from app.services.executor.inprocess_trusted import (
+    InProcessTrustedExecutor,
+    _run_handler,
+)
+
+
+def _run(code: str, *, input_data=None, timeout: int = 5, name: str = "fn"):
+    return _run_handler(
+        function_code=code,
+        function_namespace="test",
+        function_name=name,
+        input_data=input_data or {},
+        context={"user_id": "u1", "execution_id": "e1"},
+        timeout=timeout,
+    )
+
+
+def test_handler_entry_point_completes():
+    r = _run("def handler(input_data, context):\n    return {'ok': input_data['x'] + 1}", input_data={"x": 1})
+    assert r.status is ResultStatus.COMPLETED
+    assert r.result == {"ok": 2}
+    assert r.duration_ms >= 0
+
+
+def test_legacy_function_name_entry_point():
+    r = _run("def fn(input_data, context):\n    return 'legacy'", name="fn")
+    assert r.status is ResultStatus.COMPLETED
+    assert r.result == "legacy"
+
+
+def test_no_entry_point_fails():
+    r = _run("x = 1")
+    assert r.status is ResultStatus.FAILED
+    assert "handler" in r.error
+
+
+def test_exception_carries_traceback():
+    r = _run("def handler(input_data, context):\n    raise ValueError('boom')")
+    assert r.status is ResultStatus.FAILED
+    assert r.error == "boom"
+    assert "ValueError" in r.traceback
+
+
+def test_syntax_error_fails_at_load():
+    r = _run("def handler(:")
+    assert r.status is ResultStatus.FAILED
+    assert "Failed to load function code" in r.error
+
+
+def test_timeout_enforced():
+    r = _run(
+        "import time\ndef handler(input_data, context):\n    time.sleep(30)",
+        timeout=1,
+    )
+    assert r.status is ResultStatus.FAILED
+    assert "timed out" in r.error
+
+
+def test_input_raises_cleanly():
+    r = _run("def handler(input_data, context):\n    return input('prompt')")
+    assert r.status is ResultStatus.FAILED
+    assert "input() is not available" in r.error
+
+
+def test_context_passed_through():
+    r = _run("def handler(input_data, context):\n    return context['user_id']")
+    assert r.status is ResultStatus.COMPLETED
+    assert r.result == "u1"
+
+
+def test_non_json_serializable_result_fails():
+    r = _run("def handler(input_data, context):\n    return object()")
+    assert r.status is ResultStatus.FAILED
+    assert "non-JSON-serializable" in r.error
+
+
+@pytest.mark.asyncio
+async def test_resume_always_fails():
+    r = await InProcessTrustedExecutor().resume(
+        handle="h", resume_value="v", execution_id="e1", timeout=5
+    )
+    assert r.status is ResultStatus.FAILED
+    assert "does not support resume" in r.error

--- a/backend/tests/unit/test_k8s_runtime.py
+++ b/backend/tests/unit/test_k8s_runtime.py
@@ -1,0 +1,54 @@
+"""Unit tests for the k8s sandbox runtime's pure pieces.
+
+Pod manifest hardening and quantity conversion are contract-bearing (they are
+the k8s translation of the Docker sandbox hardening in
+`_ephemeral_runtime._run_config`); the API-touching lifecycle is exercised
+against a real cluster in integration testing.
+"""
+
+import pytest
+
+from app.services.executor._k8s_runtime import _k8s_quantity, _pod_manifest
+
+
+def test_quantity_conversion():
+    assert _k8s_quantity("1g") == "1Gi"
+    assert _k8s_quantity("500m") == "500Mi"
+    assert _k8s_quantity("64k") == "64Ki"
+    assert _k8s_quantity("2Gi") == "2Gi"  # already a k8s quantity: passthrough
+
+
+def test_pod_manifest_hardening():
+    m = _pod_manifest("sinas-sbx-e1", "executor:latest", deadline_seconds=600)
+    spec = m["spec"]
+    assert spec["restartPolicy"] == "Never"
+    assert spec["automountServiceAccountToken"] is False
+    assert spec["activeDeadlineSeconds"] == 600
+
+    c = spec["containers"][0]
+    sc = c["securityContext"]
+    assert sc["allowPrivilegeEscalation"] is False
+    assert sc["capabilities"]["drop"] == ["ALL"]
+    assert set(sc["capabilities"]["add"]) == {"CHOWN", "SETUID", "SETGID"}
+    assert sc["seccompProfile"] == {"type": "RuntimeDefault"}
+
+    # Sandbox mode must be set — it is what hard-disables input() in the
+    # in-container executor.
+    env = {e["name"]: e["value"] for e in c["env"]}
+    assert env["SINAS_CONTAINER_MODE"] == "sandbox"
+
+    # tmpfs /tmp parity with the Docker sandbox.
+    assert spec["volumes"][0]["emptyDir"]["medium"] == "Memory"
+    assert c["volumeMounts"][0]["mountPath"] == "/tmp"
+
+    # Resource ceilings present.
+    limits = c["resources"]["limits"]
+    assert "memory" in limits and "cpu" in limits and "ephemeral-storage" in limits
+
+    # Selectable by the chart's sandbox NetworkPolicy.
+    assert m["metadata"]["labels"]["sinas.type"] == "sandbox-executor"
+
+
+def test_pod_manifest_no_service_account_by_default():
+    m = _pod_manifest("n", "img", deadline_seconds=1)
+    assert "serviceAccountName" not in m["spec"]

--- a/charts/sinas/Chart.yaml
+++ b/charts/sinas/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: sinas
+description: >-
+  Deploys Sinas on Kubernetes: backend, queue workers, scheduler, CDC worker,
+  console, and bundled datastores. Untrusted code runs in ephemeral hardened
+  sandbox Pods (SANDBOX_EXECUTOR=k8s_pod) — no Docker socket or privileged
+  DinD required.
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/sinas/templates/NOTES.txt
+++ b/charts/sinas/templates/NOTES.txt
@@ -1,0 +1,24 @@
+Sinas has been deployed to namespace {{ .Release.Namespace }}.
+
+  Console:  https://{{ .Values.domain }}/
+  API:      https://{{ .Values.domain }}/api/v1
+  Health:   https://{{ .Values.domain }}/health
+
+Executor configuration:
+  sandbox (untrusted code):  {{ .Values.executor.sandbox }}
+  trusted (shared_pool):     {{ .Values.executor.trusted }}
+  sandbox pod image:         {{ .Values.executor.image }}
+
+{{- if eq .Values.executor.sandbox "k8s_pod" }}
+
+Untrusted code runs in ephemeral hardened Pods created in this namespace
+(label sinas.type=sandbox-executor). Watch them during an execution:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l sinas.type=sandbox-executor -w
+{{- end }}
+
+Check rollout:
+
+  kubectl get pods -n {{ .Release.Namespace }}
+
+The backend runs migrations on startup; first boot can take a minute.

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -112,6 +112,9 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
       key: clickhouse-password
 - name: BACKEND_PORT
   value: "8000"
+{{- with .Values.extraEnv }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -1,0 +1,141 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sinas.name" -}}
+{{- .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sinas.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels for a given component
+*/}}
+{{- define "sinas.selectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ . }}
+{{- end }}
+
+{{/*
+ServiceAccount names
+*/}}
+{{- define "sinas.executorManagerSA" -}}
+{{ .Release.Name }}-executor-manager
+{{- end }}
+
+{{- define "sinas.sandboxSA" -}}
+{{ .Release.Name }}-sandbox
+{{- end }}
+
+{{/*
+Image pull secret reference — shared by all sinas deployments.
+*/}}
+{{- define "sinas.imagePullSecrets" -}}
+{{- if and .Values.registry .Values.registry.username }}
+imagePullSecrets:
+  - name: {{ .Release.Name }}-pull-secret
+{{- end }}
+{{- end }}
+
+{{/*
+Backend environment — shared by backend, all workers, scheduler, cdc-worker
+*/}}
+{{- define "sinas.backendEnv" -}}
+- name: DATABASE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets
+      key: database-password
+- name: DATABASE_USER
+  value: {{ .Values.postgres.user | quote }}
+- name: DATABASE_HOST
+  value: pgbouncer
+- name: DATABASE_PORT
+  value: "5432"
+- name: DATABASE_NAME
+  value: {{ .Values.postgres.database | quote }}
+- name: DATABASE_URL
+  value: "postgresql://{{ .Values.postgres.user }}:$(DATABASE_PASSWORD)@pgbouncer:5432/{{ .Values.postgres.database }}"
+- name: DATABASE_DIRECT_HOST
+  value: postgres
+- name: CLICKHOUSE_HOST
+  value: clickhouse
+- name: CLICKHOUSE_PORT
+  value: "8123"
+- name: CLICKHOUSE_USER
+  value: {{ .Values.clickhouse.user | quote }}
+- name: CLICKHOUSE_DATABASE
+  value: {{ .Values.clickhouse.database | quote }}
+- name: REDIS_URL
+  value: "redis://redis:6379/0"
+- name: BUILDER_URL
+  value: "http://builder:3000"
+## Executor selection — k8s-native: sandbox code runs in ephemeral pods
+## created via the Kubernetes API (no Docker socket anywhere).
+- name: SANDBOX_EXECUTOR
+  value: {{ .Values.executor.sandbox | quote }}
+- name: TRUSTED_EXECUTOR
+  value: {{ .Values.executor.trusted | quote }}
+- name: FUNCTION_CONTAINER_IMAGE
+  value: {{ .Values.executor.image | quote }}
+- name: K8S_SANDBOX_IMAGE
+  value: {{ .Values.executor.image | quote }}
+- name: K8S_SANDBOX_SERVICE_ACCOUNT
+  value: {{ include "sinas.sandboxSA" . | quote }}
+- name: K8S_SANDBOX_INSTALL_DEPENDENCIES
+  value: {{ .Values.executor.installDependencies | quote }}
+- name: K8S_SANDBOX_POD_READY_TIMEOUT
+  value: {{ .Values.executor.podReadyTimeout | quote }}
+- name: POD_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+- name: SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets
+      key: secret-key
+- name: ENCRYPTION_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets
+      key: encryption-key
+- name: CLICKHOUSE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets
+      key: clickhouse-password
+- name: BACKEND_PORT
+  value: "8000"
+{{- end }}
+
+{{/*
+File storage volume mount — /var/sinas/files
+*/}}
+{{- define "sinas.fileStorageMount" -}}
+- name: file-storage
+  mountPath: /var/sinas/files
+{{- end }}
+
+{{/*
+File storage volume reference.
+Default: emptyDir (dev-friendly, no cross-pod sharing, non-persistent).
+Set fileStorage.storageClass to enable a PVC with an RWX storage class for
+production (Longhorn, NFS, etc.) — the only way to share files across pods
+on multiple nodes.
+*/}}
+{{- define "sinas.fileStorageVolume" -}}
+{{- if (.Values.fileStorage).storageClass }}
+- name: file-storage
+  persistentVolumeClaim:
+    claimName: {{ .Release.Name }}-file-storage
+{{- else }}
+- name: file-storage
+  emptyDir: {}
+{{- end }}
+{{- end }}

--- a/charts/sinas/templates/backend.yaml
+++ b/charts/sinas/templates/backend.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: {{ include "sinas.executorManagerSA" . }}
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.smtp.ipv4 }}
+      hostAliases:
+        - ip: {{ .Values.smtp.ipv4 | quote }}
+          hostnames:
+            - {{ .Values.smtp.host | quote }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+          ports:
+            - containerPort: 8000
+          env:
+            {{- include "sinas.backendEnv" . | nindent 12 }}
+            - name: SUPERADMIN_EMAIL
+              value: {{ .Values.superadminEmail | quote }}
+            - name: SMTP_HOST
+              value: {{ .Values.smtp.host | quote }}
+            - name: SMTP_PORT
+              value: {{ .Values.smtp.port | quote }}
+            - name: SMTP_USER
+              value: {{ .Values.smtp.user | quote }}
+            - name: SMTP_DOMAIN
+              value: {{ .Values.smtp.domain | quote }}
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: smtp-password
+          volumeMounts:
+            {{- include "sinas.fileStorageMount" . | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      volumes:
+        {{- include "sinas.fileStorageVolume" . | nindent 8 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: backend
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/charts/sinas/templates/builder.yaml
+++ b/charts/sinas/templates/builder.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: builder
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: builder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: builder
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: builder
+    spec:
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: builder
+          image: {{ .Values.image.registry }}/builder:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.builder.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: builder
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: builder
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/charts/sinas/templates/clickhouse.yaml
+++ b/charts/sinas/templates/clickhouse.yaml
@@ -1,0 +1,236 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-config
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+data:
+  network.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+    </clickhouse>
+
+  system-logs.xml: |
+    <clickhouse>
+        <!-- Disable high-volume system logs that cause merge bloat on small deployments -->
+        <metric_log remove="1" />
+        <asynchronous_metric_log remove="1" />
+        <trace_log remove="1" />
+        <processors_profile_log remove="1" />
+
+        <text_log>
+            <database>system</database>
+            <table>text_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </text_log>
+        <query_log>
+            <database>system</database>
+            <table>query_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </query_log>
+        <part_log>
+            <database>system</database>
+            <table>part_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </part_log>
+        <error_log>
+            <database>system</database>
+            <table>error_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </error_log>
+    </clickhouse>
+
+  resource-limits.xml: |
+    <clickhouse>
+        <max_server_memory_usage>{{ .Values.clickhouse.memoryLimit | replace "Gi" "073741824" | replace "Mi" "048576" }}</max_server_memory_usage>
+        <background_pool_size>9</background_pool_size>
+        <background_merges_mutations_concurrency_ratio>3</background_merges_mutations_concurrency_ratio>
+        <background_schedule_pool_size>4</background_schedule_pool_size>
+        <background_common_pool_size>4</background_common_pool_size>
+        <background_move_pool_size>2</background_move_pool_size>
+        <background_fetches_pool_size>2</background_fetches_pool_size>
+        <max_connections>64</max_connections>
+        <mark_cache_size>134217728</mark_cache_size>
+    </clickhouse>
+
+  user-limits.xml: |
+    <clickhouse>
+        <profiles>
+            <default>
+                <max_memory_usage>268435456</max_memory_usage>
+                <max_bytes_before_external_group_by>134217728</max_bytes_before_external_group_by>
+                <max_bytes_before_external_sort>134217728</max_bytes_before_external_sort>
+            </default>
+        </profiles>
+    </clickhouse>
+
+  init.sql: |
+    CREATE DATABASE IF NOT EXISTS {{ .Values.clickhouse.database }};
+
+    CREATE TABLE IF NOT EXISTS {{ .Values.clickhouse.database }}.request_logs
+    (
+        request_id UUID DEFAULT generateUUIDv4(),
+        timestamp DateTime64(3) DEFAULT now64(3),
+        user_id String,
+        user_email String,
+        permission_used String,
+        has_permission Boolean,
+        method String,
+        path String,
+        query_params String,
+        request_body String,
+        user_agent String,
+        referer String,
+        ip_address String,
+        status_code UInt16,
+        response_time_ms UInt32,
+        response_size_bytes UInt32,
+        resource_type String,
+        resource_id String,
+        group_id String,
+        error_message String,
+        error_type String,
+        metadata String
+    )
+    ENGINE = MergeTree()
+    PARTITION BY toYYYYMM(timestamp)
+    ORDER BY (timestamp, user_id, path)
+    SETTINGS index_granularity = 8192;
+
+    CREATE INDEX IF NOT EXISTS idx_user ON {{ .Values.clickhouse.database }}.request_logs (user_id) TYPE bloom_filter GRANULARITY 1;
+    CREATE INDEX IF NOT EXISTS idx_permission ON {{ .Values.clickhouse.database }}.request_logs (permission_used) TYPE bloom_filter GRANULARITY 1;
+    CREATE INDEX IF NOT EXISTS idx_path ON {{ .Values.clickhouse.database }}.request_logs (path) TYPE bloom_filter GRANULARITY 1;
+
+    CREATE TABLE IF NOT EXISTS {{ .Values.clickhouse.database }}.execution_logs
+    (
+        log_id UUID DEFAULT generateUUIDv4(),
+        timestamp DateTime64(3) DEFAULT now64(3),
+        execution_id String,
+        event String,
+        function_name String,
+        step_id String,
+        input_data String,
+        output_data String,
+        error String,
+        duration_ms UInt32,
+        status String
+    )
+    ENGINE = MergeTree()
+    PARTITION BY toYYYYMM(timestamp)
+    ORDER BY (timestamp, execution_id, event)
+    SETTINGS index_granularity = 8192;
+
+    CREATE INDEX IF NOT EXISTS idx_execution ON {{ .Values.clickhouse.database }}.execution_logs (execution_id) TYPE bloom_filter GRANULARITY 1;
+    CREATE INDEX IF NOT EXISTS idx_event ON {{ .Values.clickhouse.database }}.execution_logs (event) TYPE bloom_filter GRANULARITY 1;
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+spec:
+  serviceName: clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: clickhouse
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: clickhouse
+    spec:
+      securityContext:
+        fsGroup: 101
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24-alpine
+          env:
+            - name: CLICKHOUSE_DB
+              value: {{ .Values.clickhouse.database | quote }}
+            - name: CLICKHOUSE_USER
+              value: {{ .Values.clickhouse.user | quote }}
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: clickhouse-password
+          resources:
+            limits:
+              memory: {{ .Values.clickhouse.memoryLimit }}
+          ports:
+            - name: http
+              containerPort: 8123
+            - name: native
+              containerPort: 9000
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/network.xml
+              subPath: network.xml
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/system-logs.xml
+              subPath: system-logs.xml
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/resource-limits.xml
+              subPath: resource-limits.xml
+            - name: config
+              mountPath: /etc/clickhouse-server/users.d/user-limits.xml
+              subPath: user-limits.xml
+            - name: config
+              mountPath: /docker-entrypoint-initdb.d/init.sql
+              subPath: init.sql
+      volumes:
+        - name: config
+          configMap:
+            name: clickhouse-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.clickhouse.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: clickhouse
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+    - name: native
+      port: 9000
+      targetPort: 9000

--- a/charts/sinas/templates/console.yaml
+++ b/charts/sinas/templates/console.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: console
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: console
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: console
+    spec:
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: console
+          image: {{ .Values.image.registry }}/console:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.console.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: console
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: console
+  ports:
+    - port: 80
+      targetPort: 80

--- a/charts/sinas/templates/file-storage.yaml
+++ b/charts/sinas/templates/file-storage.yaml
@@ -1,0 +1,23 @@
+{{- if (.Values.fileStorage).storageClass }}
+## Shared persistent volume for user-uploaded files (/var/sinas/files).
+## Mounted into backend, queue-worker, queue-agent, and scheduler.
+##
+## Scaleway SBS (and most block storage) is ReadWriteOnce — it can only attach
+## to a single node. All pods that mount this volume must be co-located on the
+## same node.
+##
+## For multi-node production use, use an RWX storage class (NFS, Longhorn, etc.)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-file-storage
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.fileStorage.size | default "5Gi" }}
+  storageClassName: {{ .Values.fileStorage.storageClass }}
+{{- end }}

--- a/charts/sinas/templates/ingress.yaml
+++ b/charts/sinas/templates/ingress.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.ingress.enabled }}
+## Path-based routing:
+##   Backend API paths → backend:8000
+##   Everything else   → console:80 (SPA)
+##
+## Console uses window.location.hostname as the API base, so both services
+## must share the same hostname.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.domain | quote }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.domain | quote }}
+      http:
+        paths:
+          {{- range list "/api" "/adapters" "/auth" "/files" "/stores" "/webhooks" "/agents" "/chats" "/functions" "/executions" "/manifests" "/components" "/queries" "/skills" "/collections" "/states" "/jobs" "/templates" "/health" "/docs" "/openapi.json" }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          {{- end }}
+          ## Catch-all → console SPA
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: console
+                port:
+                  number: 80
+{{- end }}

--- a/charts/sinas/templates/networkpolicy.yaml
+++ b/charts/sinas/templates/networkpolicy.yaml
@@ -50,6 +50,18 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
+    ## Kubernetes API server — required by the k8s_pod executor (create/exec/
+    ## delete sandbox pods). The apiserver ClusterIP/endpoint is cluster-
+    ## specific (usually an RFC1918 address), so allow the API ports to any
+    ## destination rather than pinning a CIDR. Sandbox pods get NO such rule.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
     ## External internet — except RFC1918 (blocks cross-namespace pod IPs).
     - to:
         - ipBlock:

--- a/charts/sinas/templates/networkpolicy.yaml
+++ b/charts/sinas/templates/networkpolicy.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.networkPolicy.enabled }}
+## Namespace isolation for the sinas services (everything EXCEPT sandbox
+## pods). Allows:
+##   ingress — same namespace + the ingress controller's namespace
+##   egress  — same namespace + kube-dns + external internet (SMTP, LLM APIs,
+##             container registry). RFC1918 ranges are blocked so
+##             cross-namespace pod/service IPs are unreachable.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-services
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: sinas.type
+        operator: NotIn
+        values: ["sandbox-executor"]
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    ## Intra-namespace: backend↔pgbouncer, backend↔redis, etc.
+    - from:
+        - podSelector: {}
+    {{- if .Values.networkPolicy.ingressNamespace }}
+    ## Ingress controller → backend (8000) and console (80)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace }}
+    {{- else }}
+    ## No ingressNamespace configured — allow ingress from any namespace so
+    ## the ingress controller can reach backend/console.
+    - from:
+        - namespaceSelector: {}
+    {{- end }}
+  egress:
+    ## Intra-namespace
+    - to:
+        - podSelector: {}
+    ## kube-dns — required for all DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    ## External internet — except RFC1918 (blocks cross-namespace pod IPs).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+## Sandbox pods: the k8s equivalent of the Docker `sinas-sandbox` network.
+## Untrusted code gets DNS + internet egress ONLY — no cluster-internal
+## traffic, so it can never reach postgres/redis/clickhouse or other
+## namespaces. No ingress at all (the executor talks to the pod via the
+## kubelet exec API, which NetworkPolicy does not affect).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-sandbox-isolation
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      sinas.type: sandbox-executor
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    ## kube-dns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    ## Internet only — no RFC1918, so no cluster-internal services.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+{{- end }}

--- a/charts/sinas/templates/pgbouncer.yaml
+++ b/charts/sinas/templates/pgbouncer.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pgbouncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: pgbouncer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: pgbouncer
+    spec:
+      containers:
+        - name: pgbouncer
+          image: edoburu/pgbouncer:latest
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: database-password
+            - name: DATABASE_URL
+              value: "postgres://{{ .Values.postgres.user }}:$(DATABASE_PASSWORD)@postgres:5432/{{ .Values.postgres.database }}"
+            - name: POOL_MODE
+              value: {{ .Values.pgbouncer.poolMode | quote }}
+            - name: MAX_CLIENT_CONN
+              value: {{ .Values.pgbouncer.maxClientConn | quote }}
+            - name: DEFAULT_POOL_SIZE
+              value: {{ .Values.pgbouncer.defaultPoolSize | quote }}
+            - name: MIN_POOL_SIZE
+              value: {{ .Values.pgbouncer.minPoolSize | quote }}
+            - name: RESERVE_POOL_SIZE
+              value: {{ .Values.pgbouncer.reservePoolSize | quote }}
+            - name: AUTH_TYPE
+              value: scram-sha-256
+          ports:
+            - containerPort: 5432
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-h", "localhost", "-p", "5432"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-h", "localhost", "-p", "5432"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgbouncer
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pgbouncer
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/charts/sinas/templates/postgres.yaml
+++ b/charts/sinas/templates/postgres.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: database-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgres.user | quote }}]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgres.user | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/charts/sinas/templates/rbac.yaml
+++ b/charts/sinas/templates/rbac.yaml
@@ -1,0 +1,58 @@
+## Executor RBAC — what replaces the Docker socket / DinD.
+##
+## executor-manager SA: used by backend, queue workers, and scheduler. May
+## create/inspect/delete sandbox pods and exec into them, in this namespace
+## only. This is the entire privilege surface needed to run untrusted code.
+##
+## sandbox SA: assigned to the sandbox pods themselves. No permissions, and
+## no API token is mounted (the executor also sets
+## automountServiceAccountToken: false on each pod). It exists so sandbox
+## pods never run as the namespace default SA and so private-registry pull
+## secrets can be attached to them.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sinas.executorManagerSA" . }}
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sinas.sandboxSA" . }}
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+automountServiceAccountToken: false
+{{- if and .Values.registry .Values.registry.username }}
+imagePullSecrets:
+  - name: {{ .Release.Name }}-pull-secret
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-executor-manager
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-executor-manager
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-executor-manager
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sinas.executorManagerSA" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/sinas/templates/redis.yaml
+++ b/charts/sinas/templates/redis.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --maxmemory
+            - {{ .Values.redis.maxmemory | quote }}
+            - --maxmemory-policy
+            - allkeys-lru
+          ports:
+            - containerPort: 6379
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/charts/sinas/templates/secret.yaml
+++ b/charts/sinas/templates/secret.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  secret-key: {{ .Values.secrets.secretKey | quote }}
+  encryption-key: {{ .Values.secrets.encryptionKey | quote }}
+  database-password: {{ .Values.postgres.password | quote }}
+  clickhouse-password: {{ .Values.clickhouse.password | quote }}
+  smtp-password: {{ .Values.smtp.password | quote }}
+{{- if and .Values.registry .Values.registry.username }}
+---
+## Image pull secret for sinas images and sandbox pods (attached to the
+## sandbox ServiceAccount so the executor-created pods inherit it).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-pull-secret
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        {{ .Values.registry.server | quote }}: {
+          "auth": {{ printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc | quote }}
+        }
+      }
+    }
+{{- end }}

--- a/charts/sinas/templates/workers.yaml
+++ b/charts/sinas/templates/workers.yaml
@@ -27,6 +27,8 @@ spec:
           command: ["python", "-m", "arq", "app.queue.worker.WorkerSettings"]
           env:
             {{- include "sinas.backendEnv" . | nindent 12 }}
+            - name: QUEUE_FUNCTION_CONCURRENCY
+              value: {{ .Values.queueWorker.concurrency | quote }}
           volumeMounts:
             {{- include "sinas.fileStorageMount" . | nindent 12 }}
           resources:
@@ -63,6 +65,8 @@ spec:
           command: ["python", "-m", "arq", "app.queue.worker.AgentWorkerSettings"]
           env:
             {{- include "sinas.backendEnv" . | nindent 12 }}
+            - name: QUEUE_AGENT_CONCURRENCY
+              value: {{ .Values.queueAgent.concurrency | quote }}
           volumeMounts:
             {{- include "sinas.fileStorageMount" . | nindent 12 }}
           resources:

--- a/charts/sinas/templates/workers.yaml
+++ b/charts/sinas/templates/workers.yaml
@@ -1,0 +1,140 @@
+## queue-worker
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: queue-worker
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: queue-worker
+spec:
+  replicas: {{ .Values.queueWorker.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: queue-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: queue-worker
+    spec:
+      serviceAccountName: {{ include "sinas.executorManagerSA" . }}
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: queue-worker
+          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "arq", "app.queue.worker.WorkerSettings"]
+          env:
+            {{- include "sinas.backendEnv" . | nindent 12 }}
+          volumeMounts:
+            {{- include "sinas.fileStorageMount" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.queueWorker.resources | nindent 12 }}
+      volumes:
+        {{- include "sinas.fileStorageVolume" . | nindent 8 }}
+---
+## queue-agent
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: queue-agent
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: queue-agent
+spec:
+  replicas: {{ .Values.queueAgent.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: queue-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: queue-agent
+    spec:
+      serviceAccountName: {{ include "sinas.executorManagerSA" . }}
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: queue-agent
+          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "arq", "app.queue.worker.AgentWorkerSettings"]
+          env:
+            {{- include "sinas.backendEnv" . | nindent 12 }}
+          volumeMounts:
+            {{- include "sinas.fileStorageMount" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.queueAgent.resources | nindent 12 }}
+      volumes:
+        {{- include "sinas.fileStorageVolume" . | nindent 8 }}
+---
+## scheduler
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scheduler
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: scheduler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: scheduler
+    spec:
+      serviceAccountName: {{ include "sinas.executorManagerSA" . }}
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: scheduler
+          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "app.scheduler.service"]
+          env:
+            {{- include "sinas.backendEnv" . | nindent 12 }}
+            - name: SUPERADMIN_EMAIL
+              value: {{ .Values.superadminEmail | quote }}
+          volumeMounts:
+            {{- include "sinas.fileStorageMount" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.scheduler.resources | nindent 12 }}
+      volumes:
+        {{- include "sinas.fileStorageVolume" . | nindent 8 }}
+---
+## cdc-worker
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cdc-worker
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cdc-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: cdc-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: cdc-worker
+    spec:
+      {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: cdc-worker
+          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "app.cdc.service"]
+          env:
+            {{- include "sinas.backendEnv" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.cdcWorker.resources | nindent 12 }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -1,0 +1,178 @@
+## Image — the sinas backend image (also used by workers, scheduler, cdc).
+image:
+  registry: ghcr.io/sinas-platform/sinas
+  tag: latest
+  pullPolicy: IfNotPresent
+
+## Routing
+domain: ""
+
+## Ingress — standard networking.k8s.io/v1. For Gateway API (HTTPRoute) or
+## provider-specific routing, disable this and bring your own route objects.
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""  # existing TLS secret; leave empty when using cert-manager annotations
+
+## Secrets (required — provide via --set or a secrets values file)
+secrets:
+  secretKey: ""
+  encryptionKey: ""
+
+## Superadmin
+superadminEmail: ""
+
+## Executor — how sinas runs user/agent code.
+##
+## sandbox: untrusted code (untrusted Functions + agent codeExecution).
+##   "k8s_pod"  — one ephemeral hardened Pod per execution (default).
+##   "disabled" — reject sandbox executions (trusted-only deployment).
+## trusted: admin-approved code (Function.shared_pool=true).
+##   "inprocess" — runs inside the queue-worker process (default).
+##                 Note: shares the worker's credentials; approve shared_pool
+##                 functions accordingly.
+executor:
+  sandbox: "k8s_pod"
+  trusted: "inprocess"
+  ## Image for sandbox pods. Must be pullable by the cluster. Extra packages
+  ## (Dependency table) are pip-installed into each pod at create time; bake
+  ## them into a custom image and set installDependencies: false to skip that
+  ## cold-start cost.
+  image: "ghcr.io/sinas-platform/sinas/executor:latest"
+  installDependencies: true
+  podReadyTimeout: 120
+
+## Pull secret for private registries (applies to sinas images AND sandbox
+## pods, via their ServiceAccounts). Leave username empty for public images.
+registry:
+  server: "ghcr.io"
+  username: ""
+  password: ""
+
+## PostgreSQL
+postgres:
+  user: postgres
+  database: sinas
+  password: ""
+  storage: 5Gi
+
+## Redis
+redis:
+  maxmemory: "256mb"
+  storage: 1Gi
+
+## ClickHouse
+clickhouse:
+  user: default
+  password: ""
+  database: sinas
+  storage: 5Gi
+  memoryLimit: "1Gi"
+
+## PGBouncer
+pgbouncer:
+  poolMode: transaction
+  maxClientConn: 1000
+  defaultPoolSize: 50
+  minPoolSize: 10
+  reservePoolSize: 10
+
+## File storage — shared volume for uploaded files (/var/sinas/files).
+## Mounted into backend, queue-worker, queue-agent, scheduler.
+## Use an RWX storage class on multi-node clusters.
+fileStorage:
+  size: 5Gi
+  storageClass: ""
+
+## Network policy — namespace isolation + locked-down sandbox pods.
+## ingressNamespace: the namespace your ingress controller runs in (allowed to
+## reach backend/console). Leave empty to allow ingress from any namespace.
+networkPolicy:
+  enabled: true
+  ingressNamespace: ""
+
+## Builder (Node.js esbuild server)
+builder:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+## Backend (FastAPI)
+backend:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+
+## Queue worker
+queueWorker:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+## Queue agent worker
+queueAgent:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+## Scheduler
+scheduler:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+## CDC worker
+cdcWorker:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+## Console (React SPA)
+console:
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "128Mi"
+
+## SMTP
+## smtp.ipv4: forces smtp.host to resolve to this IPv4 (avoids ENETUNREACH on IPv6-less pods).
+smtp:
+  host: ""
+  port: 587
+  user: ""
+  password: ""
+  domain: ""
+  ipv4: ""

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -118,6 +118,10 @@ backend:
 ## Queue worker
 queueWorker:
   replicas: 1
+  ## Max concurrent function executions per worker (QUEUE_FUNCTION_CONCURRENCY).
+  ## Total burst envelope per release ≈ replicas × concurrency × per-execution
+  ## memory, bounded by resources.limits.memory — size them together.
+  concurrency: 10
   resources:
     requests:
       cpu: "200m"
@@ -129,6 +133,8 @@ queueWorker:
 ## Queue agent worker
 queueAgent:
   replicas: 1
+  ## Max concurrent agent jobs per worker (QUEUE_AGENT_CONCURRENCY).
+  concurrency: 5
   resources:
     requests:
       cpu: "200m"
@@ -176,3 +182,12 @@ smtp:
   password: ""
   domain: ""
   ipv4: ""
+
+## Extra environment variables appended to every sinas service (backend,
+## queue workers, scheduler, cdc-worker). Any backend Settings knob
+## (app/core/config.py) can be set here without a chart change, e.g.:
+##   - name: MAX_FUNCTION_MEMORY
+##     value: "256"
+##   - name: FUNCTION_TIMEOUT
+##     value: "120"
+extraEnv: []

--- a/docs-mint/docs.json
+++ b/docs-mint/docs.json
@@ -18,6 +18,7 @@
             "pages": [
               "index",
               "getting-started/deployment",
+              "getting-started/kubernetes",
               "getting-started/concepts",
               "getting-started/environment-variables"
             ]

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -65,7 +65,40 @@ Required when `AUTH_MODE` is `otp` or `password+otp`. Skip entirely for `passwor
 | `ALLOW_PACKAGE_INSTALLATION` | `true` | Allow `pip install` in functions |
 | `ALLOWED_PACKAGES` | _(all)_ | Comma-separated package whitelist |
 
+## Executors
+
+How Sinas runs user code. `SANDBOX_EXECUTOR` handles untrusted code
+(untrusted functions and agent code execution) and must isolate every
+execution; `TRUSTED_EXECUTOR` handles admin-approved functions
+(`shared_pool=true`).
+
+| Variable | Default | Description |
+|---|---|---|
+| `SANDBOX_EXECUTOR` | `docker_pool` | `docker_pool` (warm container pool), `docker_ephemeral` (single-use container per execution, baked package image), `k8s_pod` (single-use Kubernetes pod per execution), or `disabled` (reject sandbox executions) |
+| `TRUSTED_EXECUTOR` | `docker_shared` | `docker_shared` (long-lived shared worker containers) or `inprocess` (run inside the queue-worker process — no Docker socket needed, but no `input()`/pause support) |
+
+With `SANDBOX_EXECUTOR=k8s_pod` and `TRUSTED_EXECUTOR=inprocess`, no process
+needs a Docker socket — this is the configuration the Helm chart uses.
+`inprocess` runs trusted code with the worker's own environment and
+credentials, so only enable `shared_pool` on functions you'd trust with them.
+
+### Kubernetes executor (`SANDBOX_EXECUTOR=k8s_pod`)
+
+Requires running in-cluster with a ServiceAccount that can `create`/`get`/
+`list`/`delete` pods and use `pods/exec` in the sandbox namespace (the Helm
+chart provisions this).
+
+| Variable | Default | Description |
+|---|---|---|
+| `K8S_SANDBOX_NAMESPACE` | _(own namespace)_ | Namespace for sandbox pods |
+| `K8S_SANDBOX_IMAGE` | `FUNCTION_CONTAINER_IMAGE` | Image for sandbox pods (must be pullable by the cluster) |
+| `K8S_SANDBOX_SERVICE_ACCOUNT` | _(namespace default)_ | ServiceAccount assigned to sandbox pods |
+| `K8S_SANDBOX_POD_READY_TIMEOUT` | `120` | Seconds to wait for a sandbox pod to become ready |
+| `K8S_SANDBOX_INSTALL_DEPENDENCIES` | `true` | `pip install` platform dependencies into each pod; set to `false` when they are baked into `K8S_SANDBOX_IMAGE` |
+
 ## Sandbox Containers
+
+Used by `SANDBOX_EXECUTOR=docker_pool` (the warm pool).
 
 | Variable | Default | Description |
 |---|---|---|

--- a/docs-mint/getting-started/kubernetes.mdx
+++ b/docs-mint/getting-started/kubernetes.mdx
@@ -1,0 +1,105 @@
+---
+title: "Deploy on Kubernetes"
+description: "Run Sinas on any Kubernetes cluster with the bundled Helm chart"
+---
+
+Sinas ships a Helm chart at [`charts/sinas`](https://github.com/sinas-platform/sinas/tree/main/charts/sinas)
+that deploys the full platform — backend, queue workers, scheduler, CDC
+worker, console — plus bundled PostgreSQL, Redis, and ClickHouse.
+
+Untrusted code (untrusted functions and agent code execution) runs in
+**ephemeral hardened Pods**: one pod per execution, created through the
+Kubernetes API and deleted afterwards. No Docker socket, no privileged
+Docker-in-Docker. Admin-approved (`shared_pool`) functions run in-process in
+the queue workers.
+
+This works on any conformant cluster — kind, k3s, Scaleway Kapsule, GKE,
+**AWS EKS** (EKS nodes run containerd and have no Docker socket, which is
+exactly why the pod-based executor exists).
+
+## Install
+
+```bash
+helm install sinas ./charts/sinas \
+  --namespace sinas --create-namespace \
+  --set domain=sinas.example.com \
+  --set ingress.className=nginx \
+  --set secrets.secretKey=$(openssl rand -hex 32) \
+  --set secrets.encryptionKey=$(python3 -c "import base64,os;print(base64.urlsafe_b64encode(os.urandom(32)).decode())") \
+  --set postgres.password=$(openssl rand -hex 16) \
+  --set clickhouse.password=$(openssl rand -hex 16) \
+  --set superadminEmail=you@example.com
+```
+
+The backend runs database migrations on startup; first boot takes a minute.
+Watch sandbox pods appear during executions:
+
+```bash
+kubectl get pods -n sinas -l sinas.type=sandbox-executor -w
+```
+
+## How sandbox pods are secured
+
+Each execution pod is created with the same hardening as the Docker sandbox:
+
+- all capabilities dropped (`CHOWN`/`SETUID`/`SETGID` added back), no
+  privilege escalation, `RuntimeDefault` seccomp profile
+- memory / CPU / ephemeral-storage limits from `MAX_FUNCTION_*`
+- in-memory `/tmp` (100Mi), single-use, deleted after the execution,
+  `activeDeadlineSeconds` as a leak backstop
+- **no ServiceAccount token** — sandbox pods cannot talk to the Kubernetes API
+- a NetworkPolicy that allows DNS and internet egress only: sandbox pods can
+  never reach cluster-internal services (PostgreSQL, Redis, other namespaces)
+
+The services themselves use a ServiceAccount whose Role is limited to
+`pods` + `pods/exec` in the release namespace — that is the entire privilege
+surface replacing the Docker socket.
+
+<Note>
+NetworkPolicies require a CNI that enforces them (Cilium, Calico, kindnetd on
+recent kind, VPC CNI with a policy engine on EKS). Without enforcement the
+deployment still works, but sandbox pods are not network-isolated.
+</Note>
+
+## Executor image and cold-start latency
+
+Sandbox pods run `executor.image`. By default, platform dependencies (the
+admin-managed package list) are `pip install`ed into each pod at creation,
+which adds seconds to every sandbox execution. For production, bake them in:
+
+```dockerfile
+FROM ghcr.io/sinas-platform/sinas/executor:latest
+RUN pip install --no-cache-dir <your dependency list>
+```
+
+```yaml
+executor:
+  image: registry.example.com/sinas-executor-baked:v1
+  installDependencies: false
+```
+
+## Key values
+
+| Value | Default | Description |
+|---|---|---|
+| `domain` | — | Hostname for console + API (one shared hostname) |
+| `ingress.enabled` | `true` | Create a standard `Ingress`; disable to bring your own routing |
+| `ingress.className` | — | e.g. `nginx`, `traefik`, `alb` |
+| `executor.sandbox` | `k8s_pod` | Sandbox executor; `disabled` for trusted-only deployments |
+| `executor.trusted` | `inprocess` | Trusted executor |
+| `executor.image` | ghcr executor | Image for sandbox pods |
+| `executor.installDependencies` | `true` | Per-pod `pip install` (set `false` with a baked image) |
+| `registry.username/password` | — | Pull secret for private registries (also attached to sandbox pods) |
+| `fileStorage.storageClass` | _(emptyDir)_ | RWX storage class for shared file storage on multi-node clusters |
+| `networkPolicy.enabled` | `true` | Namespace isolation + sandbox lockdown |
+| `networkPolicy.ingressNamespace` | _(any)_ | Restrict which namespace may reach backend/console |
+
+## Limitations
+
+- `input()` / human-in-the-loop pauses are unavailable: sandbox pods are
+  single-use (sandbox mode has always rejected `input()`), and the
+  `inprocess` trusted executor is run-to-completion. Durable pause/resume is
+  tracked in [issue #79](https://github.com/sinas-platform/sinas/issues/79).
+- The bundled datastores are convenience-grade. For production, point
+  `DATABASE_URL`-family settings at managed services (e.g. RDS, ElastiCache)
+  and disable the bundled StatefulSets.

--- a/docs-mint/getting-started/kubernetes.mdx
+++ b/docs-mint/getting-started/kubernetes.mdx
@@ -78,6 +78,26 @@ executor:
   installDependencies: false
 ```
 
+## Advanced: per-client node scheduling
+
+These aren't exposed as values in the bundled `charts/sinas` chart — they're
+env vars for operators building their own multi-tenant deployment tooling
+around the k8s_pod executor (e.g. a chart that provisions one release per
+customer). Sinas doesn't decide scheduling policy itself; it just applies
+whatever it's given, so the same knobs work whether you want every
+customer's sandbox pods spread across dedicated nodes or packed together on
+shared ones — that choice lives entirely in your own tooling, not here.
+
+| Setting | Default | Description |
+|---|---|---|
+| `K8S_RELEASE_NAME` | _(empty)_ | Stamped as the `app.kubernetes.io/instance` label on sandbox pods, so your own affinity rules have something to match on. No label if unset. |
+| `K8S_SANDBOX_NODE_SELECTOR` | `{}` | JSON-encoded `nodeSelector` applied verbatim to sandbox pods. |
+| `K8S_SANDBOX_TOLERATIONS` | `[]` | JSON-encoded list of `toleration` objects applied verbatim. |
+| `K8S_SANDBOX_AFFINITY` | `{}` | JSON-encoded K8s `affinity` object (`podAffinity` to pack a customer's sandbox pods onto the same node as their other workloads, `podAntiAffinity` to spread them across dedicated nodes, `nodeAffinity`, or any combination) applied verbatim. |
+
+All four are no-ops by default, matching the behavior described above with
+no scheduling constraint at all.
+
 ## Key values
 
 | Value | Default | Description |


### PR DESCRIPTION
## Summary

Completes the executor refactor (steps 4+5 of the roadmap in `app/services/executor/`) and ships the Helm chart issue #69 asks for. Sinas now deploys on any Kubernetes cluster — including containerd-only nodes (EKS, Kapsule) — with **no Docker socket and no privileged DinD**.

- **`TRUSTED_EXECUTOR=inprocess`** (step 4): runs admin-approved (`shared_pool`) functions inside the queue-worker process. Run-to-completion only — `input()`/resume fail cleanly; durable HITL remains #79. Docker clients in `container_pool`/`shared_worker_manager` are now lazy and all Docker-touching startup is gated on executor modes, so socket-free deployments boot cleanly.
- **`SANDBOX_EXECUTOR=k8s_pod`** (step 5): one ephemeral hardened Pod per untrusted execution (caps dropped, seccomp RuntimeDefault, memory-backed /tmp, resource limits, no SA token, activeDeadlineSeconds backstop), speaking the same executor-image IPC as the Docker runtimes. Agent codeExecution routes through it too.
- **Helm chart at `charts/sinas`**: derived from the bootstrap `sinas-client` chart, with the DinD pod replaced by RBAC (a Role limited to `pods` + `pods/exec` in the release namespace), a token-less sandbox ServiceAccount, a sandbox NetworkPolicy (DNS + internet egress only — sandbox pods cannot reach cluster-internal services), and a generic Ingress instead of Scaleway/Traefik HTTPRoute.
- **Docs**: Kubernetes deployment guide + executor env-var reference; ephemeral-sandbox ADR flipped to Accepted.

**Defaults unchanged**: `docker_pool` / `docker_shared` — docker-compose deployments are unaffected.

## Validation

- `docker_ephemeral` runtime gate (open since June) passed on the dev compose stack: baked-image warm build, untrusted function execution in a single-use container (create→exec→destroy, no leftovers), agent codeExecution.
- End-to-end on a kind cluster via `helm install`: untrusted function through an ephemeral pod, trusted function in-process, agent codeExecution. This surfaced and fixed a real bug (cb49039): the services NetworkPolicy blocked apiserver egress, which would break the executor on any netpol-enforcing cluster.
- 21 unit tests pass (`tests/unit/test_executor_result.py`, `test_inprocess_trusted.py`, `test_k8s_runtime.py`).

## Notes for testing

- Install command and values reference: `docs-mint/getting-started/kubernetes.mdx`.
- Watch sandbox pods during an execution: `kubectl get pods -l sinas.type=sandbox-executor -w`
- Per-pod dependency install adds seconds of cold-start; production path is a baked executor image + `executor.installDependencies: false`.
- `poetry.lock` still needs regenerating for the new `kubernetes` dependency.
- `inprocess` trusted execution shares the worker's credentials — fine for self-hosted; metered managed hosts need a container/pod-backed trusted executor (meter-integrity constraint from the operations-metering design).

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)