### PR TITLE
feat(llm): track token usage of every LLM call in Postgres

### DIFF
--- a/backend/alembic/versions/l1l2m3u4s5g6_add_llm_usage_table.py
+++ b/backend/alembic/versions/l1l2m3u4s5g6_add_llm_usage_table.py
@@ -1,0 +1,49 @@
+"""add llm_usage table for per-call token tracking
+
+Revision ID: l1l2m3u4s5g6
+Revises: b1a2t3c4h5e6
+Create Date: 2026-07-16
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "l1l2m3u4s5g6"
+down_revision = "b1a2t3c4h5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llm_usage",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("chat_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("message_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("agent", sa.String(511), nullable=True),
+        sa.Column("source", sa.String(50), nullable=True),
+        sa.Column("provider_name", sa.String(255), nullable=True),
+        sa.Column("provider_type", sa.String(50), nullable=True),
+        sa.Column("model", sa.String(255), nullable=True),
+        sa.Column("prompt_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("completion_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("streamed", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("idx_llm_usage_user_created", "llm_usage", ["user_id", "created_at"])
+    op.create_index("idx_llm_usage_created", "llm_usage", ["created_at"])
+    op.create_index(op.f("ix_llm_usage_chat_id"), "llm_usage", ["chat_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("llm_usage")

--- a/backend/app/adapters/openai/endpoints.py
+++ b/backend/app/adapters/openai/endpoints.py
@@ -112,6 +112,7 @@ async def chat_completions(
             request=request,
             provider=provider,
             model_name=model_name,
+            user_id=user_id,
             db=db,
         )
 
@@ -254,10 +255,16 @@ async def _passthrough_mode(
     request: ChatCompletionRequest,
     provider: LLMProvider,
     model_name: str,
+    user_id: str,
     db: AsyncSession,
 ):
     """Handle passthrough mode: direct LLM provider call."""
-    llm_provider = await create_provider(provider.name, model_name, db)
+    llm_provider = await create_provider(
+        provider.name,
+        model_name,
+        db,
+        usage_context={"user_id": user_id, "source": "openai_adapter_passthrough"},
+    )
 
     # Convert messages to dict format
     messages = []
@@ -290,9 +297,15 @@ async def _passthrough_mode(
             **kwargs,
         )
         content = response.get("content", "")
+        usage = response.get("usage") or {}
         return ChatCompletionResponse(
             model=model_name,
             choices=[Choice(message=ChoiceMessage(content=content))],
+            usage=UsageInfo(
+                prompt_tokens=usage.get("prompt_tokens", 0),
+                completion_tokens=usage.get("completion_tokens", 0),
+                total_tokens=usage.get("total_tokens", 0),
+            ),
         )
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from .execution import Execution
 from .file import Collection, ContentFilterEvaluation, File, FileVersion
 from .function import Function, FunctionVersion
 from .llm_provider import LLMProvider
+from .llm_usage import LLMUsage
 
 from .dependency import Dependency
 from .package import Package
@@ -56,6 +57,7 @@ __all__ = [
     "ComponentShare",
     "Connector",
     "LLMProvider",
+    "LLMUsage",
     "DatabaseConnection",
     "DatabaseTrigger",
     "Query",

--- a/backend/app/models/llm_usage.py
+++ b/backend/app/models/llm_usage.py
@@ -1,0 +1,54 @@
+"""Per-call LLM token usage records."""
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base, GUID
+
+
+class LLMUsage(Base):
+    """One row per LLM API call (completion or stream), for usage accounting.
+
+    Intentionally has no foreign keys: rows must survive deletion of the
+    chat, message or user they were attributed to. chat_id/message_id are
+    NULL for calls made outside the chat pipeline (e.g. the OpenAI-compat
+    adapter's passthrough mode).
+    """
+
+    __tablename__ = "llm_usage"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID(), nullable=True)
+    chat_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID(), nullable=True, index=True)
+    message_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID(), nullable=True)
+
+    # "namespace/name" of the agent handling the chat, if any
+    agent: Mapped[Optional[str]] = mapped_column(String(511), nullable=True)
+    # Call site: "chat" | "openai_adapter" | "openai_adapter_passthrough" | ...
+    source: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+
+    # Configured provider name and its type (openai, azure, anthropic, ...)
+    provider_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    provider_type: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+
+    prompt_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    completion_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    latency_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    streamed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Set when the call raised; token counts may then be 0/partial
+    error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("idx_llm_usage_user_created", "user_id", "created_at"),
+        Index("idx_llm_usage_created", "created_at"),
+    )

--- a/backend/app/providers/__init__.py
+++ b/backend/app/providers/__init__.py
@@ -5,8 +5,10 @@ from .factory import create_provider
 from .mistral_provider import MistralProvider
 from .ollama_provider import OllamaProvider
 from .openai_provider import OpenAIProvider
+from .tracking import UsageTrackingProvider
 
 __all__ = [
+    "UsageTrackingProvider",
     "BaseLLMProvider",
     "OpenAIProvider",
     "AzureOpenAIProvider",

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -101,6 +101,11 @@ class AnthropicProvider(BaseLLMProvider):
         current_tool_calls = {}
         current_content = ""
 
+        # Token usage arrives in message_start (input) and message_delta
+        # (cumulative output); emitted on the final chunk.
+        input_tokens = 0
+        output_tokens = 0
+
         async with self.client.messages.stream(**params) as stream:
             async for event in stream:
                 chunk_data = {
@@ -109,7 +114,13 @@ class AnthropicProvider(BaseLLMProvider):
                     "finish_reason": None,
                 }
 
-                if event.type == "content_block_start":
+                if event.type == "message_start":
+                    usage = getattr(event.message, "usage", None)
+                    if usage:
+                        input_tokens = getattr(usage, "input_tokens", 0) or 0
+                        output_tokens = getattr(usage, "output_tokens", 0) or 0
+
+                elif event.type == "content_block_start":
                     if event.content_block.type == "text":
                         pass  # Text will come in content_block_delta
                     elif event.content_block.type == "tool_use":
@@ -161,9 +172,20 @@ class AnthropicProvider(BaseLLMProvider):
                 elif event.type == "message_delta":
                     if hasattr(event.delta, "stop_reason") and event.delta.stop_reason:
                         chunk_data["finish_reason"] = event.delta.stop_reason
+                    usage = getattr(event, "usage", None)
+                    if usage:
+                        if getattr(usage, "output_tokens", None) is not None:
+                            output_tokens = usage.output_tokens
+                        if getattr(usage, "input_tokens", None) is not None:
+                            input_tokens = usage.input_tokens
 
                 elif event.type == "message_stop":
                     chunk_data["finish_reason"] = chunk_data["finish_reason"] or "stop"
+                    chunk_data["usage"] = {
+                        "prompt_tokens": input_tokens,
+                        "completion_tokens": output_tokens,
+                        "total_tokens": input_tokens + output_tokens,
+                    }
 
                 yield chunk_data
 

--- a/backend/app/providers/azure_openai_provider.py
+++ b/backend/app/providers/azure_openai_provider.py
@@ -35,7 +35,9 @@ class AzureOpenAIProvider(OpenAIProvider):
       ``max_completion_tokens``; set ``max_tokens`` for legacy deployments.
     - ``drop_params``: list of parameter names to strip before sending. Set
       ``["temperature"]`` for reasoning deployments (gpt-5/o-series) that only
-      accept the default temperature.
+      accept the default temperature. Streaming requests include
+      ``stream_options`` (for token usage); add it here for gateways or API
+      versions that reject it.
     - ``extra_params``: dict of defaults merged into every request, e.g.
       ``{"reasoning_effort": "medium"}``. Caller-supplied kwargs take precedence.
 

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -70,7 +70,11 @@ class BaseLLMProvider(ABC):
             **kwargs: Additional provider-specific parameters
 
         Yields:
-            Dict chunks with incremental completion data
+            Dict chunks with incremental completion data. Chunks carry
+            'content', 'tool_calls' and 'finish_reason' keys. A chunk near
+            the end of the stream (typically the last one) additionally
+            carries a 'usage' key with the same shape as extract_usage();
+            consumers must treat 'usage' as optional per chunk.
         """
         pass
 

--- a/backend/app/providers/factory.py
+++ b/backend/app/providers/factory.py
@@ -1,5 +1,5 @@
 """Factory for creating LLM provider instances."""
-from typing import Optional
+from typing import Any, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,12 +12,14 @@ from .base import BaseLLMProvider
 from .mistral_provider import MistralProvider
 from .ollama_provider import OllamaProvider
 from .openai_provider import OpenAIProvider
+from .tracking import UsageTrackingProvider
 
 
 async def create_provider(
     provider_name: Optional[str] = None,
     model: Optional[str] = None,
     db: Optional[AsyncSession] = None,
+    usage_context: Optional[dict[str, Any]] = None,
 ) -> BaseLLMProvider:
     """
     Create an LLM provider instance from database configuration.
@@ -26,9 +28,13 @@ async def create_provider(
         provider_name: Name of provider (openai, ollama). If None, uses default provider from DB
         model: Model name (used to auto-detect provider if provider_name not given)
         db: Database session (optional - if not provided, falls back to empty config)
+        usage_context: Attribution for token-usage records (user_id, chat_id,
+            message_id, agent, source). Calls are recorded even without it,
+            just unattributed.
 
     Returns:
-        BaseLLMProvider instance
+        BaseLLMProvider instance, wrapped in UsageTrackingProvider so every
+        complete()/stream() call is recorded in the llm_usage table
 
     Raises:
         ValueError: If provider is unknown or not found
@@ -69,10 +75,10 @@ async def create_provider(
     base_url = provider_config.api_endpoint or None
 
     if provider_type == "openai":
-        return OpenAIProvider(api_key=api_key, base_url=base_url)
+        provider = OpenAIProvider(api_key=api_key, base_url=base_url)
     elif provider_type in ("azure", "azure_openai"):
         config = provider_config.config or {}
-        return AzureOpenAIProvider(
+        provider = AzureOpenAIProvider(
             api_key=api_key,
             azure_endpoint=base_url,
             api_version=config.get("api_version"),
@@ -82,10 +88,17 @@ async def create_provider(
             extra_params=config.get("extra_params"),
         )
     elif provider_type == "mistral":
-        return MistralProvider(api_key=api_key, base_url=base_url)
+        provider = MistralProvider(api_key=api_key, base_url=base_url)
     elif provider_type == "anthropic":
-        return AnthropicProvider(api_key=api_key, base_url=base_url)
+        provider = AnthropicProvider(api_key=api_key, base_url=base_url)
     elif provider_type == "ollama":
-        return OllamaProvider(base_url=base_url or "http://localhost:11434")
+        provider = OllamaProvider(base_url=base_url or "http://localhost:11434")
     else:
         raise ValueError(f"Unknown provider type: {provider_type}")
+
+    return UsageTrackingProvider(
+        inner=provider,
+        provider_name=provider_config.name,
+        provider_type=provider_type,
+        context=usage_context,
+    )

--- a/backend/app/providers/mistral_provider.py
+++ b/backend/app/providers/mistral_provider.py
@@ -102,7 +102,17 @@ class MistralProvider(BaseLLMProvider):
         tool_calls_buffer = {}
 
         async for chunk in stream:
+            # Mistral includes usage on the final stream chunk
+            usage = self.extract_usage(chunk) if getattr(chunk, "usage", None) else None
+
             if not chunk.choices:
+                if usage:
+                    yield {
+                        "content": None,
+                        "tool_calls": None,
+                        "finish_reason": None,
+                        "usage": usage,
+                    }
                 continue
 
             delta = chunk.choices[0].delta
@@ -112,6 +122,9 @@ class MistralProvider(BaseLLMProvider):
                 "tool_calls": None,
                 "finish_reason": chunk.choices[0].finish_reason,
             }
+
+            if usage:
+                chunk_data["usage"] = usage
 
             if delta.tool_calls:
                 # Buffer tool calls

--- a/backend/app/providers/ollama_provider.py
+++ b/backend/app/providers/ollama_provider.py
@@ -121,6 +121,10 @@ class OllamaProvider(BaseLLMProvider):
                             "finish_reason": "stop" if done else None,
                         }
 
+                        if done:
+                            # Final chunk carries prompt_eval_count/eval_count
+                            result["usage"] = self.extract_usage(data)
+
                         if tool_calls_data:
                             result["tool_calls"] = self.format_tool_calls(tool_calls_data)
 

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -94,6 +94,10 @@ class OpenAIProvider(BaseLLMProvider):
         **kwargs,
     ) -> AsyncIterator[dict[str, Any]]:
         """Generate a streaming completion using OpenAI API."""
+        # Ask for token usage on the final chunk. Routed through kwargs so
+        # subclasses can strip it via their param handling (e.g. Azure
+        # drop_params) for gateways that reject stream_options.
+        kwargs.setdefault("stream_options", {"include_usage": True})
         params = self._prepare_params(
             model=model,
             messages=messages,
@@ -107,6 +111,19 @@ class OpenAIProvider(BaseLLMProvider):
         stream = await self.client.chat.completions.create(**params)
 
         async for chunk in stream:
+            usage = self.extract_usage(chunk) if getattr(chunk, "usage", None) else None
+
+            if not chunk.choices:
+                # With include_usage the final chunk has no choices, only usage
+                if usage:
+                    yield {
+                        "content": None,
+                        "tool_calls": None,
+                        "finish_reason": None,
+                        "usage": usage,
+                    }
+                continue
+
             delta = chunk.choices[0].delta
 
             result = {
@@ -114,6 +131,9 @@ class OpenAIProvider(BaseLLMProvider):
                 "tool_calls": None,
                 "finish_reason": chunk.choices[0].finish_reason,
             }
+
+            if usage:
+                result["usage"] = usage
 
             if delta.tool_calls:
                 result["tool_calls"] = self.format_tool_calls(delta.tool_calls)

--- a/backend/app/providers/tracking.py
+++ b/backend/app/providers/tracking.py
@@ -1,0 +1,163 @@
+"""Usage-tracking wrapper around LLM providers.
+
+Every provider returned by ``create_provider()`` is wrapped in
+:class:`UsageTrackingProvider`, which records one ``llm_usage`` row per
+LLM call (token counts, latency, attribution). Recording is fire-and-forget
+on a dedicated DB session: a failed insert never blocks or fails the call,
+and it is isolated from whatever transaction state the caller's session
+is in.
+"""
+import asyncio
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Any, Optional
+
+from .base import BaseLLMProvider
+
+logger = logging.getLogger(__name__)
+
+# Context keys recognized on llm_usage rows (all optional):
+# user_id, chat_id, message_id, agent, source
+_CONTEXT_KEYS = ("user_id", "chat_id", "message_id", "agent", "source")
+
+
+async def _insert_usage(values: dict[str, Any]) -> None:
+    try:
+        from app.core.database import AsyncSessionLocal
+        from app.models import LLMUsage
+
+        async with AsyncSessionLocal() as session:
+            session.add(LLMUsage(**values))
+            await session.commit()
+    except Exception as e:
+        logger.warning(f"Failed to record LLM usage: {e}")
+
+
+class UsageTrackingProvider(BaseLLMProvider):
+    """Delegates to an inner provider and records token usage per call."""
+
+    def __init__(
+        self,
+        inner: BaseLLMProvider,
+        provider_name: Optional[str] = None,
+        provider_type: Optional[str] = None,
+        context: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(api_key=inner.api_key, base_url=inner.base_url)
+        self._inner = inner
+        self._provider_name = provider_name
+        self._provider_type = provider_type
+        self._context = context or {}
+
+    def _record(
+        self,
+        *,
+        model: Optional[str],
+        usage: Optional[dict[str, int]],
+        latency_ms: int,
+        streamed: bool,
+        error: Optional[str] = None,
+    ) -> None:
+        usage = usage or {}
+        values = {
+            "provider_name": self._provider_name,
+            "provider_type": self._provider_type,
+            "model": model,
+            "prompt_tokens": usage.get("prompt_tokens", 0) or 0,
+            "completion_tokens": usage.get("completion_tokens", 0) or 0,
+            "total_tokens": usage.get("total_tokens", 0) or 0,
+            "latency_ms": latency_ms,
+            "streamed": streamed,
+            "error": error,
+        }
+        for key in _CONTEXT_KEYS:
+            if self._context.get(key) is not None:
+                values[key] = self._context[key]
+        try:
+            asyncio.get_running_loop().create_task(_insert_usage(values))
+        except Exception as e:
+            logger.warning(f"Failed to schedule LLM usage recording: {e}")
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        tools: Optional[list[dict[str, Any]]] = None,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        start = time.monotonic()
+        try:
+            response = await self._inner.complete(
+                messages=messages,
+                model=model,
+                tools=tools,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                **kwargs,
+            )
+        except Exception as e:
+            self._record(
+                model=model,
+                usage=None,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                streamed=False,
+                error=str(e)[:2000],
+            )
+            raise
+        self._record(
+            model=model,
+            usage=response.get("usage"),
+            latency_ms=int((time.monotonic() - start) * 1000),
+            streamed=False,
+        )
+        return response
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        tools: Optional[list[dict[str, Any]]] = None,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> AsyncIterator[dict[str, Any]]:
+        start = time.monotonic()
+        usage: Optional[dict[str, int]] = None
+        error: Optional[str] = None
+        try:
+            async for chunk in self._inner.stream(
+                messages=messages,
+                model=model,
+                tools=tools,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                **kwargs,
+            ):
+                if chunk.get("usage"):
+                    usage = chunk["usage"]
+                yield chunk
+        except GeneratorExit:
+            # Consumer abandoned the stream (e.g. client disconnect);
+            # record whatever arrived before the cutoff.
+            error = "stream_abandoned"
+            raise
+        except Exception as e:
+            error = str(e)[:2000]
+            raise
+        finally:
+            self._record(
+                model=model,
+                usage=usage,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                streamed=True,
+                error=error,
+            )
+
+    def format_tool_calls(self, tool_calls: Any) -> list[dict[str, Any]]:
+        return self._inner.format_tool_calls(tool_calls)
+
+    def extract_usage(self, response: Any) -> dict[str, int]:
+        return self._inner.extract_usage(response)

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -294,7 +294,18 @@ class MessageService:
         )
 
         # Create LLM provider
-        llm_provider = await create_provider(provider_name, final_model, self.db)
+        llm_provider = await create_provider(
+            provider_name,
+            final_model,
+            self.db,
+            usage_context={
+                "user_id": user_id,
+                "chat_id": chat_id,
+                "message_id": user_message.id,
+                "agent": f"{agent.namespace}/{agent.name}" if agent else None,
+                "source": "chat",
+            },
+        )
 
         # If no model specified, use the provider's default model
         if not final_model:
@@ -394,6 +405,11 @@ class MessageService:
             **llm_kwargs,
         )
         end_time = datetime.now(UTC)
+
+        _usage = response.get("usage") or {}
+        if _usage.get("total_tokens"):
+            _llm_span.set_attribute("gen_ai.usage.input_tokens", _usage.get("prompt_tokens", 0))
+            _llm_span.set_attribute("gen_ai.usage.output_tokens", _usage.get("completion_tokens", 0))
 
         await self._log_request(
             user_id=user_id,
@@ -583,6 +599,7 @@ class MessageService:
         """Stream LLM response."""
         full_content = ""
         tool_calls_list = []
+        stream_usage = None
 
         clean_tools = strip_tool_metadata(tools)
 
@@ -593,6 +610,9 @@ class MessageService:
             temperature=final_temperature,
             max_tokens=max_tokens,
         ):
+            if chunk.get("usage"):
+                stream_usage = chunk["usage"]
+
             if chunk.get("content"):
                 if isinstance(chunk["content"], str):
                     full_content += chunk["content"]
@@ -652,6 +672,9 @@ class MessageService:
                 otel_attr("user_id"): user_id,
                 otel_attr("labels"): _labels,
             })
+            if stream_usage and stream_usage.get("total_tokens"):
+                _s.set_attribute("gen_ai.usage.input_tokens", stream_usage.get("prompt_tokens", 0))
+                _s.set_attribute("gen_ai.usage.output_tokens", stream_usage.get("completion_tokens", 0))
             _s.end()
         except Exception:
             pass
@@ -1000,7 +1023,22 @@ class MessageService:
                 message_dict["name"] = msg.name
             updated_messages.append(message_dict)
 
-        llm_provider = await create_provider(provider, model, self.db)
+        _agent_label = (
+            f"{chat.agent_namespace}/{chat.agent_name}"
+            if chat and chat.agent_namespace and chat.agent_name
+            else None
+        )
+        llm_provider = await create_provider(
+            provider,
+            model,
+            self.db,
+            usage_context={
+                "user_id": user_id,
+                "chat_id": chat_id,
+                "agent": _agent_label,
+                "source": "chat",
+            },
+        )
 
         clean_tools = strip_tool_metadata(tools)
 

--- a/backend/tests/unit/test_llm_usage_tracking.py
+++ b/backend/tests/unit/test_llm_usage_tracking.py
@@ -1,0 +1,282 @@
+"""Unit tests for LLM token-usage tracking.
+
+Covers the UsageTrackingProvider wrapper (recording on complete, stream,
+errors and abandoned streams) and the usage emission added to the provider
+stream() implementations. No network calls: provider clients are stubbed.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.providers import tracking
+from app.providers.anthropic_provider import AnthropicProvider
+from app.providers.azure_openai_provider import AzureOpenAIProvider
+from app.providers.base import BaseLLMProvider
+from app.providers.mistral_provider import MistralProvider
+from app.providers.openai_provider import OpenAIProvider
+from app.providers.tracking import UsageTrackingProvider
+
+USAGE = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+
+
+class FakeProvider(BaseLLMProvider):
+    """Inner provider stub with scriptable chunks/usage/errors."""
+
+    def __init__(self, chunks=None, usage=None, complete_error=None, fail_after=None):
+        super().__init__(api_key="k")
+        self._chunks = chunks or []
+        self._usage = usage
+        self._complete_error = complete_error
+        self._fail_after = fail_after
+
+    async def complete(self, messages, model, tools=None, temperature=0.7, max_tokens=None, **kwargs):
+        if self._complete_error:
+            raise self._complete_error
+        return {"content": "hi", "tool_calls": None, "usage": self._usage, "finish_reason": "stop"}
+
+    async def stream(self, messages, model, tools=None, temperature=0.7, max_tokens=None, **kwargs):
+        for i, chunk in enumerate(self._chunks):
+            if self._fail_after is not None and i >= self._fail_after:
+                raise RuntimeError("boom")
+            yield chunk
+
+    def format_tool_calls(self, tool_calls):
+        return []
+
+    def extract_usage(self, response):
+        return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Capture llm_usage rows instead of writing to the database."""
+    records = []
+
+    async def fake_insert(values):
+        records.append(values)
+
+    monkeypatch.setattr(tracking, "_insert_usage", fake_insert)
+    return records
+
+
+async def _drain_tasks():
+    # Let fire-and-forget recording tasks run
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+async def test_complete_records_usage_and_context(recorded):
+    provider = UsageTrackingProvider(
+        FakeProvider(usage=USAGE),
+        provider_name="my-openai",
+        provider_type="openai",
+        context={"user_id": "u1", "chat_id": "c1", "agent": "ns/agent", "source": "chat"},
+    )
+
+    response = await provider.complete(messages=[], model="gpt-x")
+    await _drain_tasks()
+
+    assert response["usage"] == USAGE
+    assert len(recorded) == 1
+    row = recorded[0]
+    assert row["prompt_tokens"] == 10
+    assert row["completion_tokens"] == 5
+    assert row["total_tokens"] == 15
+    assert row["streamed"] is False
+    assert row["error"] is None
+    assert row["model"] == "gpt-x"
+    assert row["provider_name"] == "my-openai"
+    assert row["provider_type"] == "openai"
+    assert row["user_id"] == "u1"
+    assert row["chat_id"] == "c1"
+    assert row["agent"] == "ns/agent"
+    assert row["source"] == "chat"
+    assert row["latency_ms"] >= 0
+
+
+async def test_complete_error_recorded_and_reraised(recorded):
+    provider = UsageTrackingProvider(
+        FakeProvider(complete_error=RuntimeError("api down")), provider_name="p", provider_type="openai"
+    )
+
+    with pytest.raises(RuntimeError, match="api down"):
+        await provider.complete(messages=[], model="m")
+    await _drain_tasks()
+
+    assert len(recorded) == 1
+    assert recorded[0]["error"] == "api down"
+    assert recorded[0]["total_tokens"] == 0
+
+
+async def test_stream_records_usage_from_final_chunk(recorded):
+    chunks = [
+        {"content": "hel", "tool_calls": None, "finish_reason": None},
+        {"content": "lo", "tool_calls": None, "finish_reason": "stop"},
+        {"content": None, "tool_calls": None, "finish_reason": None, "usage": USAGE},
+    ]
+    provider = UsageTrackingProvider(FakeProvider(chunks=chunks), provider_name="p", provider_type="openai")
+
+    seen = [c async for c in provider.stream(messages=[], model="m")]
+    await _drain_tasks()
+
+    assert seen == chunks  # chunks pass through unchanged
+    assert len(recorded) == 1
+    row = recorded[0]
+    assert row["streamed"] is True
+    assert row["error"] is None
+    assert row["total_tokens"] == 15
+
+
+async def test_stream_error_recorded_with_partial_usage(recorded):
+    chunks = [{"content": "a", "tool_calls": None, "finish_reason": None}]
+    provider = UsageTrackingProvider(
+        FakeProvider(chunks=chunks + chunks, fail_after=1), provider_name="p", provider_type="openai"
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async for _ in provider.stream(messages=[], model="m"):
+            pass
+    await _drain_tasks()
+
+    assert len(recorded) == 1
+    assert recorded[0]["error"] == "boom"
+    assert recorded[0]["streamed"] is True
+    assert recorded[0]["total_tokens"] == 0
+
+
+async def test_abandoned_stream_recorded(recorded):
+    chunks = [
+        {"content": "a", "tool_calls": None, "finish_reason": None},
+        {"content": "b", "tool_calls": None, "finish_reason": None},
+    ]
+    provider = UsageTrackingProvider(FakeProvider(chunks=chunks), provider_name="p", provider_type="openai")
+
+    agen = provider.stream(messages=[], model="m")
+    await agen.__anext__()
+    await agen.aclose()  # consumer walks away mid-stream
+    await _drain_tasks()
+
+    assert len(recorded) == 1
+    assert recorded[0]["error"] == "stream_abandoned"
+    assert recorded[0]["streamed"] is True
+
+
+# --- Provider stream() usage emission ---
+
+
+def _openai_style_provider(provider, chunks, captured):
+    async def fake_create(**params):
+        captured.update(params)
+
+        async def gen():
+            for c in chunks:
+                yield c
+
+        return gen()
+
+    provider.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+    )
+    return provider
+
+
+async def test_openai_stream_requests_and_emits_usage():
+    content_chunk = SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(content="hi", tool_calls=None), finish_reason=None)],
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(prompt_tokens=7, completion_tokens=3, total_tokens=10),
+    )
+    captured = {}
+    provider = _openai_style_provider(OpenAIProvider(api_key="k"), [content_chunk, usage_chunk], captured)
+
+    out = [c async for c in provider.stream(messages=[{"role": "user", "content": "x"}], model="m")]
+
+    assert captured["stream_options"] == {"include_usage": True}
+    assert out[0]["content"] == "hi"
+    assert "usage" not in out[0]
+    assert out[-1]["usage"] == {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+
+
+async def test_azure_drop_params_strips_stream_options():
+    provider = AzureOpenAIProvider(
+        api_key="k",
+        azure_endpoint="https://example.openai.azure.com/",
+        drop_params=["stream_options"],
+    )
+    captured = {}
+    chunk = SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(content="hi", tool_calls=None), finish_reason="stop")],
+        usage=None,
+    )
+    _openai_style_provider(provider, [chunk], captured)
+
+    out = [c async for c in provider.stream(messages=[{"role": "user", "content": "x"}], model="dep")]
+
+    assert "stream_options" not in captured
+    assert out[0]["content"] == "hi"
+
+
+async def test_mistral_stream_emits_usage_from_final_chunk():
+    content_chunk = SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(content="hi", tool_calls=None), finish_reason=None)],
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+    )
+    captured = {}
+    provider = _openai_style_provider(MistralProvider(api_key="k"), [content_chunk, usage_chunk], captured)
+
+    out = [c async for c in provider.stream(messages=[{"role": "user", "content": "x"}], model="m")]
+
+    assert out[-1]["usage"] == {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6}
+
+
+class _FakeAnthropicStream:
+    def __init__(self, events):
+        self._events = events
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for e in self._events:
+            yield e
+
+
+async def test_anthropic_stream_emits_usage_on_message_stop():
+    events = [
+        SimpleNamespace(
+            type="message_start",
+            message=SimpleNamespace(usage=SimpleNamespace(input_tokens=12, output_tokens=1)),
+        ),
+        SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(text="hi"), index=0),
+        SimpleNamespace(
+            type="message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage=SimpleNamespace(output_tokens=9, input_tokens=None),
+        ),
+        SimpleNamespace(type="message_stop"),
+    ]
+    provider = AnthropicProvider(api_key="k")
+    provider.client = SimpleNamespace(
+        messages=SimpleNamespace(stream=lambda **params: _FakeAnthropicStream(events))
+    )
+
+    out = [c async for c in provider.stream(messages=[{"role": "user", "content": "x"}], model="m")]
+
+    final = out[-1]
+    assert final["usage"] == {"prompt_tokens": 12, "completion_tokens": 9, "total_tokens": 21}
+    # stop_reason from message_delta still surfaces
+    assert any(c["finish_reason"] == "end_turn" for c in out)


### PR DESCRIPTION
## Summary

Adds per-call LLM token tracking at a single chokepoint, so every provider call (chat, streaming, tool-loop iterations, and the OpenAI-compat adapter) is recorded in Postgres.

- **`llm_usage` table** (+ alembic migration `l1l2m3u4s5g6`): one row per LLM call — token counts, latency, provider/model, streamed flag, error, and attribution (user, chat, message, agent, source). Intentionally no FKs so accounting rows survive chat/user deletion; nullable `chat_id`/`message_id` cover passthrough traffic.
- **`UsageTrackingProvider` wrapper**: `create_provider()` now always returns the provider wrapped. Recording is fire-and-forget on a dedicated DB session — a failed insert never blocks or rolls back the chat pipeline. Abandoned streams (client disconnect) and errored calls are recorded with an error marker.
- **Streaming usage emission** (previously thrown away): OpenAI/Azure request `stream_options.include_usage` (Azure deployments can strip it via `drop_params`), Anthropic reads the `message_start`/`message_delta` usage events it was discarding, Mistral reads its native final-chunk usage, Ollama reads the `done`-chunk eval counts. Stream chunks may now carry an optional `usage` key (documented in `BaseLLMProvider`).
- **Call sites** pass attribution context; the OpenAI-compat passthrough response now returns real token usage instead of hardcoded zeros; existing OTel `llm.call` spans gain `gen_ai.usage.*` attributes.

Addresses #91 (passthrough-mode calls are now recorded with user attribution; the issue can close once this reaches `main`).

## Testing

- 9 new unit tests (`tests/unit/test_llm_usage_tracking.py`) covering the wrapper (complete/stream/error/abandoned-stream recording) and per-provider stream usage emission — all passing, no network calls.
- Full unit suite otherwise unchanged (pre-existing DB-dependent errors occur identically on clean `dev`).
- Alembic chain verified: single head `l1l2m3u4s5g6`.
- Not verified: applying the migration against a live Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)