### PR TITLE
feat(auth): token exchange endpoint for external auth systems

### DIFF
--- a/backend/alembic/versions/m1e2r3g4e5i6_merge_identity_and_cache_token_heads.py
+++ b/backend/alembic/versions/m1e2r3g4e5i6_merge_identity_and_cache_token_heads.py
@@ -1,0 +1,24 @@
+"""merge identity and cache-token heads
+
+Revision ID: m1e2r3g4e5i6
+Revises: c1a2c3h4e5t6, u1i2d3e4n5t6
+Create Date: 2026-07-30 10:41:30.167884
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'm1e2r3g4e5i6'
+down_revision = ('c1a2c3h4e5t6', 'u1i2d3e4n5t6')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -1,5 +1,7 @@
 """Authentication endpoints."""
 
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,6 +43,13 @@ from app.schemas.auth import (
     RefreshRequest,
     RefreshResponse,
     ResetPasswordRequest,
+    TokenExchangeRequest,
+    TokenExchangeResponse,
+)
+from app.services.user_identity import (
+    IdentityConflictError,
+    get_user_by_identity,
+    link_user_identity,
 )
 
 
@@ -165,6 +174,91 @@ async def verify_otp(request: OTPVerifyRequest, http_request: Request, db: Async
         token_type="bearer",
         expires_in=settings.access_token_expire_minutes * 60,
         user=user_resp,
+    )
+
+
+@router.post("/token/exchange", response_model=TokenExchangeResponse)
+async def token_exchange(
+    request: Request,
+    exchange: TokenExchangeRequest,
+    current_user_data=Depends(get_current_user_with_permissions),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Exchange an external identity for Sinas tokens (RFC 8693 shape).
+
+    A trusted partner backend — authenticated with an API key holding
+    sinas.auth.exchange:all — asserts that it has authenticated the user
+    identified by (provider, subject) and receives a Sinas access + refresh
+    token pair for that user. With auto_provision, unknown users are created
+    with the configured default role.
+
+    The caller is trusted to assert identities: guard the exchange permission
+    like any other admin credential.
+    """
+    _, permissions = current_user_data
+
+    if not check_permission(permissions, "sinas.auth.exchange:all"):
+        set_permission_used(request, "sinas.auth.exchange:all", has_perm=False)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to exchange tokens",
+        )
+
+    set_permission_used(request, "sinas.auth.exchange:all")
+
+    provisioned = False
+    user = await get_user_by_identity(db, exchange.provider, exchange.subject)
+
+    # Fallback: link the identity to an existing user matched by email
+    if not user and exchange.email:
+        user = await get_user_by_email(db, exchange.email)
+
+    if not user:
+        if not exchange.auto_provision:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No user linked to this identity",
+            )
+        if not exchange.email:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="email is required to auto-provision a user",
+            )
+
+        user = User(
+            email=normalize_email(exchange.email),
+            custom_fields=exchange.custom_fields,
+        )
+        db.add(user)
+        await db.flush()
+
+        default_role = await Role.get_by_name(db, settings.token_exchange_default_role)
+        if default_role:
+            db.add(UserRole(role_id=default_role.id, user_id=user.id, active=True))
+        provisioned = True
+    elif exchange.custom_fields:
+        # Shallow merge: partner-provided keys win, admin-set keys survive
+        user.custom_fields = {**(user.custom_fields or {}), **exchange.custom_fields}
+
+    try:
+        await link_user_identity(
+            db, user, exchange.provider, exchange.subject, exchange.metadata
+        )
+    except IdentityConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+
+    user.last_login_at = datetime.now(UTC)
+
+    access_token, refresh_token, user_resp = await _issue_tokens(db, user)
+
+    return TokenExchangeResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        expires_in=settings.access_token_expire_minutes * 60,
+        user=user_resp,
+        provisioned=provisioned,
     )
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -163,6 +163,9 @@ class Settings(BaseSettings):
     # password+otp: both required (password + email-OTP as liveness check)
     auth_mode: str = "otp"
 
+    # Role assigned to users auto-provisioned via POST /auth/token/exchange
+    token_exchange_default_role: str = "GuestUsers"
+
     @field_validator("auth_mode")
     @classmethod
     def _validate_auth_mode(cls, v: str) -> str:

--- a/backend/app/core/permission_registry.py
+++ b/backend/app/core/permission_registry.py
@@ -115,6 +115,12 @@ PERMISSION_REGISTRY: list[dict[str, Any]] = [
         "actions": ["create", "read", "delete"],
     },
     {
+        "resource": "auth",
+        "description": "Token exchange for external auth systems",
+        "actions": ["exchange"],
+        "adminOnly": True,
+    },
+    {
         "resource": "roles",
         "description": "Role & permission management",
         "actions": ["create", "read", "update", "delete", "manage_members", "manage_permissions"],

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -141,6 +141,36 @@ class CreateUserRequest(BaseModel):
     identities: list[UserIdentityInput] = Field(default_factory=list)
 
 
+class TokenExchangeRequest(BaseModel):
+    """
+    Exchange an external identity for Sinas tokens. Called by a trusted
+    partner backend (authenticated with an API key holding
+    sinas.auth.exchange:all) after it has authenticated the user itself.
+    """
+
+    provider: str = Field(..., min_length=1, max_length=255)
+    subject: str = Field(..., min_length=1, max_length=255)
+    # Required for auto-provisioning and used as a linking fallback when the
+    # identity is not yet known but a user with this email exists
+    email: Optional[EmailStr] = None
+    # Snapshot of provider claims; stored on the identity, refreshed each exchange
+    metadata: Optional[dict[str, Any]] = None
+    # Shallow-merged into the user's custom_fields on each exchange
+    custom_fields: Optional[dict[str, Any]] = None
+    # Create the user (with the configured default role) if unknown
+    auto_provision: bool = False
+
+
+class TokenExchangeResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+    expires_in: int
+    user: "AuthUserResponse"
+    # True when this exchange created the user
+    provisioned: bool = False
+
+
 class PermissionCheckRequest(BaseModel):
     """Request to check if user has permission(s)."""
 

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -20,6 +20,7 @@ description: "All configuration options"
 |---|---|---|
 | `AUTH_MODE` | `otp` | One of `otp`, `password`, `password+otp`. See [Authentication](/platform/authentication) for the differences. |
 | `SUPERADMIN_PASSWORD` | _(none)_ | Seed password for the superadmin. Only used when `AUTH_MODE` includes `password`. Setting this and restarting acts as a password-reset escape hatch. |
+| `TOKEN_EXCHANGE_DEFAULT_ROLE` | `GuestUsers` | Role assigned to users auto-provisioned via `POST /auth/token/exchange`. See [Token Exchange](/platform/authentication#token-exchange-bring-your-own-auth). |
 
 ## SMTP
 

--- a/docs-mint/platform/authentication.mdx
+++ b/docs-mint/platform/authentication.mdx
@@ -78,4 +78,35 @@ DELETE /api/v1/api-keys/{id}      # Revoke key
 
 API keys can be used via `Authorization: Bearer <key>` or `X-API-Key: <key>` headers. Keys can have optional expiration dates.
 
+## Token Exchange (bring your own auth)
+
+If your application already authenticates users itself, you don't need to run a second Sinas login flow. Your backend exchanges its knowledge of "who is logged in" for Sinas tokens:
+
+1. An admin links your application's user ids to Sinas users as [external identities](/admin/users-roles#external-identities) — or you let the exchange auto-provision them.
+2. Your backend calls the exchange endpoint with an API key holding the `sinas.auth.exchange:all` permission:
+
+```json
+POST /auth/token/exchange
+X-API-Key: <exchange key>
+{
+  "provider": "acme-app",
+  "subject": "usr_8f3a2",
+  "email": "jane@acme.com",
+  "metadata": {"name": "Jane"},
+  "custom_fields": {"plan": "enterprise"},
+  "auto_provision": true
+}
+```
+
+3. The response contains a normal Sinas access + refresh token pair for that user, which your frontend uses against the runtime API. All ownership scoping (`:own`), permissions, and audit logging apply as if the user had logged in directly.
+
+Behavior details:
+
+- The user is resolved by `(provider, subject)`. If unknown and `email` is given, an existing user with that email is matched and the identity is linked to them.
+- With `auto_provision: true`, unknown users are created and assigned the `TOKEN_EXCHANGE_DEFAULT_ROLE` (default `GuestUsers`). `email` is required to provision.
+- `metadata` is stored on the identity and refreshed on every exchange. `custom_fields` is shallow-merged into the user's custom fields (partner keys win, admin-set keys survive).
+- `provisioned: true` in the response indicates the exchange created the user.
+
+The exchange endpoint trusts the caller to assert identities — treat keys with `sinas.auth.exchange:all` like any other admin credential.
+
 ---

--- a/tests/integration/suites/token_exchange.py
+++ b/tests/integration/suites/token_exchange.py
@@ -1,0 +1,187 @@
+"""Token exchange (external auth integration) tests."""
+
+import uuid
+
+_SUFFIX = uuid.uuid4().hex[:8]
+_PROVIDER = f"partner-app-{_SUFFIX}"
+_SUBJECT = f"ext_{_SUFFIX}"
+_EMAIL = f"test_exchange_{_SUFFIX}@example.com"
+_exchange_key = None
+_exchange_key_id = None
+_provisioned_user_id = None
+_linked_user_id = None
+
+
+def _exchange_headers():
+    return {"X-API-Key": _exchange_key}
+
+
+def teardown(ctx):
+    for user_id in (_provisioned_user_id, _linked_user_id):
+        if user_id:
+            try:
+                ctx.client.delete(f"/api/v1/users/{user_id}", headers=ctx.admin_headers())
+            except Exception:
+                pass
+    if _exchange_key_id:
+        try:
+            ctx.client.delete(
+                f"/api/v1/api-keys/{_exchange_key_id}", headers=ctx.admin_headers()
+            )
+        except Exception:
+            pass
+
+
+def test_01_create_exchange_api_key(ctx):
+    global _exchange_key, _exchange_key_id
+    r = ctx.client.post(
+        "/api/v1/api-keys",
+        headers=ctx.admin_headers(),
+        json={
+            "name": f"exchange-test-{_SUFFIX}",
+            "permissions": {"sinas.auth.exchange:all": True},
+        },
+    )
+    assert r.status_code in (200, 201), f"Create key failed: {r.text}"
+    body = r.json()
+    _exchange_key = body["key"]
+    _exchange_key_id = body["id"]
+
+
+def test_02_unknown_identity_404_without_provision(ctx):
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={"provider": _PROVIDER, "subject": _SUBJECT},
+    )
+    assert r.status_code == 404, f"Expected 404, got {r.status_code}: {r.text}"
+
+
+def test_03_auto_provision_requires_email(ctx):
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={"provider": _PROVIDER, "subject": _SUBJECT, "auto_provision": True},
+    )
+    assert r.status_code == 400, f"Expected 400, got {r.status_code}: {r.text}"
+
+
+def test_04_auto_provision_creates_user(ctx):
+    global _provisioned_user_id
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={
+            "provider": _PROVIDER,
+            "subject": _SUBJECT,
+            "email": _EMAIL,
+            "auto_provision": True,
+            "custom_fields": {"plan": "enterprise"},
+            "metadata": {"source": "integration-test"},
+        },
+    )
+    assert r.status_code == 200, f"Exchange failed: {r.text}"
+    body = r.json()
+    assert body["provisioned"] is True
+    assert body["access_token"] and body["refresh_token"]
+    assert body["user"]["email"] == _EMAIL
+    _provisioned_user_id = body["user"]["id"]
+
+    # The issued access token works as the provisioned user
+    r = ctx.client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {body['access_token']}"}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["email"] == _EMAIL
+
+
+def test_05_second_exchange_reuses_user(ctx):
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={"provider": _PROVIDER, "subject": _SUBJECT},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["provisioned"] is False
+    assert body["user"]["id"] == _provisioned_user_id
+
+
+def test_06_custom_fields_merge_on_exchange(ctx):
+    # Admin sets a field the partner doesn't know about
+    r = ctx.client.patch(
+        f"/api/v1/users/{_provisioned_user_id}",
+        headers=ctx.admin_headers(),
+        json={"custom_fields": {"plan": "enterprise", "admin_note": "keep"}},
+    )
+    assert r.status_code == 200, r.text
+
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={
+            "provider": _PROVIDER,
+            "subject": _SUBJECT,
+            "custom_fields": {"plan": "pro"},
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    r = ctx.client.get(
+        f"/api/v1/users/{_provisioned_user_id}", headers=ctx.admin_headers()
+    )
+    fields = r.json()["custom_fields"]
+    assert fields["plan"] == "pro", f"Partner key not updated: {fields}"
+    assert fields["admin_note"] == "keep", f"Admin key clobbered: {fields}"
+
+
+def test_07_email_fallback_links_identity(ctx):
+    global _linked_user_id
+    email2 = f"test_exchange2_{_SUFFIX}@example.com"
+    r = ctx.client.post(
+        "/api/v1/users", headers=ctx.admin_headers(), json={"email": email2}
+    )
+    assert r.status_code in (200, 201), r.text
+    _linked_user_id = r.json()["id"]
+
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={"provider": _PROVIDER, "subject": f"other_{_SUFFIX}", "email": email2},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["user"]["id"] == _linked_user_id
+    assert r.json()["provisioned"] is False
+
+    # Identity is now linked: same exchange without email resolves the user
+    r = ctx.client.post(
+        "/auth/token/exchange",
+        headers=_exchange_headers(),
+        json={"provider": _PROVIDER, "subject": f"other_{_SUFFIX}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["user"]["id"] == _linked_user_id
+
+
+def test_08_exchange_denied_without_permission(ctx):
+    # Key with an unrelated permission must not be able to exchange
+    r = ctx.client.post(
+        "/api/v1/api-keys",
+        headers=ctx.admin_headers(),
+        json={
+            "name": f"no-exchange-{_SUFFIX}",
+            "permissions": {"sinas.users.read:own": True},
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+    key = r.json()["key"]
+    key_id = r.json()["id"]
+    try:
+        r = ctx.client.post(
+            "/auth/token/exchange",
+            headers={"X-API-Key": key},
+            json={"provider": _PROVIDER, "subject": _SUBJECT},
+        )
+        assert r.status_code == 403, f"Expected 403, got {r.status_code}: {r.text}"
+    finally:
+        ctx.client.delete(f"/api/v1/api-keys/{key_id}", headers=ctx.admin_headers())


### PR DESCRIPTION
Part 2 of #89 — stacked on #92 (base is `feat/user-identities-89`; retarget to `dev` after #92 merges).

## What

`POST /auth/token/exchange` — a partner backend that has already authenticated a user trades that knowledge for Sinas tokens (RFC 8693 shape), so applications with their own auth never run a second login flow:

```json
POST /auth/token/exchange            (X-API-Key with sinas.auth.exchange:all)
{ "provider": "acme-app", "subject": "usr_8f3a2",
  "email": "jane@acme.com", "auto_provision": true,
  "custom_fields": {"plan": "enterprise"} }
→ { access_token, refresh_token, user, provisioned }
```

- Resolution order: `(provider, subject)` identity → existing user by email (identity gets linked) → JIT provision when `auto_provision` (new `TOKEN_EXCHANGE_DEFAULT_ROLE` setting, default `GuestUsers`; email required).
- Identity `metadata` refreshed on every exchange; `custom_fields` shallow-merged so partner-sent keys update while admin-set keys survive.
- New `sinas.auth.exchange` permission (adminOnly) added to the permission registry.
- Issued tokens are ordinary Sinas JWTs — all downstream `:own` scoping, permission checks, and audit logging apply unchanged.

## Verification

Against a locally booted backend (fresh postgres + full migrations): `token_exchange` suite 8/8 — 404 without provisioning, 400 without email, JIT provision + token works on /auth/me, idempotent re-exchange, custom_fields merge semantics, email-fallback linking, 403 for keys lacking the permission. `users_identities` re-run green (9/9).

## Security notes

- The endpoint trusts the caller to assert identities by design; it is gated by a dedicated adminOnly permission so exchange keys can be minted with exactly that one capability.
- No rate limiting beyond global middleware — callers are authenticated privileged backends, not end users. Happy to add if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)