### PR TITLE
Studio: business-analyst app for projects, assistants, and workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 *
 !console
 !studio/app
+!studio/packages
 console/node_modules
 console/dist
 studio/app/node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Applies to builds whose context is the repo root (console/Dockerfile).
+# Backend images build from ./backend and use backend/.dockerignore instead.
+# Allowlist: only what console/Dockerfile actually copies.
+*
+!console
+!studio/app
+console/node_modules
+console/dist
+studio/app/node_modules
+studio/app/dist

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -30,7 +30,8 @@ jobs:
             context: ./backend
             dockerfile: ./backend/Dockerfile.executor
           - name: console
-            context: ./console
+            # Repo-root context: the console image bundles studio/app at /studio/
+            context: .
             dockerfile: ./console/Dockerfile
 
     steps:

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,18 @@
 {$DOMAIN} {
-    reverse_proxy backend:8000 {
-        lb_policy round_robin
-        health_uri /health
-        health_interval 10s
-        health_timeout 5s
+    # Studio is bundled into the console image and served same-origin with
+    # the API so it can detect the workspace via GET /info (studio/README.md §8)
+    @studio path /studio /studio/*
+    handle @studio {
+        reverse_proxy console:80
+    }
+
+    handle {
+        reverse_proxy backend:8000 {
+            lb_policy round_robin
+            health_uri /health
+            health_interval 10s
+            health_timeout 5s
+        }
     }
 
     @notComponents not path /components/*

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -44,12 +44,15 @@ RUN npm run build
 # Stage 2: Build Studio (served under /studio/, see studio/README.md §8)
 FROM node:20-alpine AS studio-builder
 
-WORKDIR /studio
+# Mirror the repo layout: the app imports ../../packages/studio-runtime.yaml
+# (relative to studio/app) so setup installs a version-matched package.
+WORKDIR /src/studio/app
 
 COPY studio/app/package.json studio/app/package-lock.json ./
 RUN npm ci
 
 COPY studio/app/ ./
+COPY studio/packages/ /src/studio/packages/
 RUN npm run build
 
 # Stage 3: Serve with Nginx
@@ -57,7 +60,7 @@ FROM nginx:alpine
 
 # Copy built files from builders
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY --from=studio-builder /studio/dist /usr/share/nginx/html/studio
+COPY --from=studio-builder /src/studio/app/dist /usr/share/nginx/html/studio
 
 # Copy nginx configuration
 COPY console/nginx.conf /etc/nginx/conf.d/default.conf

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -1,4 +1,8 @@
-# Stage 1: Build the frontend
+# Build context is the REPO ROOT (not ./console) so this image can bundle
+# the Studio app alongside the console. Build with:
+#   docker build -f console/Dockerfile .
+
+# Stage 1: Build the console
 FROM node:20-alpine AS builder
 
 # Set to "true" to use locally built @sinas/sdk and @sinas/ui instead of npm
@@ -7,10 +11,10 @@ ARG USE_LOCAL_PACKAGES=false
 WORKDIR /app
 
 # Copy package.json only (lockfile has file: paths that get rewritten)
-COPY package.json ./
+COPY console/package.json ./
 
 # Copy local packages (only used when USE_LOCAL_PACKAGES=true)
-COPY sinas-sdk.tgz* sinas-ui.tgz* ./
+COPY console/sinas-sdk.tgz* console/sinas-ui.tgz* ./
 
 # Replace file: deps with either local tarballs or npm latest
 RUN if [ "$USE_LOCAL_PACKAGES" = "true" ]; then \
@@ -25,26 +29,38 @@ RUN if [ "$USE_LOCAL_PACKAGES" = "true" ]; then \
 RUN npm install
 
 # Copy source code
-COPY src ./src
-COPY public ./public
-COPY index.html ./
-COPY tsconfig*.json ./
-COPY vite.config.ts ./
-COPY postcss.config.js ./
-COPY tailwind.config.js ./
-COPY eslint.config.js ./
+COPY console/src ./src
+COPY console/public ./public
+COPY console/index.html ./
+COPY console/tsconfig.json console/tsconfig.app.json console/tsconfig.node.json ./
+COPY console/vite.config.ts ./
+COPY console/postcss.config.js ./
+COPY console/tailwind.config.js ./
+COPY console/eslint.config.js ./
 
 # Build the application
 RUN npm run build
 
-# Stage 2: Serve with Nginx
+# Stage 2: Build Studio (served under /studio/, see studio/README.md §8)
+FROM node:20-alpine AS studio-builder
+
+WORKDIR /studio
+
+COPY studio/app/package.json studio/app/package-lock.json ./
+RUN npm ci
+
+COPY studio/app/ ./
+RUN npm run build
+
+# Stage 3: Serve with Nginx
 FROM nginx:alpine
 
-# Copy built files from builder
+# Copy built files from builders
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=studio-builder /studio/dist /usr/share/nginx/html/studio
 
 # Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY console/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port
 EXPOSE 80

--- a/console/nginx.conf
+++ b/console/nginx.conf
@@ -21,6 +21,14 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Studio (bundled BA app) - SPA fallback within its own prefix
+    location = /studio {
+        return 301 /studio/;
+    }
+    location /studio/ {
+        try_files $uri $uri/ /studio/index.html;
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/console/src/components/Layout.tsx
+++ b/console/src/components/Layout.tsx
@@ -29,6 +29,8 @@ import {
   HardDrive,
   KeyRound,
   Plug,
+  Sparkles,
+  ExternalLink,
 } from 'lucide-react';
 import { useState } from 'react';
 
@@ -164,8 +166,8 @@ export function Layout() {
             ))}
           </nav>
 
-          {/* Chat History link */}
-          <div className="px-4 pb-2">
+          {/* Chat History + Studio links */}
+          <div className="px-4 pb-2 space-y-1">
             <Link
               to="/chats"
               onClick={() => setSidebarOpen(false)}
@@ -174,6 +176,17 @@ export function Layout() {
               <MessageSquare className="w-4 h-4 mr-2" />
               Chat History
             </Link>
+            {/* Studio is bundled with the console and served same-origin at /studio/ */}
+            <a
+              href="/studio/"
+              target="_blank"
+              rel="noopener"
+              className="flex items-center px-3 py-1.5 text-xs font-medium text-gray-500 hover:text-gray-300 hover:bg-white/5 rounded-md transition-colors"
+            >
+              <Sparkles className="w-4 h-4 mr-2" />
+              Open Studio
+              <ExternalLink className="w-3 h-3 ml-auto" />
+            </a>
           </div>
 
           {/* User menu */}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,7 +78,9 @@ services:
 
   console:
     build:
-      context: ./console
+      # Repo-root context so the image can bundle studio/app (see console/Dockerfile)
+      context: .
+      dockerfile: console/Dockerfile
       args:
         USE_LOCAL_PACKAGES: ${USE_LOCAL_PACKAGES:-false}
     ports:

--- a/studio/README.md
+++ b/studio/README.md
@@ -170,10 +170,9 @@ platform; extract to its own repo only if that ever changes):
 ```
 studio/
 ├── README.md          # this contract
-├── app/               # the web app (to be scaffolded)
-├── packages/
-│   └── studio-runtime.yaml
-└── design/            # branch-only; dropped before merge
+├── app/               # the web app
+└── packages/
+    └── studio-runtime.yaml
 ```
 
 **Distribution (settled):** Studio ships OSS in this repo, on the platform's

--- a/studio/README.md
+++ b/studio/README.md
@@ -151,6 +151,16 @@ Ordered by value to Studio:
    recognition.
 5. **Permissions on `/auth/me`** — lets Studio adapt UI to the caller's role
    instead of discovering by 403.
+6. **Record admission failures as executions** — found during live testing:
+   when a webhook fires but the platform can't run the function (e.g.
+   "No workers available"), the caller gets a 500 and **no execution row is
+   written**. Studio's Runs rail honestly shows "no runs recorded", but the
+   workflow silently swallowed a real event. Failed admission should create
+   a failed execution so it's visible after the fact.
+7. **`@sinas/cli install` can't pass variables** — `install` reads
+   `opts.variables` but registers no `--variables`/`--set` option, so any
+   package with required variables (like studio-runtime's `WORKSPACE_URL`)
+   can't be installed via the CLI. Needs a `--set KEY=VALUE` flag.
 
 ## 8. Repository layout & delivery
 

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,0 +1,172 @@
+# Sinas Studio
+
+Studio is a standalone web app for **business analysts** to build and operate
+AI assistants and automations on a Sinas workspace — without touching Python,
+SQL, YAML, or the admin console. It connects to an existing Sinas instance
+over the public API and works entirely within the permissions of a "Studio"
+role.
+
+This README is the founding design contract. It records the decisions made
+before the first line of code so that every screen and feature can be checked
+against them. Change the contract deliberately, not by drift.
+
+---
+
+## 1. Who does what: the BA / admin boundary
+
+**Principle:** if it can be done by *choosing, naming, parameterizing,
+scheduling, or writing natural language* → BA. If it requires *code, SQL,
+schemas, shared credentials, or granting authority* → admin. The BA composes
+capabilities; the admin authors them.
+
+| Resource | Admin | BA (Studio) |
+|---|---|---|
+| Functions | Authors all Python; ships adapter functions | Never creates/edits function rows. "Creating" a router/fan-out/webhook step = creating a *binding* to an admin function with parameters (`default_values`, `inputData`, `functionParameters`) |
+| Connectors | Defines (base URL, auth scheme, operations) | Attaches to agents, selects operations, supplies own key (private secret overrides shared) |
+| Secrets | Creates/rotates shared credentials | Sets values (never reads any) |
+| Agents | Everything | Full create/edit: instructions, tools, knowledge, memory, inputs. Model from an admin-curated list; sampling params hidden |
+| Skills | Everything | Authors freely (markdown guidance, zero blast radius) |
+| Schedules | Everything | Create/edit/toggle |
+| Webhooks | Any | Create against adapter functions with parameters. Public (`requiresAuth: false`) endpoints allowed **with a prominent UI warning** and a permanent "public" badge |
+| CDC triggers | Defines DB connections & exposed tables | Creates triggers on exposed tables → adapter functions |
+| Queries (SQL) | Authors | Attaches/parameterizes |
+| Collections / documents | Any | Creates collections, uploads documents |
+| Projects (manifests) | Any | Creates/manages |
+| Packages, LLM providers, users/roles, DB connections, system | Yes | **No** — note: packages contain code, so BAs never install packages; admins install integrations, BAs compose them |
+
+Posture: BAs are **trusted members of the org**, not untrusted users. No
+per-project permission scoping — BAs see the whole workspace. The boundary is
+enforced by a single **"Studio" role** in existing Sinas RBAC (broad read;
+write on agents, skills, schedules, webhooks, collections, stores, private
+secret values, manifests). No backend changes required to enforce it.
+
+## 2. Concepts, translated
+
+Studio never shows platform nouns. The mapping is fixed:
+
+| Sinas | Studio | Notes |
+|---|---|---|
+| Agent | **Assistant** | |
+| System prompt | **Instructions** | plain text field |
+| Skill (`enabledSkills` + `preload`) | **Guidance** | chips under Instructions: "always" (preload) / "when needed" |
+| Connector / composable function / query | **Tool** | capability cards with per-action toggles |
+| Collection | **Files** | shared library (read-only) or the assistant's **own file space** (auto-created, read & write) |
+| Store | **Memory** | predefined type: "Conversation memory — remembers between conversations" (auto-created private store); shared stores attachable |
+| `input_schema` + templating | **Inputs** | `@tokens` (e.g. `@customer_tier`), typed rows (text/choice/…), insertable into instructions by typing `@`. Never shows JSON schema or Jinja |
+| Webhook / schedule / CDC trigger | **Workflow** | trigger → action strip |
+| Manifest (+ future `layout` column) | **Project** | a board/grouping; membership = `required_resources` |
+| Execution | **Run** | |
+
+## 3. Screens (v1 — exactly five)
+
+1. **Connect** — workspace URL + sign-in; detects the companion package and
+   degrades gracefully (see §6).
+2. **Projects** — list of manifests-as-projects; create = create manifest.
+3. **Project home** — deliberately boring: lists the project's assistants and
+   workflows with health/status. No project-level canvas in v1.
+4. **Assistant editor** — form + permanent live **test chat** (right, ~40%).
+   Left: plain-language capability summary header → Instructions (with
+   Guidance chips + per-field AI assist) → Tools → Files & memory → Inputs →
+   trigger footnotes linking to workflows. Edits apply live (autosave).
+   Hidden entirely: schemas, hooks, status templates, timeouts, temperature.
+5. **Workflow editor** — horizontal strip: **When** card (trigger; typed
+   config; public-URL warning) → **Then** card (assistant or function, with
+   `@token` request template and explicit input mapping). Right rail: **Runs**
+   (per-fire history, failures explained honestly) + "send a test event".
+   The **on/off switch is the publish moment** — workflows assemble inert.
+
+Runtime constraints are baked into the UI: chat → assistant; webhook →
+function (via adapter → assistant); schedule → either. Only valid flows are
+constructible.
+
+Design mocks for screens 4–5 live in `design/mocks/` **on the design branch
+only — never merged**; they are throwaway HTML used to settle these decisions.
+
+## 4. The honesty rule
+
+**Every string on screen names its source field.** Trigger titles come from
+`webhook.description` (BA-authored at creation) → adapter function description
+→ generic fallback. "via X" is the prettified target function name. "Accepts
+fields" is the adapter's `input_schema`. Failure messages state only what the
+platform knows (e.g. schema-validation misses); anything AI-phrased —
+"explain this error", "improve instructions" — is generated **on demand and
+labeled**, never pre-rendered. No fiction in the UI.
+
+## 5. The adapter contract (webhook → assistant, until native support)
+
+An **adapter** is an admin-authored function that bridges a trigger to an
+assistant. The contract is declarative:
+
+- Its `input_schema` declares the trigger payload (this powers "accepts
+  fields" and `@token` availability).
+- It accepts reserved parameters — `studio_agent`, `studio_message_template`,
+  and an input-mapping object — supplied via the webhook's `default_values`.
+  Reserved names are prefixed to avoid collisions.
+- **Recognition:** a function that declares the reserved parameters *is* an
+  adapter — detection reads the same schema the runtime executes; no
+  namespace, description, or tag heuristics. A first-class `role` field on
+  Function may formalize this later.
+- One generic adapter covers all plain webhook→assistant workflows;
+  integration-specific adapters (Jira, Slack Events) add only signature
+  verification and payload normalization.
+
+This is bridge infrastructure: when Sinas gains **native trigger→agent
+targets** (see §7), the template moves onto the webhook itself and generic
+adapters retire.
+
+## 6. The companion package (`studio-runtime`)
+
+Studio's AI features require resources that vanilla Sinas doesn't have. They
+ship as a versioned `SinasPackage` in this directory:
+
+- `studio/copilot` agent — AI assist (improve/draft instructions, extract
+  guidance into a skill), "explain this error", plain-language read-backs.
+- `studio/ask-agent` — the generic adapter function (§5).
+
+Rules:
+- **Installation is an admin act** (`packages.install` is admin-only): the
+  one-time "connect Studio to this workspace" setup installs the package and
+  creates the Studio role.
+- **Graceful degradation:** Studio must run against vanilla Sinas. AI buttons
+  render as "needs Studio setup — ask your admin" when `studio/copilot` is
+  absent; webhook-workflow creation is hidden when no adapter exists;
+  everything else works regardless.
+- **Versioning:** the app pins the `studio-runtime` version it requires,
+  checks on connect, and offers admins a one-click upgrade (idempotent apply
+  makes reinstall safe).
+
+## 7. Sinas backend follow-ups (tracked, not required for v1)
+
+Ordered by value to Studio:
+
+1. **Native trigger→agent targets** on webhooks and CDC triggers
+   (polymorphic `{function | agent}` + payload→input mapping; sync mode
+   returns the agent reply). Retires generic adapters; also the zero-glue
+   enabler for Slack/Telegram message hooks.
+2. **`layout` column on manifests** (nullable JSON) — project board state;
+   Studio uses local storage until then.
+3. **Manifest validator type map** — extend `RESOURCE_TYPE_MAP` beyond
+   agent/function/skill/collection so project health checks cover all types.
+4. **`role` field on Function** (`webhook_adapter`, …) — formalizes adapter
+   recognition.
+5. **Permissions on `/auth/me`** — lets Studio adapt UI to the caller's role
+   instead of discovering by 403.
+
+## 8. Repository layout & delivery
+
+Studio lives in this monorepo (same license and release train as the
+platform; extract to its own repo only if that ever changes):
+
+```
+studio/
+├── README.md          # this contract
+├── app/               # the web app (to be scaffolded)
+├── packages/
+│   └── studio-runtime.yaml
+└── design/            # branch-only; dropped before merge
+```
+
+Built and shipped as its own image alongside `console` (see
+`.github/workflows/build-images.yml` and docker-compose when wired). It is a
+separate deployment with its own URL and a connect-to-workspace flow — 
+standalone is a deployment property, not a repo property.

--- a/studio/README.md
+++ b/studio/README.md
@@ -166,7 +166,37 @@ studio/
 └── design/            # branch-only; dropped before merge
 ```
 
-Built and shipped as its own image alongside `console` (see
-`.github/workflows/build-images.yml` and docker-compose when wired). It is a
-separate deployment with its own URL and a connect-to-workspace flow — 
-standalone is a deployment property, not a repo property.
+**Distribution (settled):** Studio ships OSS in this repo, on the platform's
+release train — in-repo bundling makes version skew structurally impossible
+for self-hosters. Default serving is **bundled**: the app builds with base
+`/studio/` and is served from the workspace's own origin (same-origin, no
+CORS, no extra service). When served this way it detects the workspace via
+`GET /info` on its own origin, skips the workspace step, and tucks
+"connect to a different workspace" behind an unobtrusive link. A standalone
+deployment (own domain) and a future managed/hosted Studio are distribution
+options built from the same code; the managed variant handles version skew
+via `/info` version detection + graceful degradation, and is a roadmap item,
+not an architecture decision.
+
+## 9. Local development & testing
+
+Against a local Sinas (backend on `http://localhost:8000`, CORS is open):
+
+```bash
+cd studio/app && npm install && npm run dev
+# open http://localhost:5180/studio/ → enter http://localhost:8000 as the workspace
+```
+
+Install the companion package (admin credentials; the workspace URL variable
+must be reachable *from function sandboxes* — for local Docker that is
+http://host.docker.internal:8000):
+
+```bash
+mkdir -p /tmp/studio-pkg && cp studio/packages/studio-runtime.yaml /tmp/studio-pkg/sinas-package.yaml
+cd /tmp/studio-pkg && npx @sinas/cli login && npx @sinas/cli validate && npx @sinas/cli install
+```
+
+Still to wire for the bundled deployment: building `studio/app/dist` into the
+console image needs the console Docker build context widened to the repo root
+(today it is `./console`, which cannot see `studio/`) plus one nginx
+`location /studio/` block with an SPA fallback.

--- a/studio/README.md
+++ b/studio/README.md
@@ -161,6 +161,11 @@ Ordered by value to Studio:
    `opts.variables` but registers no `--variables`/`--set` option, so any
    package with required variables (like studio-runtime's `WORKSPACE_URL`)
    can't be installed via the CLI. Needs a `--set KEY=VALUE` flag.
+8. **Package uninstall breaks on function version history** — found during
+   live testing: `PackageService.uninstall` bulk-deletes managed functions
+   without first removing their `function_versions` rows, so uninstalling
+   any package containing a function that has version history 500s on the
+   foreign key. Delete versions first (or cascade).
 
 ## 8. Repository layout & delivery
 

--- a/studio/README.md
+++ b/studio/README.md
@@ -206,7 +206,19 @@ mkdir -p /tmp/studio-pkg && cp studio/packages/studio-runtime.yaml /tmp/studio-p
 cd /tmp/studio-pkg && npx @sinas/cli login && npx @sinas/cli validate && npx @sinas/cli install
 ```
 
-Still to wire for the bundled deployment: building `studio/app/dist` into the
-console image needs the console Docker build context widened to the repo root
-(today it is `./console`, which cannot see `studio/`) plus one nginx
-`location /studio/` block with an SPA fallback.
+**Bundled deployment (wired):** the console image builds Studio in its own
+stage and serves it at `/studio/`:
+
+- `console/Dockerfile` builds with the **repo root** as context
+  (`docker build -f console/Dockerfile .`) so it can see `studio/app`; the
+  root `.dockerignore` allowlists only `console/` and `studio/app/`.
+- `console/nginx.conf` serves `/studio/` with its own SPA fallback
+  (`/studio` 301-redirects to `/studio/`).
+- The production `Caddyfile` routes `{$DOMAIN}/studio*` to the console
+  container **on the main domain** — same origin as the API, which is what
+  makes the workspace auto-detect via `GET /info` work.
+- `docker-compose.dev.yml` and the CI image matrix use the widened context.
+
+On the dev compose (no Caddy), bundled Studio is at
+`http://localhost:51245/studio/` — cross-origin to the backend, so it falls
+back to the standalone connect flow, which is correct.

--- a/studio/app/.gitignore
+++ b/studio/app/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/studio/app/index.html
+++ b/studio/app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sinas Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/studio/app/package-lock.json
+++ b/studio/app/package-lock.json
@@ -1,0 +1,1936 @@
+{
+  "name": "sinas-studio",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sinas-studio",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.90.5",
+        "lucide-react": "^0.548.0",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.5"
+      },
+      "devDependencies": {
+        "@types/node": "^24.6.0",
+        "@types/react": "^19.1.16",
+        "@types/react-dom": "^19.1.9",
+        "@vitejs/plugin-react": "^5.0.4",
+        "typescript": "~5.9.3",
+        "vite": "^7.1.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.548.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.548.0.tgz",
+      "integrity": "sha512-63b16z63jM9yc1MwxajHeuu0FRZFsDtljtDjYm26Kd86UQ5HQzu9ksEtoUUw4RBuewodw/tGFmvipePvRsKeDA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/studio/app/package-lock.json
+++ b/studio/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sinas-studio",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/schibsted-grotesk": "^5.2.8",
         "@tanstack/react-query": "^5.90.5",
         "lucide-react": "^0.548.0",
         "react": "^19.1.1",
@@ -745,6 +746,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/schibsted-grotesk": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/schibsted-grotesk/-/schibsted-grotesk-5.2.8.tgz",
+      "integrity": "sha512-nZAorDrFue4dXZbI613WdvAhu5DPH1UJYNn5fWl7Poa+nl/s9o3VUcQImIiVZpQnYG/jkPVzHsTE7WZbSDvvkw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/studio/app/package.json
+++ b/studio/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "sinas-studio",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.90.5",
+    "lucide-react": "^0.548.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.5"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.1.16",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "~5.9.3",
+    "vite": "^7.1.7"
+  }
+}

--- a/studio/app/package.json
+++ b/studio/app/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource-variable/schibsted-grotesk": "^5.2.8",
     "@tanstack/react-query": "^5.90.5",
     "lucide-react": "^0.548.0",
     "react": "^19.1.1",

--- a/studio/app/src/App.tsx
+++ b/studio/app/src/App.tsx
@@ -22,8 +22,9 @@ function Shell() {
   return (
     <div className="app-shell">
       <header className="topbar">
-        <Link to="/projects" style={{ fontWeight: 800, fontSize: 15, color: 'var(--ink)' }}>
-          Sinas <span style={{ color: 'var(--accent)' }}>Studio</span>
+        <Link to="/projects" className="wordmark">
+          <span className="wm-name">sinas</span>
+          <span className="wm-app">Studio</span>
         </Link>
         <span style={{ fontSize: 12, color: 'var(--faint)' }}>{host}</span>
         <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 12 }}>

--- a/studio/app/src/App.tsx
+++ b/studio/app/src/App.tsx
@@ -6,6 +6,7 @@ import { Connect } from './screens/Connect';
 import { Projects } from './screens/Projects';
 import { ProjectHome } from './screens/ProjectHome';
 import { AssistantEditor } from './screens/AssistantEditor';
+import { NewWorkflow, ScheduleWorkflow, WebhookWorkflow } from './screens/WorkflowEditor';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { refetchOnWindowFocus: false, retry: 1 } },
@@ -49,7 +50,7 @@ function Shell() {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter basename="/studio">
         <Routes>
           <Route path="/connect" element={<Connect />} />
           <Route element={<Shell />}>
@@ -57,6 +58,9 @@ export default function App() {
             <Route path="projects" element={<Projects />} />
             <Route path="projects/:ns/:name" element={<ProjectHome />} />
             <Route path="projects/:pns/:pname/assistants/:ans/:aname" element={<AssistantEditor />} />
+            <Route path="projects/:pns/:pname/workflows/new" element={<NewWorkflow />} />
+            <Route path="projects/:pns/:pname/workflows/schedule/:name" element={<ScheduleWorkflow />} />
+            <Route path="projects/:pns/:pname/workflows/webhook/*" element={<WebhookWorkflow />} />
           </Route>
           <Route path="*" element={<Navigate to="/projects" replace />} />
         </Routes>

--- a/studio/app/src/App.tsx
+++ b/studio/app/src/App.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter, Link, Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom';
+import { LogOut } from 'lucide-react';
+import { clearConnection, getConnection } from './lib/connection';
+import { Connect } from './screens/Connect';
+import { Projects } from './screens/Projects';
+import { ProjectHome } from './screens/ProjectHome';
+import { AssistantEditor } from './screens/AssistantEditor';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { refetchOnWindowFocus: false, retry: 1 } },
+});
+
+function Shell() {
+  const navigate = useNavigate();
+  const conn = getConnection();
+  if (!conn) return <Navigate to="/connect" replace />;
+
+  const host = new URL(conn.baseUrl).host;
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <Link to="/projects" style={{ fontWeight: 800, fontSize: 15, color: 'var(--ink)' }}>
+          Sinas <span style={{ color: 'var(--accent)' }}>Studio</span>
+        </Link>
+        <span style={{ fontSize: 12, color: 'var(--faint)' }}>{host}</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 12 }}>
+          <span style={{ fontSize: 12.5, color: 'var(--muted)' }}>{conn.user.email}</span>
+          <button
+            className="kebab"
+            title="Disconnect"
+            onClick={() => {
+              clearConnection();
+              navigate('/connect');
+            }}
+          >
+            <LogOut size={16} />
+          </button>
+        </div>
+      </header>
+      <div className="main-scroll" style={{ display: 'flex', flexDirection: 'column' }}>
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/connect" element={<Connect />} />
+          <Route element={<Shell />}>
+            <Route index element={<Navigate to="/projects" replace />} />
+            <Route path="projects" element={<Projects />} />
+            <Route path="projects/:ns/:name" element={<ProjectHome />} />
+            <Route path="projects/:pns/:pname/assistants/:ans/:aname" element={<AssistantEditor />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/projects" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}

--- a/studio/app/src/components/SetupStudio.tsx
+++ b/studio/app/src/components/SetupStudio.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2, Sparkles, X } from 'lucide-react';
+import { ApiError, api } from '../lib/api';
+import { getConnection } from '../lib/connection';
+// Bundled at build time — same repo, same release train, so the installed
+// package version always matches this Studio build.
+import studioRuntimeYaml from '../../../packages/studio-runtime.yaml?raw';
+
+/** True while the companion package is installed in the workspace. */
+export function useStudioRuntimeInstalled(): boolean {
+  const { data: packages } = useQuery({ queryKey: ['packages'], queryFn: api.listPackages, retry: false });
+  return (packages ?? []).some((p) => p.name === 'studio-runtime');
+}
+
+/**
+ * Install trigger for the studio-runtime package. Shown to everyone when the
+ * package is missing: the platform doesn't expose permissions on /auth/me yet
+ * (studio/README.md §7.5), so authorization is attempt-based — a 403 becomes
+ * an "ask your admin" message rather than a hidden button.
+ */
+export function SetupStudioLink() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button className="btn btn-secondary btn-sm" onClick={() => setOpen(true)}>
+        <Sparkles size={13} style={{ color: 'var(--accent)' }} /> Set up Studio
+      </button>
+      {open && <SetupStudioModal onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function SetupStudioModal({ onClose }: { onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [workspaceUrl, setWorkspaceUrl] = useState(getConnection()?.baseUrl ?? '');
+
+  const install = useMutation({
+    mutationFn: () =>
+      api.installPackage(studioRuntimeYaml, { WORKSPACE_URL: workspaceUrl.replace(/\/+$/, '') }),
+  });
+
+  // Refetching flips the parent's "not installed" conditionals, which unmounts
+  // this modal — so hold the invalidation until the user dismisses it.
+  const close = () => {
+    if (install.isSuccess) queryClient.invalidateQueries();
+    onClose();
+  };
+
+  const denied = install.error instanceof ApiError && install.error.status === 403;
+
+  return (
+    <div className="overlay" onClick={close}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 10 }}>
+          <h2 style={{ fontSize: 16 }}>Set up Studio</h2>
+          <button className="kebab" onClick={close} aria-label="Close">
+            <X size={16} />
+          </button>
+        </div>
+
+        {install.isSuccess ? (
+          <>
+            <p style={{ fontSize: 13.5, color: 'var(--muted)', margin: '0 0 14px' }}>
+              Done — webhook workflows and “Improve with AI” are now available in this workspace.
+            </p>
+            <button className="btn btn-primary" style={{ justifyContent: 'center', width: '100%' }} onClick={close}>
+              Close
+            </button>
+          </>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (workspaceUrl.trim() && !install.isPending) install.mutate();
+            }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+          >
+            <p style={{ fontSize: 13, color: 'var(--muted)', margin: 0 }}>
+              Installs the <b>studio-runtime</b> package that ships with this version of Studio. It adds two
+              things to the workspace: the <b>studio/copilot</b> assistant (powers “Improve with AI”) and the{' '}
+              <b>studio/ask-agent</b> function (lets web requests start assistants).
+            </p>
+            <div className="field">
+              <label>Workspace URL</label>
+              <input
+                className="input"
+                value={workspaceUrl}
+                onChange={(e) => setWorkspaceUrl(e.target.value)}
+                placeholder="https://sinas.yourcompany.com"
+              />
+              <p style={{ fontSize: 11.5, color: 'var(--faint)', margin: '6px 0 0' }}>
+                Must be reachable from the containers that run functions. The public workspace address usually
+                works; for a local Docker deployment use <code>http://host.docker.internal:8000</code>.
+              </p>
+            </div>
+            {install.isError && (
+              <div className="error-box">
+                {denied
+                  ? 'Your account can’t install packages. Ask a workspace admin to open this dialog, or to install studio/packages/studio-runtime.yaml.'
+                  : (install.error as Error).message}
+              </div>
+            )}
+            <button
+              className="btn btn-primary"
+              disabled={!workspaceUrl.trim() || install.isPending}
+              style={{ justifyContent: 'center' }}
+            >
+              {install.isPending ? <Loader2 size={14} className="spin" /> : 'Install into this workspace'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/studio/app/src/components/TestChat.tsx
+++ b/studio/app/src/components/TestChat.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, RotateCcw, Send } from 'lucide-react';
+import { api } from '../lib/api';
+import { initials, schemaToInputRows } from '../lib/model';
+import type { Agent, Message } from '../lib/types';
+import { messageText } from '../lib/types';
+
+/**
+ * Live test chat against the real assistant, using the editor's current
+ * (autosaved) state. Non-streaming in this iteration: each send blocks on the
+ * reply, then the full transcript is refetched so tool activity (role: tool
+ * messages) renders as chips.
+ */
+export function TestChat({ agent }: { agent: Agent }) {
+  const [chatId, setChatId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [inputValues, setInputValues] = useState<Record<string, string>>({});
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const inputRows = schemaToInputRows(agent.input_schema);
+  const requiredRows = inputRows.filter((r) => r.required);
+  const missingRequired = requiredRows.filter((r) => !inputValues[r.name]?.trim());
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages, sending]);
+
+  const restart = () => {
+    setChatId(null);
+    setMessages([]);
+    setError(null);
+  };
+
+  // A different assistant means a different conversation.
+  useEffect(restart, [agent.namespace, agent.name]);
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || sending || missingRequired.length > 0) return;
+    setSending(true);
+    setError(null);
+    setInput('');
+    setMessages((prev) => [
+      ...prev,
+      { id: `local-${prev.length}`, role: 'user', content: text, name: null, tool_calls: null, created_at: '' },
+    ]);
+    try {
+      let id = chatId;
+      if (!id) {
+        const values = Object.fromEntries(Object.entries(inputValues).filter(([, v]) => v.trim() !== ''));
+        const chat = await api.createChat(agent.namespace, agent.name, {
+          title: 'Studio test chat',
+          ...(Object.keys(values).length ? { input: values } : {}),
+        });
+        id = chat.id;
+        setChatId(id);
+      }
+      await api.sendMessage(id, text);
+      setMessages(await api.listMessages(id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Message failed');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <aside className="chat-pane">
+      <div className="pane-head">
+        <div>
+          <div className="pane-title">Test chat</div>
+          <div className="pane-sub">Talks to the real assistant, with your current edits</div>
+        </div>
+        <button className="btn btn-secondary btn-sm" style={{ marginLeft: 'auto' }} onClick={restart}>
+          <RotateCcw size={13} /> Restart
+        </button>
+      </div>
+
+      <div ref={scrollRef} className="pane-scroll">
+        {inputRows.length > 0 && !chatId && (
+          <div className="card" style={{ padding: 14, boxShadow: 'none' }}>
+            <p style={{ margin: '0 0 10px', fontSize: 12, color: 'var(--muted)', fontWeight: 600 }}>
+              This assistant asks for inputs when it starts:
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {inputRows.map((row) => (
+                <div key={row.name} className="field">
+                  <label>
+                    <span className="token">@{row.name}</span>
+                    {row.required && <span style={{ color: 'var(--accent)' }}> *</span>}
+                  </label>
+                  {row.kind === 'choice' ? (
+                    <select
+                      className="input"
+                      value={inputValues[row.name] ?? ''}
+                      onChange={(e) => setInputValues({ ...inputValues, [row.name]: e.target.value })}
+                    >
+                      <option value="">Choose…</option>
+                      {row.choices.map((c) => (
+                        <option key={c} value={c}>
+                          {c}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      className="input"
+                      placeholder={row.description}
+                      value={inputValues[row.name] ?? ''}
+                      onChange={(e) => setInputValues({ ...inputValues, [row.name]: e.target.value })}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((m) => {
+          if (m.role === 'user') {
+            return (
+              <div key={m.id} className="msg-user">
+                {messageText(m.content)}
+              </div>
+            );
+          }
+          if (m.role === 'tool') {
+            return (
+              <span key={m.id} className="tool-call">
+                <span className="tc-dot" /> used <b>{m.name || 'a tool'}</b>
+              </span>
+            );
+          }
+          if (m.role === 'assistant') {
+            const text = messageText(m.content);
+            if (!text && m.tool_calls?.length) return null; // pure tool-call turns render via their tool results
+            return (
+              <div key={m.id} className="msg-bot">
+                <div className="bot-avatar">{initials(agent.name)}</div>
+                <div className="bot-bubble">
+                  <div className="bot-text">{text}</div>
+                </div>
+              </div>
+            );
+          }
+          return null;
+        })}
+
+        {sending && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--faint)', fontSize: 12.5 }}>
+            <Loader2 size={14} className="spin" /> Thinking…
+          </div>
+        )}
+        {error && <div className="error-box">{error}</div>}
+      </div>
+
+      <form
+        className="chat-input"
+        onSubmit={(e) => {
+          e.preventDefault();
+          send();
+        }}
+      >
+        <input
+          className="input"
+          placeholder={missingRequired.length > 0 ? `Fill in ${missingRequired.map((r) => '@' + r.name).join(', ')} first…` : 'Test your assistant…'}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          disabled={sending}
+        />
+        <button className="btn btn-primary" disabled={sending || !input.trim() || missingRequired.length > 0} aria-label="Send">
+          <Send size={14} />
+        </button>
+      </form>
+      <div className="hint-strip">Tool use shows up as chips, so you can see exactly what it did.</div>
+    </aside>
+  );
+}

--- a/studio/app/src/components/TestChat.tsx
+++ b/studio/app/src/components/TestChat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Loader2, RotateCcw, Send } from 'lucide-react';
 import { api } from '../lib/api';
-import { initials, schemaToInputRows } from '../lib/model';
+import { avatarStyle, initials, schemaToInputRows } from '../lib/model';
 import type { Agent, Message } from '../lib/types';
 import { messageText } from '../lib/types';
 
@@ -139,7 +139,7 @@ export function TestChat({ agent }: { agent: Agent }) {
             if (!text && m.tool_calls?.length) return null; // pure tool-call turns render via their tool results
             return (
               <div key={m.id} className="msg-bot">
-                <div className="bot-avatar">{initials(agent.name)}</div>
+                <div className="bot-avatar" style={avatarStyle(agent.name)}>{initials(agent.name)}</div>
                 <div className="bot-bubble">
                   <div className="bot-text">{text}</div>
                 </div>

--- a/studio/app/src/lib/api.ts
+++ b/studio/app/src/lib/api.ts
@@ -24,7 +24,7 @@ import type {
   Webhook,
 } from './types';
 
-class ApiError extends Error {
+export class ApiError extends Error {
   status: number;
   constructor(status: number, message: string) {
     super(message);
@@ -197,8 +197,13 @@ export const api = {
     return request<Execution[]>(`/executions?${qs}`);
   },
 
-  // Companion package detection
+  // Companion package detection + in-app setup (see components/SetupStudio.tsx)
   listPackages: () => request<InstalledPackage[]>('/api/v1/packages'),
+  installPackage: (yamlContent: string, variables: Record<string, string>) =>
+    request<unknown>('/api/v1/packages/install', {
+      method: 'POST',
+      body: { source: yamlContent, variables },
+    }),
 
   // One-shot agent invocation (used for studio/copilot AI assist)
   invokeAgent: (ns: string, name: string, data: { message: string; session_key?: string }) =>

--- a/studio/app/src/lib/api.ts
+++ b/studio/app/src/lib/api.ts
@@ -1,0 +1,180 @@
+// Thin fetch client for the Sinas API. Management endpoints live under
+// /api/v1, runtime endpoints (auth, chats, executions) at the root.
+// 401s trigger one refresh-and-retry; a failed refresh disconnects.
+import { clearConnection, getConnection, updateTokens } from './connection';
+import type {
+  Agent,
+  AgentUpdate,
+  AuthUser,
+  Chat,
+  Collection,
+  Connector,
+  InstalledPackage,
+  InstanceInfo,
+  LoginResponse,
+  Manifest,
+  ManifestResourceRef,
+  Message,
+  Schedule,
+  Secret,
+  Skill,
+  Store,
+  Webhook,
+} from './types';
+
+class ApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function parseError(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (typeof data?.detail === 'string') return data.detail;
+    if (data?.detail) return JSON.stringify(data.detail);
+  } catch {
+    /* non-JSON body */
+  }
+  return `Request failed (${res.status})`;
+}
+
+let refreshing: Promise<boolean> | null = null;
+
+async function refreshTokens(): Promise<boolean> {
+  const conn = getConnection();
+  if (!conn) return false;
+  refreshing ??= (async () => {
+    try {
+      const res = await fetch(`${conn.baseUrl}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: conn.refreshToken }),
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      updateTokens(data.access_token, data.refresh_token ?? conn.refreshToken);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshing = null;
+    }
+  })();
+  return refreshing;
+}
+
+async function request<T>(
+  path: string,
+  opts: { method?: string; body?: unknown; retried?: boolean } = {},
+): Promise<T> {
+  const conn = getConnection();
+  if (!conn) throw new ApiError(401, 'Not connected to a workspace');
+
+  const res = await fetch(`${conn.baseUrl}${path}`, {
+    method: opts.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${getConnection()!.accessToken}`,
+      ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+
+  if (res.status === 401 && !opts.retried) {
+    if (await refreshTokens()) {
+      return request<T>(path, { ...opts, retried: true });
+    }
+    clearConnection();
+    window.location.assign('/connect');
+    throw new ApiError(401, 'Session expired');
+  }
+
+  if (!res.ok) throw new ApiError(res.status, await parseError(res));
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+// ---- Pre-connection (no stored tokens) ----
+
+export async function fetchInstanceInfo(baseUrl: string): Promise<InstanceInfo> {
+  const res = await fetch(`${baseUrl}/info`);
+  if (!res.ok) throw new ApiError(res.status, 'Could not reach this workspace');
+  return res.json();
+}
+
+export async function login(baseUrl: string, email: string, password?: string): Promise<LoginResponse> {
+  const res = await fetch(`${baseUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(password !== undefined ? { email, password } : { email }),
+  });
+  if (!res.ok) throw new ApiError(res.status, await parseError(res));
+  return res.json();
+}
+
+export async function verifyOtp(baseUrl: string, sessionId: string, otpCode: string): Promise<Required<Omit<LoginResponse, 'session_id'>>> {
+  const res = await fetch(`${baseUrl}/auth/verify-otp`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, otp_code: otpCode }),
+  });
+  if (!res.ok) throw new ApiError(res.status, await parseError(res));
+  return res.json();
+}
+
+// ---- Authenticated API ----
+
+export const api = {
+  me: () => request<AuthUser>('/auth/me'),
+
+  // Projects (manifests)
+  listProjects: () => request<Manifest[]>('/api/v1/manifests'),
+  getProject: (ns: string, name: string) => request<Manifest>(`/api/v1/manifests/${ns}/${name}`),
+  createProject: (data: { namespace: string; name: string; description?: string; required_resources: ManifestResourceRef[] }) =>
+    request<Manifest>('/api/v1/manifests', { method: 'POST', body: data }),
+  updateProject: (ns: string, name: string, data: { description?: string; required_resources?: ManifestResourceRef[] }) =>
+    request<Manifest>(`/api/v1/manifests/${ns}/${name}`, { method: 'PUT', body: data }),
+  deleteProject: (ns: string, name: string) =>
+    request<void>(`/api/v1/manifests/${ns}/${name}`, { method: 'DELETE' }),
+
+  // Assistants (agents)
+  listAgents: () => request<Agent[]>('/api/v1/agents'),
+  getAgent: (ns: string, name: string) => request<Agent>(`/api/v1/agents/${ns}/${name}`),
+  createAgent: (data: { namespace: string; name: string; description?: string; system_prompt?: string }) =>
+    request<Agent>('/api/v1/agents', { method: 'POST', body: data }),
+  updateAgent: (ns: string, name: string, data: AgentUpdate) =>
+    request<Agent>(`/api/v1/agents/${ns}/${name}`, { method: 'PUT', body: data }),
+
+  // Capabilities
+  listConnectors: () => request<Connector[]>('/api/v1/connectors'),
+  listSkills: () => request<Skill[]>('/api/v1/skills'),
+  createSkill: (data: { namespace: string; name: string; description: string; content: string }) =>
+    request<Skill>('/api/v1/skills', { method: 'POST', body: data }),
+  listCollections: () => request<Collection[]>('/api/v1/collections'),
+  createCollection: (data: { namespace: string; name: string }) =>
+    request<Collection>('/api/v1/collections', { method: 'POST', body: data }),
+  listStores: () => request<Store[]>('/api/v1/stores'),
+  createStore: (data: { namespace: string; name: string; description?: string }) =>
+    request<Store>('/api/v1/stores', { method: 'POST', body: data }),
+  listSecrets: () => request<Secret[]>('/api/v1/secrets'),
+
+  // Workflows (read-only in this iteration)
+  listSchedules: () => request<Schedule[]>('/api/v1/schedules'),
+  listWebhooks: () => request<Webhook[]>('/api/v1/webhooks'),
+
+  // Companion package detection
+  listPackages: () => request<InstalledPackage[]>('/api/v1/packages'),
+
+  // One-shot agent invocation (used for studio/copilot AI assist)
+  invokeAgent: (ns: string, name: string, data: { message: string; session_key?: string }) =>
+    request<{ reply: string }>(`/agents/${ns}/${name}/invoke`, { method: 'POST', body: data }),
+
+  // Test chat (runtime)
+  createChat: (ns: string, name: string, data: { title?: string; input?: Record<string, unknown> }) =>
+    request<Chat>(`/agents/${ns}/${name}/chats`, { method: 'POST', body: data }),
+  sendMessage: (chatId: string, content: string) =>
+    request<Message>(`/chats/${chatId}/messages`, { method: 'POST', body: { content } }),
+  listMessages: (chatId: string) => request<Message[]>(`/chats/${chatId}/messages`),
+};

--- a/studio/app/src/lib/api.ts
+++ b/studio/app/src/lib/api.ts
@@ -9,7 +9,9 @@ import type {
   Chat,
   Collection,
   Connector,
+  Execution,
   InstalledPackage,
+  SinasFunction,
   InstanceInfo,
   LoginResponse,
   Manifest,
@@ -87,7 +89,7 @@ async function request<T>(
       return request<T>(path, { ...opts, retried: true });
     }
     clearConnection();
-    window.location.assign('/connect');
+    window.location.assign(`${import.meta.env.BASE_URL}connect`);
     throw new ApiError(401, 'Session expired');
   }
 
@@ -160,9 +162,40 @@ export const api = {
     request<Store>('/api/v1/stores', { method: 'POST', body: data }),
   listSecrets: () => request<Secret[]>('/api/v1/secrets'),
 
-  // Workflows (read-only in this iteration)
+  // Workflows
   listSchedules: () => request<Schedule[]>('/api/v1/schedules'),
+  createSchedule: (data: {
+    name: string;
+    schedule_type: 'function' | 'agent';
+    target_namespace: string;
+    target_name: string;
+    description?: string;
+    cron_expression: string;
+    timezone?: string;
+    content?: string;
+  }) => request<Schedule>('/api/v1/schedules', { method: 'POST', body: data }),
+  updateSchedule: (name: string, data: Partial<{ description: string; cron_expression: string; content: string; is_active: boolean; target_namespace: string; target_name: string }>) =>
+    request<Schedule>(`/api/v1/schedules/${encodeURIComponent(name)}`, { method: 'PATCH', body: data }),
   listWebhooks: () => request<Webhook[]>('/api/v1/webhooks'),
+  createWebhook: (data: {
+    path: string;
+    function_namespace: string;
+    function_name: string;
+    http_method?: string;
+    description?: string;
+    default_values?: Record<string, any>;
+    requires_auth?: boolean;
+  }) => request<Webhook>('/api/v1/webhooks', { method: 'POST', body: data }),
+  updateWebhook: (path: string, data: Partial<{ description: string; default_values: Record<string, any>; is_active: boolean; requires_auth: boolean }>) =>
+    request<Webhook>(`/api/v1/webhooks/${path}`, { method: 'PUT', body: data }),
+
+  listFunctions: () => request<SinasFunction[]>('/api/v1/functions'),
+  listExecutions: (params: { trigger_type?: string; limit?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.trigger_type) qs.set('trigger_type', params.trigger_type);
+    qs.set('limit', String(params.limit ?? 50));
+    return request<Execution[]>(`/executions?${qs}`);
+  },
 
   // Companion package detection
   listPackages: () => request<InstalledPackage[]>('/api/v1/packages'),

--- a/studio/app/src/lib/connection.ts
+++ b/studio/app/src/lib/connection.ts
@@ -1,0 +1,40 @@
+// The stored link between this Studio app and a Sinas workspace.
+import type { AuthUser } from './types';
+
+const KEY = 'studio-connection';
+
+export interface Connection {
+  baseUrl: string; // e.g. https://sinas.company.com
+  accessToken: string;
+  refreshToken: string;
+  user: AuthUser;
+}
+
+export function getConnection(): Connection | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Connection) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveConnection(conn: Connection): void {
+  localStorage.setItem(KEY, JSON.stringify(conn));
+}
+
+export function updateTokens(accessToken: string, refreshToken: string): void {
+  const conn = getConnection();
+  if (conn) saveConnection({ ...conn, accessToken, refreshToken });
+}
+
+export function clearConnection(): void {
+  localStorage.removeItem(KEY);
+}
+
+/** Normalize whatever the user typed into an origin we can call. */
+export function normalizeBaseUrl(input: string): string {
+  let url = input.trim().replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(url)) url = `https://${url}`;
+  return url;
+}

--- a/studio/app/src/lib/model.ts
+++ b/studio/app/src/lib/model.ts
@@ -109,6 +109,56 @@ export function triggersForAgent(agent: Agent, schedules: Schedule[], webhooks: 
   return { scheduleHits, webhookHits };
 }
 
+// ---- Adapters (see studio/README.md §5) ----
+
+/** An adapter is recognizable by the reserved parameter it must declare. */
+export function isAdapter(fn: { input_schema?: Record<string, any> }): boolean {
+  return !!fn.input_schema?.properties?.studio_agent;
+}
+
+/** The trigger payload fields an adapter accepts (its schema minus reserved params). */
+export function adapterPayloadFields(fn: { input_schema?: Record<string, any> }): string[] {
+  return Object.keys(fn.input_schema?.properties ?? {}).filter((k) => !k.startsWith('studio_'));
+}
+
+// ---- Schedule presets (friendly cron) ----
+
+export type SchedulePreset = 'hourly' | 'daily' | 'weekdays' | 'weekly' | 'monthly';
+
+export const SCHEDULE_PRESETS: Array<{ value: SchedulePreset; label: string }> = [
+  { value: 'hourly', label: 'Every hour' },
+  { value: 'daily', label: 'Every day' },
+  { value: 'weekdays', label: 'Every weekday' },
+  { value: 'weekly', label: 'Every Monday' },
+  { value: 'monthly', label: 'Monthly (1st)' },
+];
+
+export function cronFromPreset(preset: SchedulePreset, time: string): string {
+  const [h = 9, m = 0] = time.split(':').map((n) => parseInt(n, 10));
+  switch (preset) {
+    case 'hourly': return `${m || 0} * * * *`;
+    case 'daily': return `${m || 0} ${h} * * *`;
+    case 'weekdays': return `${m || 0} ${h} * * 1-5`;
+    case 'weekly': return `${m || 0} ${h} * * 1`;
+    case 'monthly': return `${m || 0} ${h} 1 * *`;
+  }
+}
+
+export function presetFromCron(cron: string): { preset: SchedulePreset; time: string } | null {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [min, hour, dom, month, dow] = parts;
+  if (!/^\d+$/.test(min)) return null;
+  const time = /^\d+$/.test(hour) ? `${hour.padStart(2, '0')}:${min.padStart(2, '0')}` : `09:${min.padStart(2, '0')}`;
+  if (hour === '*' && dom === '*' && dow === '*') return { preset: 'hourly', time };
+  if (!/^\d+$/.test(hour) || month !== '*') return null;
+  if (dow === '1-5' && dom === '*') return { preset: 'weekdays', time };
+  if (dow === '1' && dom === '*') return { preset: 'weekly', time };
+  if (dom === '1' && dow === '*') return { preset: 'monthly', time };
+  if (dom === '*' && dow === '*') return { preset: 'daily', time };
+  return null;
+}
+
 /** Members of a project, grouped the way the project home displays them. */
 export function projectMembers(manifest: Manifest) {
   const byType = (types: string[]) =>

--- a/studio/app/src/lib/model.ts
+++ b/studio/app/src/lib/model.ts
@@ -24,6 +24,18 @@ export function prettyName(name: string): string {
   return bare.replaceAll(/[-_]/g, ' ').replace(/^./, (c) => c.toUpperCase());
 }
 
+/** Deterministic identity gradient for an assistant, from its name. */
+export function avatarStyle(name: string): React.CSSProperties {
+  let hash = 0;
+  for (const ch of name) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+  const hue = hash % 360;
+  return {
+    background: `linear-gradient(135deg, hsl(${hue} 62% 52%), hsl(${(hue + 40) % 360} 68% 40%))`,
+    color: '#fff',
+    boxShadow: 'inset 0 1px 0 rgba(255,255,255,.25), 0 1px 3px rgba(27,22,19,.2)',
+  };
+}
+
 export function initials(name: string): string {
   const words = prettyName(name).split(' ').filter(Boolean);
   return ((words[0]?.[0] ?? '') + (words[1]?.[0] ?? '')).toUpperCase() || '?';

--- a/studio/app/src/lib/model.ts
+++ b/studio/app/src/lib/model.ts
@@ -1,0 +1,123 @@
+// Studio's concept layer over the raw API shapes: naming conventions for
+// auto-created resources, input-schema <-> friendly rows, and the
+// plain-language capability summary. Every derived string traces back to a
+// stored field (see studio/README.md §4).
+import type { Agent, Manifest, Schedule, Webhook } from './types';
+
+export function kebab(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+export function splitRef(ref: string): { namespace: string; name: string } {
+  const idx = ref.indexOf('/');
+  return idx === -1
+    ? { namespace: 'default', name: ref }
+    : { namespace: ref.slice(0, idx), name: ref.slice(idx + 1) };
+}
+
+export function prettyName(name: string): string {
+  const bare = name.includes('/') ? name.slice(name.indexOf('/') + 1) : name;
+  return bare.replaceAll(/[-_]/g, ' ').replace(/^./, (c) => c.toUpperCase());
+}
+
+export function initials(name: string): string {
+  const words = prettyName(name).split(' ').filter(Boolean);
+  return ((words[0]?.[0] ?? '') + (words[1]?.[0] ?? '')).toUpperCase() || '?';
+}
+
+// ---- Auto-created resource conventions ----
+
+/** The assistant's own read-write file space: collection `<agent>-files` in its namespace. */
+export function ownFilesRef(agent: Agent): string {
+  return `${agent.namespace}/${agent.name}-files`;
+}
+
+/** The assistant's conversation memory: store `<agent>-memory` in its namespace. */
+export function memoryRef(agent: Agent): string {
+  return `${agent.namespace}/${agent.name}-memory`;
+}
+
+// ---- Inputs: friendly rows over input_schema ----
+
+export interface InputRow {
+  name: string;
+  description: string;
+  kind: 'text' | 'choice';
+  choices: string[];
+  required: boolean;
+}
+
+export function schemaToInputRows(schema: Record<string, any> | null | undefined): InputRow[] {
+  const props = schema?.properties ?? {};
+  const required: string[] = schema?.required ?? [];
+  return Object.entries(props).map(([name, def]: [string, any]) => ({
+    name,
+    description: def?.description ?? '',
+    kind: Array.isArray(def?.enum) ? 'choice' : 'text',
+    choices: Array.isArray(def?.enum) ? def.enum.map(String) : [],
+    required: required.includes(name),
+  }));
+}
+
+export function inputRowsToSchema(rows: InputRow[]): Record<string, any> {
+  if (rows.length === 0) return {};
+  const properties: Record<string, any> = {};
+  for (const row of rows) {
+    properties[row.name] = {
+      type: 'string',
+      ...(row.description ? { description: row.description } : {}),
+      ...(row.kind === 'choice' && row.choices.length ? { enum: row.choices } : {}),
+    };
+  }
+  const required = rows.filter((r) => r.required).map((r) => r.name);
+  return { type: 'object', properties, ...(required.length ? { required } : {}) };
+}
+
+// ---- Plain-language derivations ----
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+export function cronToEnglish(cron: string): string {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return cron;
+  const [min, hour, dom, month, dow] = parts;
+  const time = () =>
+    `${Number(hour) % 12 === 0 ? 12 : Number(hour) % 12}:${min.padStart(2, '0')} ${Number(hour) < 12 ? 'AM' : 'PM'}`;
+  if (/^\d+$/.test(min) && /^\d+$/.test(hour)) {
+    if (dom === '*' && month === '*' && dow === '*') return `every day at ${time()}`;
+    if (dow === '1-5' && dom === '*') return `every weekday at ${time()}`;
+    if (/^\d+$/.test(dow) && dom === '*') return `every ${DAY_NAMES[Number(dow) % 7]} at ${time()}`;
+    if (/^\d+$/.test(dom) && dow === '*') return `monthly on day ${dom} at ${time()}`;
+  }
+  if (min === '0' && hour === '*') return 'every hour';
+  return cron;
+}
+
+/** Workflows that run a given assistant (source: schedule/webhook target fields). */
+export function triggersForAgent(agent: Agent, schedules: Schedule[], webhooks: Webhook[]) {
+  const scheduleHits = schedules.filter(
+    (s) => s.schedule_type === 'agent' && s.target_namespace === agent.namespace && s.target_name === agent.name,
+  );
+  // Webhook -> adapter -> agent: the target assistant is a default_values
+  // parameter on the webhook (see studio/README.md §5).
+  const agentRef = `${agent.namespace}/${agent.name}`;
+  const webhookHits = webhooks.filter((w) => w.default_values?.studio_agent === agentRef);
+  return { scheduleHits, webhookHits };
+}
+
+/** Members of a project, grouped the way the project home displays them. */
+export function projectMembers(manifest: Manifest) {
+  const byType = (types: string[]) =>
+    (manifest.required_resources ?? []).filter((r) => types.includes(r.type.replace(/s$/, '')));
+  return {
+    assistants: byType(['agent']),
+    workflows: byType(['schedule', 'webhook']),
+    other: (manifest.required_resources ?? []).filter(
+      (r) => !['agent', 'schedule', 'webhook'].includes(r.type.replace(/s$/, '')),
+    ),
+  };
+}

--- a/studio/app/src/lib/types.ts
+++ b/studio/app/src/lib/types.ts
@@ -1,0 +1,153 @@
+// Shapes mirror the Sinas API (snake_case). Only fields Studio uses.
+
+export interface InstanceInfo {
+  auth_mode: 'otp' | 'password' | 'password+otp';
+  version: string;
+  features?: Record<string, unknown>;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  is_active: boolean;
+}
+
+export interface LoginResponse {
+  access_token?: string;
+  refresh_token?: string;
+  user?: AuthUser;
+  session_id?: string; // present when an OTP step follows
+}
+
+export interface ManifestResourceRef {
+  type: string;
+  namespace: string;
+  name: string;
+}
+
+export interface Manifest {
+  id: string;
+  namespace: string;
+  name: string;
+  description: string | null;
+  required_resources: ManifestResourceRef[];
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface EnabledSkill { skill: string; preload: boolean }
+export interface EnabledConnector { connector: string; operations: string[] }
+export interface EnabledCollection { collection: string; access: 'readonly' | 'readwrite' }
+export interface EnabledStore { store: string; access: 'readonly' | 'readwrite' }
+
+export interface Agent {
+  id: string;
+  namespace: string;
+  name: string;
+  description: string | null;
+  system_prompt: string | null;
+  input_schema: Record<string, any>;
+  enabled_functions: string[];
+  enabled_agents: string[];
+  enabled_skills: EnabledSkill[];
+  enabled_queries: string[];
+  enabled_connectors: EnabledConnector[];
+  enabled_collections: EnabledCollection[];
+  enabled_stores: EnabledStore[];
+  icon_url: string | null;
+  is_active: boolean;
+}
+
+export type AgentUpdate = Partial<
+  Pick<
+    Agent,
+    | 'description'
+    | 'system_prompt'
+    | 'input_schema'
+    | 'enabled_skills'
+    | 'enabled_connectors'
+    | 'enabled_collections'
+    | 'enabled_stores'
+  >
+>;
+
+export interface ConnectorOperation { name: string; description: string | null }
+export interface Connector {
+  id: string;
+  namespace: string;
+  name: string;
+  description: string | null;
+  base_url: string;
+  auth: { type?: string; secret?: string } | null;
+  operations: ConnectorOperation[];
+}
+
+export interface Skill {
+  id: string;
+  namespace: string;
+  name: string;
+  description: string;
+  content: string;
+}
+
+export interface Collection {
+  id: string;
+  namespace: string;
+  name: string;
+  is_public?: boolean;
+}
+
+export interface Store {
+  id: string;
+  namespace: string;
+  name: string;
+  description: string | null;
+}
+
+export interface Secret { name: string }
+
+export interface Schedule {
+  id: string;
+  name: string;
+  schedule_type: 'function' | 'agent';
+  target_namespace: string;
+  target_name: string;
+  description: string | null;
+  cron_expression: string;
+  timezone: string;
+  is_active: boolean;
+  last_run: string | null;
+  next_run: string | null;
+}
+
+export interface Webhook {
+  id: string;
+  path: string;
+  function_namespace: string;
+  function_name: string;
+  http_method: string;
+  description: string | null;
+  is_active: boolean;
+  requires_auth: boolean;
+  default_values: Record<string, any> | null;
+}
+
+export interface InstalledPackage { id: string; name: string; version: string }
+
+export interface Chat { id: string; title: string }
+
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string | Array<{ type: string; text?: string }> | null;
+  name: string | null;
+  tool_calls: any[] | null;
+  created_at: string;
+}
+
+/** Extract plain text from a message content union. */
+export function messageText(content: Message['content']): string {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+  return content.map((part) => (part.type === 'text' ? part.text || '' : '')).join('');
+}

--- a/studio/app/src/lib/types.ts
+++ b/studio/app/src/lib/types.ts
@@ -115,6 +115,7 @@ export interface Schedule {
   description: string | null;
   cron_expression: string;
   timezone: string;
+  content: string | null;
   is_active: boolean;
   last_run: string | null;
   next_run: string | null;
@@ -133,6 +134,26 @@ export interface Webhook {
 }
 
 export interface InstalledPackage { id: string; name: string; version: string }
+
+export interface SinasFunction {
+  id: string;
+  namespace: string;
+  name: string;
+  description: string | null;
+  input_schema: Record<string, any>;
+}
+
+export interface Execution {
+  execution_id: string;
+  function_name: string;
+  status: string;
+  trigger_type: string | null;
+  trigger_id: string | null;
+  error: string | null;
+  started_at: string | null;
+  created_at?: string;
+  duration_ms: number | null;
+}
 
 export interface Chat { id: string; title: string }
 

--- a/studio/app/src/main.tsx
+++ b/studio/app/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/studio/app/src/main.tsx
+++ b/studio/app/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import '@fontsource-variable/schibsted-grotesk';
 import './styles.css';
 
 createRoot(document.getElementById('root')!).render(

--- a/studio/app/src/screens/AssistantEditor.tsx
+++ b/studio/app/src/screens/AssistantEditor.tsx
@@ -29,11 +29,7 @@ import {
 import type { AgentUpdate } from '../lib/types';
 import { TestChat } from '../components/TestChat';
 
-/** True while the companion package (studio/copilot agent) is installed. */
-function useCopilotAvailable(): boolean {
-  const { data: packages } = useQuery({ queryKey: ['packages'], queryFn: api.listPackages, retry: false });
-  return (packages ?? []).some((p) => p.name === 'studio-runtime');
-}
+import { SetupStudioLink, useStudioRuntimeInstalled } from '../components/SetupStudio';
 
 function Popover({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
   return (
@@ -62,7 +58,7 @@ export function AssistantEditor() {
   const secrets = useQuery({ queryKey: ['secrets'], queryFn: api.listSecrets, retry: false }).data;
   const schedules = useQuery({ queryKey: ['schedules'], queryFn: api.listSchedules }).data ?? [];
   const webhooks = useQuery({ queryKey: ['webhooks'], queryFn: api.listWebhooks }).data ?? [];
-  const copilotAvailable = useCopilotAvailable();
+  const copilotAvailable = useStudioRuntimeInstalled();
 
   const patch = useMutation({
     mutationFn: (update: AgentUpdate) => api.updateAgent(ans!, aname!, update),
@@ -278,6 +274,7 @@ export function AssistantEditor() {
                   {assistBusy ? <Loader2 size={13} className="spin" /> : <Sparkles size={13} style={{ color: 'var(--accent)' }} />}
                   Improve with AI
                 </button>
+                {!copilotAvailable && <SetupStudioLink />}
                 {assistError && <span style={{ fontSize: 12, color: 'var(--bad)' }}>{assistError}</span>}
                 <span style={{ marginLeft: 'auto', fontSize: 11.5, color: 'var(--faint)' }}>
                   Changes apply immediately — try them in the test chat →

--- a/studio/app/src/screens/AssistantEditor.tsx
+++ b/studio/app/src/screens/AssistantEditor.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { api } from '../lib/api';
 import {
+  avatarStyle,
   cronToEnglish,
   initials,
   inputRowsToSchema,
@@ -141,7 +142,7 @@ export function AssistantEditor() {
         <Link to={`/projects/${pns}/${pname}`} style={{ color: 'var(--muted)', display: 'flex' }}>
           <ArrowLeft size={17} />
         </Link>
-        <span className="row-logo" style={{ width: 28, height: 28, fontSize: 11, background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+        <span className="row-logo" style={{ width: 28, height: 28, fontSize: 11, ...avatarStyle(agent.name) }}>
           {initials(agent.name)}
         </span>
         <span style={{ fontWeight: 700, color: 'var(--ink)', fontSize: 15 }}>{prettyName(agent.name)}</span>

--- a/studio/app/src/screens/AssistantEditor.tsx
+++ b/studio/app/src/screens/AssistantEditor.tsx
@@ -1,0 +1,735 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Archive,
+  ArrowLeft,
+  BookOpen,
+  Brain,
+  Loader2,
+  Plug,
+  Plus,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { api } from '../lib/api';
+import {
+  cronToEnglish,
+  initials,
+  inputRowsToSchema,
+  memoryRef,
+  ownFilesRef,
+  prettyName,
+  schemaToInputRows,
+  splitRef,
+  triggersForAgent,
+  type InputRow,
+} from '../lib/model';
+import type { AgentUpdate } from '../lib/types';
+import { TestChat } from '../components/TestChat';
+
+/** True while the companion package (studio/copilot agent) is installed. */
+function useCopilotAvailable(): boolean {
+  const { data: packages } = useQuery({ queryKey: ['packages'], queryFn: api.listPackages, retry: false });
+  return (packages ?? []).some((p) => p.name === 'studio-runtime');
+}
+
+function Popover({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
+  return (
+    <>
+      <div style={{ position: 'fixed', inset: 0, zIndex: 30 }} onClick={onClose} />
+      <div className="pop" style={{ left: 20, marginTop: 6, padding: 8 }}>
+        {children}
+      </div>
+    </>
+  );
+}
+
+export function AssistantEditor() {
+  const { pns, pname, ans, aname } = useParams<{ pns: string; pname: string; ans: string; aname: string }>();
+  const queryClient = useQueryClient();
+
+  const { data: agent, isLoading } = useQuery({
+    queryKey: ['agent', ans, aname],
+    queryFn: () => api.getAgent(ans!, aname!),
+    enabled: !!ans && !!aname,
+  });
+  const connectors = useQuery({ queryKey: ['connectors'], queryFn: api.listConnectors }).data ?? [];
+  const skills = useQuery({ queryKey: ['skills'], queryFn: api.listSkills }).data ?? [];
+  const collections = useQuery({ queryKey: ['collections'], queryFn: api.listCollections }).data ?? [];
+  const stores = useQuery({ queryKey: ['stores'], queryFn: api.listStores }).data ?? [];
+  const secrets = useQuery({ queryKey: ['secrets'], queryFn: api.listSecrets, retry: false }).data;
+  const schedules = useQuery({ queryKey: ['schedules'], queryFn: api.listSchedules }).data ?? [];
+  const webhooks = useQuery({ queryKey: ['webhooks'], queryFn: api.listWebhooks }).data ?? [];
+  const copilotAvailable = useCopilotAvailable();
+
+  const patch = useMutation({
+    mutationFn: (update: AgentUpdate) => api.updateAgent(ans!, aname!, update),
+    onSuccess: (updated) => queryClient.setQueryData(['agent', ans, aname], updated),
+  });
+
+  // ---- Instructions: local draft with debounced autosave ----
+  const [instructions, setInstructions] = useState('');
+  const loadedFor = useRef<string | null>(null);
+  useEffect(() => {
+    const key = agent ? `${agent.namespace}/${agent.name}` : null;
+    if (agent && loadedFor.current !== key) {
+      setInstructions(agent.system_prompt ?? '');
+      loadedFor.current = key;
+    }
+  }, [agent]);
+  const saveTimer = useRef<number | undefined>(undefined);
+  const onInstructionsChange = (value: string) => {
+    setInstructions(value);
+    window.clearTimeout(saveTimer.current);
+    saveTimer.current = window.setTimeout(() => patch.mutate({ system_prompt: value }), 800);
+  };
+
+  const [openPicker, setOpenPicker] = useState<'guidance' | 'tools' | 'storage' | null>(null);
+  const [inputModal, setInputModal] = useState<{ row: InputRow; isNew: boolean } | null>(null);
+  const [assistBusy, setAssistBusy] = useState(false);
+  const [assistError, setAssistError] = useState<string | null>(null);
+
+  const inputRows = useMemo(() => schemaToInputRows(agent?.input_schema), [agent]);
+
+  if (isLoading || !agent) {
+    return (
+      <div className="empty">
+        <Loader2 size={20} className="spin" style={{ margin: '20px auto', display: 'block' }} />
+      </div>
+    );
+  }
+
+  // ---- Derived data for sections & summary (all from stored fields) ----
+  const enabledSkillRefs = new Set(agent.enabled_skills.map((s) => s.skill));
+  const enabledConnectorRefs = new Set(agent.enabled_connectors.map((c) => c.connector));
+  const enabledCollectionRefs = new Set(agent.enabled_collections.map((c) => c.collection));
+  const enabledStoreRefs = new Set(agent.enabled_stores.map((s) => s.store));
+  const hasOwnFiles = enabledCollectionRefs.has(ownFilesRef(agent));
+  const hasMemory = enabledStoreRefs.has(memoryRef(agent));
+  const { scheduleHits, webhookHits } = triggersForAgent(agent, schedules, webhooks);
+
+  const toolNames = agent.enabled_connectors.map((c) => prettyName(splitRef(c.connector).name));
+  const fileNames = agent.enabled_collections.map((c) =>
+    c.collection === ownFilesRef(agent) ? 'its own files' : prettyName(splitRef(c.collection).name),
+  );
+
+  const saveInputRows = (rows: InputRow[]) => patch.mutate({ input_schema: inputRowsToSchema(rows) });
+
+  const improveInstructions = async () => {
+    // On-demand AI, per the honesty rule: only offered when studio/copilot exists.
+    setAssistBusy(true);
+    setAssistError(null);
+    try {
+      const res = await api.invokeAgent('studio', 'copilot', {
+        message:
+          `Mode: improve-instructions.\nRewrite the following assistant instructions to be clearer and more ` +
+          `complete without changing their intent. Reply with ONLY the improved instructions text.\n\n${instructions}`,
+      });
+      onInstructionsChange(res.reply.trim());
+    } catch (e) {
+      setAssistError(e instanceof Error ? e.message : 'AI assist failed');
+    } finally {
+      setAssistBusy(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      {/* Header */}
+      <div className="topbar" style={{ height: 50 }}>
+        <Link to={`/projects/${pns}/${pname}`} style={{ color: 'var(--muted)', display: 'flex' }}>
+          <ArrowLeft size={17} />
+        </Link>
+        <span className="row-logo" style={{ width: 28, height: 28, fontSize: 11, background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+          {initials(agent.name)}
+        </span>
+        <span style={{ fontWeight: 700, color: 'var(--ink)', fontSize: 15 }}>{prettyName(agent.name)}</span>
+        <div style={{ marginLeft: 'auto' }}>
+          {patch.isPending ? (
+            <span className="saving">Saving…</span>
+          ) : patch.isError ? (
+            <span style={{ color: 'var(--bad)', fontSize: 12.5 }}>Save failed — retrying on next edit</span>
+          ) : (
+            <span className="saved">
+              <span className="dot" /> Saved
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Capability summary — every clause derives from a stored field */}
+      <div className="summary">
+        {fileNames.length > 0 && (
+          <>
+            Reads <span className="cap">{fileNames.join(', ')}</span> ·{' '}
+          </>
+        )}
+        {toolNames.length > 0 && (
+          <>
+            can use <span className="cap">{toolNames.join(', ')}</span> ·{' '}
+          </>
+        )}
+        {hasMemory && <b>remembers between conversations · </b>}
+        {inputRows.length > 0 && (
+          <>
+            asks for <b>{inputRows.map((r) => '@' + r.name).join(', ')}</b> ·{' '}
+          </>
+        )}
+        {scheduleHits.length + webhookHits.length > 0 ? (
+          <>
+            runs{' '}
+            <b>
+              {[...scheduleHits.map((s) => cronToEnglish(s.cron_expression)), ...webhookHits.map((w) => `when ${w.description || `/webhooks/${w.path} is called`}`)].join(' and ')}
+            </b>
+          </>
+        ) : (
+          <>started manually in chat</>
+        )}
+      </div>
+
+      <div className="editor-split">
+        <main className="editor-scroll">
+          {/* Instructions */}
+          <section className="card">
+            <div className="card-head">
+              <span className="card-title">Instructions</span>
+              <span className="card-hint">what it should do, in your own words</span>
+            </div>
+            <div className="card-body">
+              <textarea
+                className="input"
+                style={{ minHeight: 160, fontSize: 14.5 }}
+                value={instructions}
+                onChange={(e) => onInstructionsChange(e.target.value)}
+                placeholder="e.g. You triage incoming support requests. Search the product docs first and answer from them when you can…"
+              />
+
+              {/* Guidance (skills) */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 12, position: 'relative' }}>
+                <span style={{ fontSize: 12, color: 'var(--faint)', fontWeight: 600 }}>Also follows:</span>
+                {agent.enabled_skills.map((s) => (
+                  <span key={s.skill} className="skill-chip">
+                    <b>{prettyName(splitRef(s.skill).name)}</b>
+                    <button
+                      className="link-btn"
+                      style={{ padding: 0 }}
+                      title={s.preload ? 'Applied always — click for on-demand' : 'Retrieved when needed — click for always'}
+                      onClick={() =>
+                        patch.mutate({
+                          enabled_skills: agent.enabled_skills.map((x) =>
+                            x.skill === s.skill ? { ...x, preload: !x.preload } : x,
+                          ),
+                        })
+                      }
+                    >
+                      <span className="mode">{s.preload ? 'always' : 'when needed'}</span>
+                    </button>
+                    <button
+                      className="chip-x"
+                      aria-label={`Remove ${s.skill}`}
+                      onClick={() => patch.mutate({ enabled_skills: agent.enabled_skills.filter((x) => x.skill !== s.skill) })}
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
+                <button className="chip-add" onClick={() => setOpenPicker(openPicker === 'guidance' ? null : 'guidance')}>
+                  + Add guidance
+                </button>
+                {openPicker === 'guidance' && (
+                  <Popover onClose={() => setOpenPicker(null)}>
+                    {skills.filter((s) => !enabledSkillRefs.has(`${s.namespace}/${s.name}`)).length === 0 && (
+                      <p style={{ padding: 10, margin: 0, fontSize: 12.5, color: 'var(--muted)' }}>
+                        No other guidance modules in the workspace yet.
+                      </p>
+                    )}
+                    {skills
+                      .filter((s) => !enabledSkillRefs.has(`${s.namespace}/${s.name}`))
+                      .map((s) => (
+                        <button
+                          key={s.id}
+                          className="pop-item"
+                          onClick={() => {
+                            patch.mutate({
+                              enabled_skills: [...agent.enabled_skills, { skill: `${s.namespace}/${s.name}`, preload: false }],
+                            });
+                            setOpenPicker(null);
+                          }}
+                        >
+                          <span style={{ flex: 1, minWidth: 0 }}>
+                            <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>{prettyName(s.name)}</span>
+                            <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)' }}>{s.description}</span>
+                          </span>
+                        </button>
+                      ))}
+                  </Popover>
+                )}
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 12 }}>
+                <button
+                  className="btn btn-secondary btn-sm"
+                  disabled={!copilotAvailable || assistBusy || !instructions.trim()}
+                  title={copilotAvailable ? 'Rewrite for clarity using the workspace copilot' : 'Needs Studio setup — ask your admin to install the studio-runtime package'}
+                  onClick={improveInstructions}
+                >
+                  {assistBusy ? <Loader2 size={13} className="spin" /> : <Sparkles size={13} style={{ color: 'var(--accent)' }} />}
+                  Improve with AI
+                </button>
+                {assistError && <span style={{ fontSize: 12, color: 'var(--bad)' }}>{assistError}</span>}
+                <span style={{ marginLeft: 'auto', fontSize: 11.5, color: 'var(--faint)' }}>
+                  Changes apply immediately — try them in the test chat →
+                </span>
+              </div>
+            </div>
+          </section>
+
+          {/* Tools */}
+          <section className="card" style={{ position: 'relative' }}>
+            <div className="card-head">
+              <span className="card-title">Tools</span>
+              <span className="card-hint">what it's allowed to do in other systems</span>
+            </div>
+            <div className="rows" style={{ marginTop: 10 }}>
+              {agent.enabled_connectors.length === 0 && (
+                <p style={{ padding: '4px 20px 12px', margin: 0, fontSize: 13, color: 'var(--muted)' }}>No tools yet.</p>
+              )}
+              {agent.enabled_connectors.map((entry) => {
+                const ref = splitRef(entry.connector);
+                const connector = connectors.find((c) => c.namespace === ref.namespace && c.name === ref.name);
+                const secretName = connector?.auth?.secret;
+                const needsKey = secrets !== undefined && !!secretName && !secrets.some((s) => s.name === secretName);
+                return (
+                  <div key={entry.connector}>
+                    <div className="row">
+                      <span className="row-logo">
+                        <Plug size={15} />
+                      </span>
+                      <span className="row-main">
+                        <span className="row-name">{prettyName(ref.name)}</span>
+                        <span className="row-desc" style={{ display: 'block' }}>
+                          {connector?.description || entry.connector}
+                        </span>
+                      </span>
+                      <span className="row-side">
+                        {needsKey ? <span className="pill pill-warn">Needs a key</span> : connector && <span className="pill pill-good">Ready</span>}
+                        {!connector && <span className="pill pill-bad">Missing</span>}
+                        <button
+                          className="chip-x"
+                          aria-label={`Remove ${entry.connector}`}
+                          onClick={() =>
+                            patch.mutate({ enabled_connectors: agent.enabled_connectors.filter((c) => c.connector !== entry.connector) })
+                          }
+                        >
+                          <X size={14} />
+                        </button>
+                      </span>
+                    </div>
+                    {connector && connector.operations.length > 0 && (
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, padding: '0 20px 14px 68px' }}>
+                        {connector.operations.map((op) => {
+                          const on = entry.operations.includes(op.name);
+                          return (
+                            <button
+                              key={op.name}
+                              className={`toggle${on ? ' on' : ''}`}
+                              title={op.description || op.name}
+                              onClick={() =>
+                                patch.mutate({
+                                  enabled_connectors: agent.enabled_connectors.map((c) =>
+                                    c.connector === entry.connector
+                                      ? { ...c, operations: on ? c.operations.filter((o) => o !== op.name) : [...c.operations, op.name] }
+                                      : c,
+                                  ),
+                                })
+                              }
+                            >
+                              <span className="sw" /> {prettyName(op.name)}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+              <button className="add-row" onClick={() => setOpenPicker(openPicker === 'tools' ? null : 'tools')}>
+                <Plus size={15} /> Add a tool
+              </button>
+              {openPicker === 'tools' && (
+                <Popover onClose={() => setOpenPicker(null)}>
+                  {connectors.filter((c) => !enabledConnectorRefs.has(`${c.namespace}/${c.name}`)).length === 0 && (
+                    <p style={{ padding: 10, margin: 0, fontSize: 12.5, color: 'var(--muted)' }}>
+                      No more connections available. Your admin can add integrations to the workspace.
+                    </p>
+                  )}
+                  {connectors
+                    .filter((c) => !enabledConnectorRefs.has(`${c.namespace}/${c.name}`))
+                    .map((c) => (
+                      <button
+                        key={c.id}
+                        className="pop-item"
+                        onClick={() => {
+                          patch.mutate({
+                            enabled_connectors: [
+                              ...agent.enabled_connectors,
+                              { connector: `${c.namespace}/${c.name}`, operations: c.operations.map((o) => o.name) },
+                            ],
+                          });
+                          setOpenPicker(null);
+                        }}
+                      >
+                        <span className="row-logo" style={{ width: 28, height: 28 }}>
+                          <Plug size={13} />
+                        </span>
+                        <span style={{ flex: 1, minWidth: 0 }}>
+                          <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>{prettyName(c.name)}</span>
+                          <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)' }}>
+                            {c.description || c.base_url}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                </Popover>
+              )}
+            </div>
+          </section>
+
+          {/* Files & memory */}
+          <section className="card" style={{ position: 'relative' }}>
+            <div className="card-head">
+              <span className="card-title">Files &amp; memory</span>
+              <span className="card-hint">what it can read, keep, and remember</span>
+            </div>
+            <div className="rows" style={{ marginTop: 10 }}>
+              {agent.enabled_collections.map((entry) => {
+                const own = entry.collection === ownFilesRef(agent);
+                return (
+                  <div key={entry.collection} className="row">
+                    <span className="row-logo" style={{ background: own ? '#EDE9FE' : 'var(--good-soft)', color: own ? '#7C3AED' : 'var(--good)' }}>
+                      <BookOpen size={15} />
+                    </span>
+                    <span className="row-main">
+                      <span className="row-name">{own ? 'Its own file space' : prettyName(splitRef(entry.collection).name)}</span>
+                      <span className="row-desc" style={{ display: 'block' }}>
+                        {own ? 'Files it saves or receives live here' : 'Shared library'}
+                      </span>
+                    </span>
+                    <span className="row-side">
+                      <span className={entry.access === 'readwrite' ? 'pill pill-good' : 'pill'}>
+                        {entry.access === 'readwrite' ? 'Read & write' : 'Read only'}
+                      </span>
+                      <button
+                        className="chip-x"
+                        aria-label={`Remove ${entry.collection}`}
+                        onClick={() =>
+                          patch.mutate({ enabled_collections: agent.enabled_collections.filter((c) => c.collection !== entry.collection) })
+                        }
+                      >
+                        <X size={14} />
+                      </button>
+                    </span>
+                  </div>
+                );
+              })}
+              {agent.enabled_stores.map((entry) => {
+                const own = entry.store === memoryRef(agent);
+                return (
+                  <div key={entry.store} className="row">
+                    <span className="row-logo" style={{ background: '#CCFBF1', color: '#0F766E' }}>
+                      <Brain size={15} />
+                    </span>
+                    <span className="row-main">
+                      <span className="row-name">{own ? 'Conversation memory' : prettyName(splitRef(entry.store).name)}</span>
+                      <span className="row-desc" style={{ display: 'block' }}>
+                        {own ? 'Remembers useful facts between conversations' : 'Shared memory'}
+                      </span>
+                    </span>
+                    <span className="row-side">
+                      <span className={entry.access === 'readwrite' ? 'pill pill-good' : 'pill'}>
+                        {entry.access === 'readwrite' ? 'Read & write' : 'Read only'}
+                      </span>
+                      <button
+                        className="chip-x"
+                        aria-label={`Remove ${entry.store}`}
+                        onClick={() => patch.mutate({ enabled_stores: agent.enabled_stores.filter((s) => s.store !== entry.store) })}
+                      >
+                        <X size={14} />
+                      </button>
+                    </span>
+                  </div>
+                );
+              })}
+              {agent.enabled_collections.length === 0 && agent.enabled_stores.length === 0 && (
+                <p style={{ padding: '4px 20px 12px', margin: 0, fontSize: 13, color: 'var(--muted)' }}>
+                  No files or memory yet — it only knows what's in the conversation.
+                </p>
+              )}
+              <button className="add-row" onClick={() => setOpenPicker(openPicker === 'storage' ? null : 'storage')}>
+                <Plus size={15} /> Add files or memory
+              </button>
+              {openPicker === 'storage' && (
+                <Popover onClose={() => setOpenPicker(null)}>
+                  {!hasOwnFiles && (
+                    <button
+                      className="pop-item"
+                      onClick={async () => {
+                        setOpenPicker(null);
+                        // Create-if-missing, then attach read & write.
+                        const { namespace, name } = splitRef(ownFilesRef(agent));
+                        await api.createCollection({ namespace, name }).catch(() => undefined);
+                        patch.mutate({
+                          enabled_collections: [...agent.enabled_collections, { collection: ownFilesRef(agent), access: 'readwrite' }],
+                        });
+                      }}
+                    >
+                      <span className="row-logo" style={{ width: 28, height: 28, background: '#EDE9FE', color: '#7C3AED' }}>
+                        <BookOpen size={13} />
+                      </span>
+                      <span style={{ flex: 1 }}>
+                        <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>Its own file space</span>
+                        <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)' }}>Read & write, created automatically</span>
+                      </span>
+                    </button>
+                  )}
+                  {!hasMemory && (
+                    <button
+                      className="pop-item"
+                      onClick={async () => {
+                        setOpenPicker(null);
+                        const { namespace, name } = splitRef(memoryRef(agent));
+                        await api
+                          .createStore({ namespace, name, description: `Conversation memory for ${agent.namespace}/${agent.name}` })
+                          .catch(() => undefined);
+                        patch.mutate({
+                          enabled_stores: [...agent.enabled_stores, { store: memoryRef(agent), access: 'readwrite' }],
+                        });
+                      }}
+                    >
+                      <span className="row-logo" style={{ width: 28, height: 28, background: '#CCFBF1', color: '#0F766E' }}>
+                        <Brain size={13} />
+                      </span>
+                      <span style={{ flex: 1 }}>
+                        <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>Conversation memory</span>
+                        <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)' }}>Remembers facts between conversations</span>
+                      </span>
+                    </button>
+                  )}
+                  {collections
+                    .filter((c) => !enabledCollectionRefs.has(`${c.namespace}/${c.name}`) && `${c.namespace}/${c.name}` !== ownFilesRef(agent))
+                    .map((c) => (
+                      <button
+                        key={c.id}
+                        className="pop-item"
+                        onClick={() => {
+                          patch.mutate({
+                            enabled_collections: [
+                              ...agent.enabled_collections,
+                              { collection: `${c.namespace}/${c.name}`, access: 'readonly' },
+                            ],
+                          });
+                          setOpenPicker(null);
+                        }}
+                      >
+                        <span className="row-logo" style={{ width: 28, height: 28, background: 'var(--good-soft)', color: 'var(--good)' }}>
+                          <BookOpen size={13} />
+                        </span>
+                        <span style={{ flex: 1 }}>
+                          <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>{prettyName(c.name)}</span>
+                          <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)' }}>Shared library · read only</span>
+                        </span>
+                      </button>
+                    ))}
+                  {stores
+                    .filter((s) => !enabledStoreRefs.has(`${s.namespace}/${s.name}`) && `${s.namespace}/${s.name}` !== memoryRef(agent))
+                    .map((s) => (
+                      <button
+                        key={s.id}
+                        className="pop-item"
+                        onClick={() => {
+                          patch.mutate({
+                            enabled_stores: [...agent.enabled_stores, { store: `${s.namespace}/${s.name}`, access: 'readonly' }],
+                          });
+                          setOpenPicker(null);
+                        }}
+                      >
+                        <span className="row-logo" style={{ width: 28, height: 28 }}>
+                          <Archive size={13} />
+                        </span>
+                        <span style={{ flex: 1 }}>
+                          <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>{prettyName(s.name)}</span>
+                          <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)' }}>Shared memory · read only</span>
+                        </span>
+                      </button>
+                    ))}
+                </Popover>
+              )}
+            </div>
+          </section>
+
+          {/* Inputs */}
+          <section className="card">
+            <div className="card-head">
+              <span className="card-title">Inputs</span>
+              <span className="card-hint">values provided each time it starts</span>
+            </div>
+            <div className="rows" style={{ marginTop: 8 }}>
+              {inputRows.map((row) => (
+                <div key={row.name} className="row" style={{ padding: '11px 20px' }}>
+                  <span className="token">@{row.name}</span>
+                  <span className="row-main" style={{ fontSize: 12.5, color: 'var(--muted)' }}>
+                    {row.description || '—'}
+                  </span>
+                  <span style={{ fontSize: 11.5, color: 'var(--faint)', flexShrink: 0 }}>
+                    {row.kind === 'choice' ? `Choice: ${row.choices.join(' / ')}` : 'Text'}
+                    {row.required ? ' · required' : ' · optional'}
+                  </span>
+                  <button className="link-btn" onClick={() => setInputModal({ row, isNew: false })}>
+                    Edit
+                  </button>
+                  <button
+                    className="chip-x"
+                    aria-label={`Remove @${row.name}`}
+                    onClick={() => saveInputRows(inputRows.filter((r) => r.name !== row.name))}
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+              <button
+                className="add-row"
+                onClick={() => setInputModal({ row: { name: '', description: '', kind: 'text', choices: [], required: false }, isNew: true })}
+              >
+                <Plus size={15} /> Add an input
+              </button>
+            </div>
+            <p style={{ padding: '0 20px 14px', margin: 0, fontSize: 12, color: 'var(--faint)' }}>
+              Inputs are filled in when a chat starts, or supplied automatically by a workflow. Reference them in the
+              instructions as <span className="token">@name</span>.
+            </p>
+          </section>
+
+          {/* Trigger footnotes */}
+          {(scheduleHits.length > 0 || webhookHits.length > 0) && (
+            <aside style={{ border: '1px dashed var(--line)', borderRadius: 12, padding: '14px 20px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {scheduleHits.map((s) => (
+                <div key={s.id} style={{ fontSize: 13, color: 'var(--muted)' }}>
+                  ◷ Runs <b style={{ color: 'var(--ink)' }}>{cronToEnglish(s.cron_expression)}</b>
+                  {s.description ? ` — ${s.description}` : ''}
+                </div>
+              ))}
+              {webhookHits.map((w) => (
+                <div key={w.id} style={{ fontSize: 13, color: 'var(--muted)' }}>
+                  ⚡ Runs when <b style={{ color: 'var(--ink)' }}>{w.description || `/webhooks/${w.path} is called`}</b>
+                </div>
+              ))}
+            </aside>
+          )}
+        </main>
+
+        <TestChat agent={agent} />
+      </div>
+
+      {inputModal && (
+        <InputModal
+          initial={inputModal.row}
+          isNew={inputModal.isNew}
+          existingNames={inputRows.map((r) => r.name)}
+          onSave={(row) => {
+            const rows = inputModal.isNew
+              ? [...inputRows, row]
+              : inputRows.map((r) => (r.name === inputModal.row.name ? row : r));
+            saveInputRows(rows);
+            setInputModal(null);
+          }}
+          onClose={() => setInputModal(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function InputModal({
+  initial,
+  isNew,
+  existingNames,
+  onSave,
+  onClose,
+}: {
+  initial: InputRow;
+  isNew: boolean;
+  existingNames: string[];
+  onSave: (row: InputRow) => void;
+  onClose: () => void;
+}) {
+  const [row, setRow] = useState<InputRow>(initial);
+  const [choicesText, setChoicesText] = useState(initial.choices.join(', '));
+
+  const name = row.name.trim().toLowerCase().replace(/[^a-z0-9_]+/g, '_').replace(/^_+|_+$/g, '');
+  const duplicate = isNew && existingNames.includes(name);
+
+  return (
+    <div className="overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+          <h2 style={{ fontSize: 16 }}>{isNew ? 'New input' : `Edit @${initial.name}`}</h2>
+          <button className="kebab" onClick={onClose} aria-label="Close">
+            <X size={16} />
+          </button>
+        </div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!name || duplicate) return;
+            onSave({
+              ...row,
+              name,
+              choices: row.kind === 'choice' ? choicesText.split(',').map((c) => c.trim()).filter(Boolean) : [],
+            });
+          }}
+          style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+        >
+          <div className="field">
+            <label>Name (becomes @{name || '…'})</label>
+            <input className="input" value={row.name} onChange={(e) => setRow({ ...row, name: e.target.value })} autoFocus={isNew} />
+            {duplicate && <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--bad)' }}>An input with this name already exists.</p>}
+          </div>
+          <div className="field">
+            <label>What is it? (shown when someone fills it in)</label>
+            <input className="input" value={row.description} onChange={(e) => setRow({ ...row, description: e.target.value })} />
+          </div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <div className="field" style={{ flex: 1 }}>
+              <label>Type</label>
+              <select className="input" value={row.kind} onChange={(e) => setRow({ ...row, kind: e.target.value as InputRow['kind'] })}>
+                <option value="text">Text</option>
+                <option value="choice">Choice</option>
+              </select>
+            </div>
+            <div className="field" style={{ display: 'flex', alignItems: 'flex-end', paddingBottom: 6 }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, margin: 0 }}>
+                <input type="checkbox" checked={row.required} onChange={(e) => setRow({ ...row, required: e.target.checked })} />
+                Required
+              </label>
+            </div>
+          </div>
+          {row.kind === 'choice' && (
+            <div className="field">
+              <label>Choices (comma-separated)</label>
+              <input className="input" placeholder="Free, Pro, Enterprise" value={choicesText} onChange={(e) => setChoicesText(e.target.value)} />
+            </div>
+          )}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button className="btn btn-primary" disabled={!name || duplicate}>
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/studio/app/src/screens/Connect.tsx
+++ b/studio/app/src/screens/Connect.tsx
@@ -1,25 +1,46 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { fetchInstanceInfo, login, verifyOtp } from '../lib/api';
 import { normalizeBaseUrl, saveConnection } from '../lib/connection';
 import type { InstanceInfo } from '../lib/types';
 
-type Step = 'workspace' | 'credentials' | 'otp';
+type Step = 'probing' | 'workspace' | 'credentials' | 'otp';
 
 export function Connect() {
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>('workspace');
+  const [step, setStep] = useState<Step>('probing');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [urlInput, setUrlInput] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [info, setInfo] = useState<InstanceInfo | null>(null);
+  // True when Studio is served from the workspace itself (bundled at
+  // <workspace>/studio/) — the workspace step is skipped entirely then.
+  const [workspaceContext, setWorkspaceContext] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [sessionId, setSessionId] = useState('');
   const [otp, setOtp] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchInstanceInfo(window.location.origin)
+      .then((instanceInfo) => {
+        if (cancelled) return;
+        setBaseUrl(window.location.origin);
+        setInfo(instanceInfo);
+        setWorkspaceContext(true);
+        setStep('credentials');
+      })
+      .catch(() => {
+        if (!cancelled) setStep('workspace'); // standalone deployment
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const needsPassword = info?.auth_mode === 'password' || info?.auth_mode === 'password+otp';
 
@@ -78,6 +99,12 @@ export function Connect() {
           Build assistants and automations on your Sinas workspace.
         </p>
 
+        {step === 'probing' && (
+          <div style={{ display: 'grid', placeItems: 'center', padding: 24 }}>
+            <Loader2 size={18} className="spin" />
+          </div>
+        )}
+
         {step === 'workspace' && (
           <form
             onSubmit={(e) => {
@@ -111,12 +138,14 @@ export function Connect() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
           >
-            <p style={{ fontSize: 12.5, color: 'var(--faint)', margin: 0 }}>
-              Connecting to <b style={{ color: 'var(--ink)' }}>{new URL(baseUrl).host}</b>{' '}
-              <button type="button" className="link-btn" onClick={() => setStep('workspace')}>
-                change
-              </button>
-            </p>
+            {!workspaceContext && (
+              <p style={{ fontSize: 12.5, color: 'var(--faint)', margin: 0 }}>
+                Connecting to <b style={{ color: 'var(--ink)' }}>{new URL(baseUrl).host}</b>{' '}
+                <button type="button" className="link-btn" onClick={() => setStep('workspace')}>
+                  change
+                </button>
+              </p>
+            )}
             <div className="field">
               <label>Email</label>
               <input className="input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoFocus />
@@ -164,6 +193,26 @@ export function Connect() {
               {busy ? <Loader2 size={15} className="spin" /> : 'Connect'}
             </button>
           </form>
+        )}
+
+        {/* Deliberately unobtrusive: in workspace context this is an escape
+            hatch for the rare cross-workspace case, not a primary action. */}
+        {workspaceContext && step === 'credentials' && (
+          <p style={{ margin: '18px 0 0', textAlign: 'center' }}>
+            <button
+              type="button"
+              className="link-btn"
+              style={{ fontSize: 11, color: 'var(--faint)', fontWeight: 500 }}
+              onClick={() => {
+                setWorkspaceContext(false);
+                setBaseUrl('');
+                setInfo(null);
+                setStep('workspace');
+              }}
+            >
+              connect to a different workspace
+            </button>
+          </p>
         )}
       </div>
     </div>

--- a/studio/app/src/screens/Connect.tsx
+++ b/studio/app/src/screens/Connect.tsx
@@ -92,10 +92,11 @@ export function Connect() {
   return (
     <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center', padding: 20 }}>
       <div className="card" style={{ width: '100%', maxWidth: 420, padding: 28 }}>
-        <h1 style={{ fontSize: 20, marginBottom: 4 }}>
-          Sinas <span style={{ color: 'var(--accent)' }}>Studio</span>
-        </h1>
-        <p style={{ color: 'var(--muted)', fontSize: 13.5, margin: '0 0 20px' }}>
+        <div className="wordmark" style={{ marginBottom: 6 }}>
+          <span className="wm-name" style={{ fontSize: 22 }}>sinas</span>
+          <span className="wm-app">Studio</span>
+        </div>
+        <p style={{ color: 'var(--muted)', fontSize: 13.5, margin: '0 0 22px' }}>
           Build assistants and automations on your Sinas workspace.
         </p>
 

--- a/studio/app/src/screens/Connect.tsx
+++ b/studio/app/src/screens/Connect.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { fetchInstanceInfo, login, verifyOtp } from '../lib/api';
+import { normalizeBaseUrl, saveConnection } from '../lib/connection';
+import type { InstanceInfo } from '../lib/types';
+
+type Step = 'workspace' | 'credentials' | 'otp';
+
+export function Connect() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>('workspace');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [urlInput, setUrlInput] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [info, setInfo] = useState<InstanceInfo | null>(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [sessionId, setSessionId] = useState('');
+  const [otp, setOtp] = useState('');
+
+  const needsPassword = info?.auth_mode === 'password' || info?.auth_mode === 'password+otp';
+
+  const run = async (fn: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const checkWorkspace = () =>
+    run(async () => {
+      const url = normalizeBaseUrl(urlInput);
+      const instanceInfo = await fetchInstanceInfo(url);
+      setBaseUrl(url);
+      setInfo(instanceInfo);
+      setStep('credentials');
+    });
+
+  const finish = (access: string, refresh: string, user: any) => {
+    saveConnection({ baseUrl, accessToken: access, refreshToken: refresh, user });
+    navigate('/projects');
+  };
+
+  const submitCredentials = () =>
+    run(async () => {
+      const res = await login(baseUrl, email, needsPassword ? password : undefined);
+      if (res.access_token && res.refresh_token && res.user) {
+        finish(res.access_token, res.refresh_token, res.user);
+      } else if (res.session_id) {
+        setSessionId(res.session_id);
+        setStep('otp');
+      } else {
+        setError('Unexpected response from the workspace');
+      }
+    });
+
+  const submitOtp = () =>
+    run(async () => {
+      const res = await verifyOtp(baseUrl, sessionId, otp);
+      finish(res.access_token!, res.refresh_token!, res.user!);
+    });
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center', padding: 20 }}>
+      <div className="card" style={{ width: '100%', maxWidth: 420, padding: 28 }}>
+        <h1 style={{ fontSize: 20, marginBottom: 4 }}>
+          Sinas <span style={{ color: 'var(--accent)' }}>Studio</span>
+        </h1>
+        <p style={{ color: 'var(--muted)', fontSize: 13.5, margin: '0 0 20px' }}>
+          Build assistants and automations on your Sinas workspace.
+        </p>
+
+        {step === 'workspace' && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              checkWorkspace();
+            }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
+          >
+            <div className="field">
+              <label>Workspace address</label>
+              <input
+                className="input"
+                placeholder="sinas.yourcompany.com"
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                autoFocus
+              />
+            </div>
+            {error && <div className="error-box">{error}</div>}
+            <button className="btn btn-primary" disabled={busy || !urlInput.trim()} style={{ justifyContent: 'center' }}>
+              {busy ? <Loader2 size={15} className="spin" /> : 'Continue'}
+            </button>
+          </form>
+        )}
+
+        {step === 'credentials' && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              submitCredentials();
+            }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
+          >
+            <p style={{ fontSize: 12.5, color: 'var(--faint)', margin: 0 }}>
+              Connecting to <b style={{ color: 'var(--ink)' }}>{new URL(baseUrl).host}</b>{' '}
+              <button type="button" className="link-btn" onClick={() => setStep('workspace')}>
+                change
+              </button>
+            </p>
+            <div className="field">
+              <label>Email</label>
+              <input className="input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoFocus />
+            </div>
+            {needsPassword && (
+              <div className="field">
+                <label>Password</label>
+                <input className="input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+              </div>
+            )}
+            {error && <div className="error-box">{error}</div>}
+            <button
+              className="btn btn-primary"
+              disabled={busy || !email.trim() || (needsPassword && !password)}
+              style={{ justifyContent: 'center' }}
+            >
+              {busy ? <Loader2 size={15} className="spin" /> : needsPassword ? 'Sign in' : 'Email me a code'}
+            </button>
+          </form>
+        )}
+
+        {step === 'otp' && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              submitOtp();
+            }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
+          >
+            <p style={{ fontSize: 13, color: 'var(--muted)', margin: 0 }}>
+              We sent a sign-in code to <b style={{ color: 'var(--ink)' }}>{email}</b>.
+            </p>
+            <div className="field">
+              <label>Code</label>
+              <input
+                className="input"
+                inputMode="numeric"
+                value={otp}
+                onChange={(e) => setOtp(e.target.value)}
+                autoFocus
+              />
+            </div>
+            {error && <div className="error-box">{error}</div>}
+            <button className="btn btn-primary" disabled={busy || !otp.trim()} style={{ justifyContent: 'center' }}>
+              {busy ? <Loader2 size={15} className="spin" /> : 'Connect'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/studio/app/src/screens/ProjectHome.tsx
+++ b/studio/app/src/screens/ProjectHome.tsx
@@ -1,0 +1,255 @@
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Bot, Clock, Loader2, Plus, Webhook as WebhookIcon, X, Zap } from 'lucide-react';
+import { api } from '../lib/api';
+import { cronToEnglish, initials, kebab, prettyName, projectMembers } from '../lib/model';
+import type { Manifest, ManifestResourceRef } from '../lib/types';
+
+function AddAssistantModal({ project, onClose }: { project: Manifest; onClose: () => void }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [mode, setMode] = useState<'existing' | 'new'>('existing');
+  const [newName, setNewName] = useState('');
+  const { data: agents } = useQuery({ queryKey: ['agents'], queryFn: api.listAgents });
+
+  const memberIds = new Set(
+    projectMembers(project).assistants.map((r) => `${r.namespace}/${r.name}`),
+  );
+  const candidates = (agents ?? []).filter((a) => a.is_active && !memberIds.has(`${a.namespace}/${a.name}`));
+
+  const addMember = useMutation({
+    mutationFn: (ref: ManifestResourceRef) =>
+      api.updateProject(project.namespace, project.name, {
+        required_resources: [...(project.required_resources ?? []), ref],
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['project', project.namespace, project.name] }),
+  });
+
+  const createNew = useMutation({
+    mutationFn: async () => {
+      // New assistants land in the project's namespace by convention.
+      const agent = await api.createAgent({ namespace: project.namespace, name: kebab(newName) });
+      await api.updateProject(project.namespace, project.name, {
+        required_resources: [
+          ...(project.required_resources ?? []),
+          { type: 'agent', namespace: agent.namespace, name: agent.name },
+        ],
+      });
+      return agent;
+    },
+    onSuccess: (agent) => {
+      queryClient.invalidateQueries();
+      navigate(`/projects/${project.namespace}/${project.name}/assistants/${agent.namespace}/${agent.name}`);
+    },
+  });
+
+  return (
+    <div className="overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 14 }}>
+          <h2 style={{ fontSize: 16 }}>Add an assistant</h2>
+          <button className="kebab" onClick={onClose} aria-label="Close">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, marginBottom: 14 }}>
+          <button
+            className={mode === 'existing' ? 'btn btn-primary btn-sm' : 'btn btn-secondary btn-sm'}
+            onClick={() => setMode('existing')}
+          >
+            Existing
+          </button>
+          <button
+            className={mode === 'new' ? 'btn btn-primary btn-sm' : 'btn btn-secondary btn-sm'}
+            onClick={() => setMode('new')}
+          >
+            New assistant
+          </button>
+        </div>
+
+        {mode === 'existing' ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 300, overflowY: 'auto' }}>
+            {candidates.length === 0 && (
+              <p style={{ fontSize: 13, color: 'var(--muted)' }}>Every assistant in the workspace is already on this project.</p>
+            )}
+            {candidates.map((a) => (
+              <button
+                key={a.id}
+                className="pop-item"
+                disabled={addMember.isPending}
+                onClick={() =>
+                  addMember.mutate({ type: 'agent', namespace: a.namespace, name: a.name }, { onSuccess: onClose })
+                }
+              >
+                <span className="row-logo" style={{ width: 28, height: 28, fontSize: 11, background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+                  {initials(a.name)}
+                </span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ display: 'block', fontWeight: 600, color: 'var(--ink)', fontSize: 13 }}>{prettyName(a.name)}</span>
+                  <span style={{ display: 'block', fontSize: 11.5, color: 'var(--faint)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {a.description || `${a.namespace}/${a.name}`}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (newName.trim()) createNew.mutate();
+            }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+          >
+            <div className="field">
+              <label>Assistant name</label>
+              <input className="input" placeholder="e.g. Triage assistant" value={newName} onChange={(e) => setNewName(e.target.value)} autoFocus />
+            </div>
+            {createNew.isError && <div className="error-box">{(createNew.error as Error).message}</div>}
+            <button className="btn btn-primary" disabled={!newName.trim() || createNew.isPending} style={{ justifyContent: 'center' }}>
+              {createNew.isPending ? <Loader2 size={14} className="spin" /> : 'Create & open editor'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ProjectHome() {
+  const { ns, name } = useParams<{ ns: string; name: string }>();
+  const [showAdd, setShowAdd] = useState(false);
+
+  const { data: project, isLoading } = useQuery({
+    queryKey: ['project', ns, name],
+    queryFn: () => api.getProject(ns!, name!),
+    enabled: !!ns && !!name,
+  });
+  const { data: schedules } = useQuery({ queryKey: ['schedules'], queryFn: api.listSchedules });
+  const { data: webhooks } = useQuery({ queryKey: ['webhooks'], queryFn: api.listWebhooks });
+  const { data: agents } = useQuery({ queryKey: ['agents'], queryFn: api.listAgents });
+
+  if (isLoading || !project) {
+    return (
+      <div className="empty">
+        <Loader2 size={20} className="spin" style={{ margin: '20px auto', display: 'block' }} />
+      </div>
+    );
+  }
+
+  const members = projectMembers(project);
+
+  return (
+    <div className="page" style={{ width: '100%' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 4 }}>
+        <Link to="/projects" style={{ color: 'var(--muted)', display: 'flex' }}>
+          <ArrowLeft size={18} />
+        </Link>
+        <h1 style={{ fontSize: 20 }}>{prettyName(project.name)}</h1>
+      </div>
+      {project.description && (
+        <p style={{ color: 'var(--muted)', margin: '0 0 24px 30px', fontSize: 13.5 }}>{project.description}</p>
+      )}
+
+      {/* Assistants */}
+      <section className="card" style={{ marginTop: 16 }}>
+        <div className="card-head" style={{ justifyContent: 'space-between', paddingBottom: 4 }}>
+          <span className="card-title">Assistants</span>
+        </div>
+        <div className="rows">
+          {members.assistants.length === 0 && (
+            <p style={{ padding: '10px 20px', margin: 0, fontSize: 13, color: 'var(--muted)' }}>
+              No assistants on this project yet.
+            </p>
+          )}
+          {members.assistants.map((ref) => {
+            const agent = agents?.find((a) => a.namespace === ref.namespace && a.name === ref.name);
+            return (
+              <Link
+                key={`${ref.namespace}/${ref.name}`}
+                to={`/projects/${project.namespace}/${project.name}/assistants/${ref.namespace}/${ref.name}`}
+                className="row"
+                style={{ color: 'inherit', textDecoration: 'none' }}
+              >
+                <span className="row-logo" style={{ background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+                  {agent ? initials(agent.name) : <Bot size={15} />}
+                </span>
+                <span className="row-main">
+                  <span className="row-name">{prettyName(ref.name)}</span>
+                  <span className="row-desc" style={{ display: 'block' }}>
+                    {agent ? agent.description || 'No description yet' : 'Missing from the workspace'}
+                  </span>
+                </span>
+                <span className="row-side">
+                  {!agent && <span className="pill pill-bad">Missing</span>}
+                  {agent && <span className="pill">Open editor →</span>}
+                </span>
+              </Link>
+            );
+          })}
+          <button className="add-row" onClick={() => setShowAdd(true)}>
+            <Plus size={15} /> Add an assistant
+          </button>
+        </div>
+      </section>
+
+      {/* Workflows */}
+      <section className="card" style={{ marginTop: 18 }}>
+        <div className="card-head" style={{ paddingBottom: 4 }}>
+          <span className="card-title">Workflows</span>
+          <span className="card-hint">what runs automatically</span>
+        </div>
+        <div className="rows">
+          {members.workflows.length === 0 && (
+            <p style={{ padding: '10px 20px 16px', margin: 0, fontSize: 13, color: 'var(--muted)' }}>
+              No workflows on this project yet. The workflow editor arrives in the next iteration — schedules and
+              webhooks created in the admin console appear here once added to the project.
+            </p>
+          )}
+          {members.workflows.map((ref) => {
+            const kind = ref.type.replace(/s$/, '');
+            const schedule = kind === 'schedule' ? schedules?.find((s) => s.name === ref.name) : undefined;
+            const webhook = kind === 'webhook' ? webhooks?.find((w) => w.path === ref.name) : undefined;
+            const exists = !!(schedule || webhook);
+            return (
+              <div key={`${ref.type}:${ref.name}`} className="row">
+                <span className="row-logo" style={{ background: 'var(--warn-soft)', color: 'var(--warn)' }}>
+                  {kind === 'schedule' ? <Clock size={15} /> : <WebhookIcon size={15} />}
+                </span>
+                <span className="row-main">
+                  <span className="row-name">
+                    {schedule
+                      ? `Runs ${cronToEnglish(schedule.cron_expression)}`
+                      : webhook
+                        ? webhook.description || `When ${webhook.http_method} /webhooks/${webhook.path} is called`
+                        : prettyName(ref.name)}
+                  </span>
+                  <span className="row-desc" style={{ display: 'block' }}>
+                    {schedule
+                      ? schedule.description || schedule.name
+                      : webhook
+                        ? `/webhooks/${webhook.path}${webhook.requires_auth ? '' : ' · public'}`
+                        : 'Missing from the workspace'}
+                  </span>
+                </span>
+                <span className="row-side">
+                  {!exists && <span className="pill pill-bad">Missing</span>}
+                  {schedule && <span className={schedule.is_active ? 'pill pill-good' : 'pill'}>{schedule.is_active ? 'On' : 'Off'}</span>}
+                  {webhook && <span className={webhook.is_active ? 'pill pill-good' : 'pill'}>{webhook.is_active ? 'On' : 'Off'}</span>}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <p style={{ fontSize: 12, color: 'var(--faint)', marginTop: 16, display: 'flex', alignItems: 'center', gap: 6 }}>
+        <Zap size={13} /> Removing something here only takes it off the project — it never deletes the resource.
+      </p>
+
+      {showAdd && <AddAssistantModal project={project} onClose={() => setShowAdd(false)} />}
+    </div>
+  );
+}

--- a/studio/app/src/screens/ProjectHome.tsx
+++ b/studio/app/src/screens/ProjectHome.tsx
@@ -204,8 +204,7 @@ export function ProjectHome() {
         <div className="rows">
           {members.workflows.length === 0 && (
             <p style={{ padding: '10px 20px 16px', margin: 0, fontSize: 13, color: 'var(--muted)' }}>
-              No workflows on this project yet. The workflow editor arrives in the next iteration — schedules and
-              webhooks created in the admin console appear here once added to the project.
+              No workflows on this project yet.
             </p>
           )}
           {members.workflows.map((ref) => {
@@ -213,8 +212,18 @@ export function ProjectHome() {
             const schedule = kind === 'schedule' ? schedules?.find((s) => s.name === ref.name) : undefined;
             const webhook = kind === 'webhook' ? webhooks?.find((w) => w.path === ref.name) : undefined;
             const exists = !!(schedule || webhook);
+            const href = schedule
+              ? `/projects/${project.namespace}/${project.name}/workflows/schedule/${encodeURIComponent(schedule.name)}`
+              : webhook
+                ? `/projects/${project.namespace}/${project.name}/workflows/webhook/${webhook.path}`
+                : undefined;
             return (
-              <div key={`${ref.type}:${ref.name}`} className="row">
+              <Link
+                key={`${ref.type}:${ref.name}`}
+                to={href ?? '#'}
+                className="row"
+                style={{ color: 'inherit', textDecoration: 'none', pointerEvents: href ? undefined : 'none' }}
+              >
                 <span className="row-logo" style={{ background: 'var(--warn-soft)', color: 'var(--warn)' }}>
                   {kind === 'schedule' ? <Clock size={15} /> : <WebhookIcon size={15} />}
                 </span>
@@ -239,9 +248,12 @@ export function ProjectHome() {
                   {schedule && <span className={schedule.is_active ? 'pill pill-good' : 'pill'}>{schedule.is_active ? 'On' : 'Off'}</span>}
                   {webhook && <span className={webhook.is_active ? 'pill pill-good' : 'pill'}>{webhook.is_active ? 'On' : 'Off'}</span>}
                 </span>
-              </div>
+              </Link>
             );
           })}
+          <Link className="add-row" to={`/projects/${project.namespace}/${project.name}/workflows/new`} style={{ textDecoration: 'none' }}>
+            <Plus size={15} /> Add a workflow
+          </Link>
         </div>
       </section>
 

--- a/studio/app/src/screens/ProjectHome.tsx
+++ b/studio/app/src/screens/ProjectHome.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Bot, Clock, Loader2, Plus, Webhook as WebhookIcon, X, Zap } from 'lucide-react';
 import { api } from '../lib/api';
-import { cronToEnglish, initials, kebab, prettyName, projectMembers } from '../lib/model';
+import { avatarStyle, cronToEnglish, initials, kebab, prettyName, projectMembers } from '../lib/model';
 import type { Manifest, ManifestResourceRef } from '../lib/types';
 
 function AddAssistantModal({ project, onClose }: { project: Manifest; onClose: () => void }) {
@@ -83,7 +83,7 @@ function AddAssistantModal({ project, onClose }: { project: Manifest; onClose: (
                   addMember.mutate({ type: 'agent', namespace: a.namespace, name: a.name }, { onSuccess: onClose })
                 }
               >
-                <span className="row-logo" style={{ width: 28, height: 28, fontSize: 11, background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+                <span className="row-logo" style={{ width: 28, height: 28, fontSize: 11, ...avatarStyle(a.name) }}>
                   {initials(a.name)}
                 </span>
                 <span style={{ flex: 1, minWidth: 0 }}>
@@ -173,7 +173,7 @@ export function ProjectHome() {
                 className="row"
                 style={{ color: 'inherit', textDecoration: 'none' }}
               >
-                <span className="row-logo" style={{ background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+                <span className="row-logo" style={agent ? avatarStyle(agent.name) : undefined}>
                   {agent ? initials(agent.name) : <Bot size={15} />}
                 </span>
                 <span className="row-main">

--- a/studio/app/src/screens/Projects.tsx
+++ b/studio/app/src/screens/Projects.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowRight, FolderKanban, Loader2, Plus, X } from 'lucide-react';
+import { api } from '../lib/api';
+import { kebab, prettyName, projectMembers } from '../lib/model';
+
+function NewProjectModal({ onClose }: { onClose: () => void }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const create = useMutation({
+    mutationFn: () =>
+      api.createProject({
+        namespace: kebab(name),
+        name: kebab(name),
+        description: description || undefined,
+        required_resources: [],
+      }),
+    onSuccess: (manifest) => {
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      navigate(`/projects/${manifest.namespace}/${manifest.name}`);
+    },
+  });
+
+  return (
+    <div className="overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+          <h2 style={{ fontSize: 16 }}>New project</h2>
+          <button className="kebab" onClick={onClose} aria-label="Close">
+            <X size={16} />
+          </button>
+        </div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (name.trim()) create.mutate();
+          }}
+          style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
+        >
+          <div className="field">
+            <label>Name</label>
+            <input className="input" placeholder="e.g. Support triage" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
+          </div>
+          <div className="field">
+            <label>What is it for? (optional)</label>
+            <input className="input" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+          {create.isError && <div className="error-box">{(create.error as Error).message}</div>}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button className="btn btn-primary" disabled={!name.trim() || create.isPending}>
+              {create.isPending ? <Loader2 size={14} className="spin" /> : 'Create project'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function Projects() {
+  const [showCreate, setShowCreate] = useState(false);
+  const { data: projects, isLoading, isError, error } = useQuery({
+    queryKey: ['projects'],
+    queryFn: api.listProjects,
+  });
+
+  return (
+    <div className="page" style={{ width: '100%' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12, marginBottom: 22 }}>
+        <div>
+          <h1 style={{ fontSize: 22 }}>Projects</h1>
+          <p style={{ color: 'var(--muted)', margin: '4px 0 0', fontSize: 13.5 }}>
+            Each project groups the assistants and workflows that make up one solution.
+          </p>
+        </div>
+        <button className="btn btn-primary" onClick={() => setShowCreate(true)}>
+          <Plus size={15} /> New project
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="empty">
+          <Loader2 size={20} className="spin" style={{ margin: '0 auto 8px', display: 'block' }} /> Loading…
+        </div>
+      ) : isError ? (
+        <div className="error-box">Couldn't load projects: {(error as Error).message}</div>
+      ) : !projects || projects.length === 0 ? (
+        <div className="card empty">
+          <FolderKanban size={30} style={{ margin: '0 auto 10px', display: 'block', color: 'var(--faint)' }} />
+          <p style={{ margin: 0 }}>No projects yet — create the first one.</p>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gap: 14, gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))' }}>
+          {projects.map((p) => {
+            const members = projectMembers(p);
+            return (
+              <Link key={p.id} to={`/projects/${p.namespace}/${p.name}`} className="card" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span className="row-logo" style={{ background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}>
+                    <FolderKanban size={16} />
+                  </span>
+                  <span style={{ fontWeight: 700, color: 'var(--ink)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {prettyName(p.name)}
+                  </span>
+                  <ArrowRight size={14} style={{ color: 'var(--faint)' }} />
+                </div>
+                <p style={{ margin: 0, fontSize: 12.5, color: 'var(--muted)', minHeight: 34 }}>
+                  {p.description || 'No description yet.'}
+                </p>
+                <p style={{ margin: 0, fontSize: 11.5, color: 'var(--faint)' }}>
+                  {members.assistants.length} assistant{members.assistants.length === 1 ? '' : 's'} ·{' '}
+                  {members.workflows.length} workflow{members.workflows.length === 1 ? '' : 's'}
+                </p>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      {showCreate && <NewProjectModal onClose={() => setShowCreate(false)} />}
+    </div>
+  );
+}

--- a/studio/app/src/screens/WorkflowEditor.tsx
+++ b/studio/app/src/screens/WorkflowEditor.tsx
@@ -15,6 +15,7 @@ import {
   type SchedulePreset,
 } from '../lib/model';
 import type { Agent, Execution, Manifest } from '../lib/types';
+import { SetupStudioLink } from '../components/SetupStudio';
 
 // ---------- shared bits ----------
 
@@ -569,10 +570,18 @@ export function NewWorkflow() {
             <WebhookIcon size={16} style={{ color: 'var(--warn)', marginBottom: 6 }} />
             <div style={{ fontWeight: 650, color: 'var(--ink)', fontSize: 13.5 }}>A web request</div>
             <div style={{ fontSize: 12, color: 'var(--faint)' }}>
-              {adapters.length ? 'A form or another tool calls a URL' : 'Needs Studio setup — ask your admin'}
+              {adapters.length ? 'A form or another tool calls a URL' : 'Needs Studio setup'}
             </div>
           </button>
         </div>
+        {adapters.length === 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 10 }}>
+            <span style={{ fontSize: 12.5, color: 'var(--muted)' }}>
+              Webhook workflows need the studio-runtime package in this workspace.
+            </span>
+            <SetupStudioLink />
+          </div>
+        )}
       </div>
 
       {kind && (

--- a/studio/app/src/screens/WorkflowEditor.tsx
+++ b/studio/app/src/screens/WorkflowEditor.tsx
@@ -1,0 +1,669 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, ArrowLeft, ArrowRight, Bot, Clock, Copy, Loader2, Webhook as WebhookIcon } from 'lucide-react';
+import { api } from '../lib/api';
+import { getConnection } from '../lib/connection';
+import {
+  SCHEDULE_PRESETS,
+  adapterPayloadFields,
+  cronFromPreset,
+  isAdapter,
+  kebab,
+  presetFromCron,
+  prettyName,
+  type SchedulePreset,
+} from '../lib/model';
+import type { Agent, Execution, Manifest } from '../lib/types';
+
+// ---------- shared bits ----------
+
+function OnOffSwitch({ on, busy, onChange }: { on: boolean; busy: boolean; onChange: (next: boolean) => void }) {
+  return (
+    <button
+      className={`toggle${on ? ' on' : ''}`}
+      style={{ fontWeight: 700, color: on ? 'var(--good)' : 'var(--faint)' }}
+      disabled={busy}
+      onClick={() => onChange(!on)}
+      title="Off = assembled but inert. The switch is the publish moment."
+    >
+      <span className="sw" /> {on ? 'On' : 'Off'}
+    </button>
+  );
+}
+
+function AssistantSelect({
+  agents,
+  value,
+  onChange,
+}: {
+  agents: Agent[];
+  value: string; // "namespace/name" or ''
+  onChange: (ref: string) => void;
+}) {
+  return (
+    <select className="input" value={value} onChange={(e) => onChange(e.target.value)}>
+      <option value="">Choose an assistant…</option>
+      {agents
+        .filter((a) => a.is_active)
+        .map((a) => (
+          <option key={a.id} value={`${a.namespace}/${a.name}`}>
+            {prettyName(a.name)} ({a.namespace})
+          </option>
+        ))}
+    </select>
+  );
+}
+
+/**
+ * Per-fire history. Executions carry trigger_type + trigger_id, so a
+ * webhook's runs are filterable precisely. Agent-type schedules start chats
+ * rather than function executions, so their rail may legitimately be empty —
+ * the copy says so instead of pretending.
+ */
+function RunsRail({ triggerType, triggerId, emptyNote }: { triggerType: string; triggerId: string; emptyNote: string }) {
+  const { data: executions, isLoading } = useQuery({
+    queryKey: ['executions', triggerType],
+    queryFn: () => api.listExecutions({ trigger_type: triggerType, limit: 50 }),
+    refetchInterval: 15000,
+    retry: false,
+  });
+  const runs = (executions ?? []).filter((e: Execution) => e.trigger_id === triggerId);
+
+  return (
+    <aside className="chat-pane">
+      <div className="pane-head">
+        <div>
+          <div className="pane-title">Runs</div>
+          <div className="pane-sub">Every time this workflow fired</div>
+        </div>
+      </div>
+      <div className="pane-scroll" style={{ gap: 0, paddingTop: 6 }}>
+        {isLoading && <Loader2 size={16} className="spin" style={{ margin: '12px auto' }} />}
+        {!isLoading && runs.length === 0 && (
+          <p style={{ fontSize: 12.5, color: 'var(--muted)', padding: '8px 2px' }}>{emptyNote}</p>
+        )}
+        {runs.map((run) => (
+          <div key={run.execution_id} style={{ display: 'flex', gap: 10, padding: '10px 0', borderBottom: '1px solid var(--line-soft)' }}>
+            <span
+              style={{
+                width: 8, height: 8, borderRadius: '50%', marginTop: 6, flexShrink: 0,
+                background: run.status === 'completed' ? 'var(--good)' : run.status === 'failed' ? 'var(--bad)' : 'var(--faint)',
+              }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, color: 'var(--ink)', fontWeight: 600 }}>
+                {run.status === 'completed' ? 'Succeeded' : run.status === 'failed' ? 'Failed' : run.status}
+                {run.duration_ms != null && <span style={{ color: 'var(--faint)', fontWeight: 400 }}> · {(run.duration_ms / 1000).toFixed(1)}s</span>}
+              </div>
+              <div style={{ fontSize: 11.5, color: 'var(--faint)' }}>
+                {run.started_at ? new Date(run.started_at).toLocaleString() : ''}
+              </div>
+              {run.error && (
+                <div style={{ marginTop: 6, background: 'var(--bad-soft)', borderRadius: 8, padding: '8px 10px', fontSize: 12, color: 'var(--bad)', wordBreak: 'break-word' }}>
+                  {run.error}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="hint-strip">Off = assembled but inert. The switch is the publish moment.</div>
+    </aside>
+  );
+}
+
+function StripCard({
+  kicker,
+  title,
+  icon,
+  tone,
+  children,
+}: {
+  kicker: string;
+  title: string;
+  icon: React.ReactNode;
+  tone: 'trigger' | 'action';
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="card" style={{ width: 330, flexShrink: 0 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 18px', borderBottom: '1px solid var(--line-soft)' }}>
+        <span
+          className="row-logo"
+          style={tone === 'trigger' ? { background: 'var(--warn-soft)', color: 'var(--warn)' } : { background: 'var(--accent-soft)', color: 'var(--accent-ink)' }}
+        >
+          {icon}
+        </span>
+        <div>
+          <div style={{ fontSize: 10.5, fontWeight: 800, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--faint)' }}>{kicker}</div>
+          <div style={{ fontSize: 14.5, fontWeight: 700, color: 'var(--ink)' }}>{title}</div>
+        </div>
+      </div>
+      <div style={{ padding: '14px 18px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>{children}</div>
+    </div>
+  );
+}
+
+function StripArrow() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', padding: '0 18px' }}>
+      <ArrowRight size={18} style={{ color: 'var(--faint)' }} />
+    </div>
+  );
+}
+
+const PUBLIC_WARNING = 'Public link — anyone who has this URL can trigger this workflow. Fine for website forms; don’t share it further.';
+
+// ---------- schedule workflow ----------
+
+export function ScheduleWorkflow() {
+  const { pns, pname, name } = useParams<{ pns: string; pname: string; name: string }>();
+  const queryClient = useQueryClient();
+
+  const { data: schedules } = useQuery({ queryKey: ['schedules'], queryFn: api.listSchedules });
+  const { data: agents } = useQuery({ queryKey: ['agents'], queryFn: api.listAgents });
+  const schedule = schedules?.find((s) => s.name === name);
+
+  const patch = useMutation({
+    mutationFn: (data: Parameters<typeof api.updateSchedule>[1]) => api.updateSchedule(name!, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['schedules'] }),
+  });
+
+  // Local draft for the agent message, autosaved on blur.
+  const [content, setContent] = useState<string | null>(null);
+
+  if (!schedules) return <Loader2 size={20} className="spin" style={{ margin: '40px auto', display: 'block' }} />;
+  if (!schedule) {
+    return (
+      <div className="empty">
+        This schedule no longer exists in the workspace.{' '}
+        <Link to={`/projects/${pns}/${pname}`}>Back to the project</Link>
+      </div>
+    );
+  }
+
+  const parsed = presetFromCron(schedule.cron_expression);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      <div className="topbar" style={{ height: 50 }}>
+        <Link to={`/projects/${pns}/${pname}`} style={{ color: 'var(--muted)', display: 'flex' }}>
+          <ArrowLeft size={17} />
+        </Link>
+        <span className="row-logo" style={{ width: 28, height: 28, background: 'var(--warn-soft)', color: 'var(--warn)' }}>
+          <Clock size={14} />
+        </span>
+        <span style={{ fontWeight: 700, color: 'var(--ink)', fontSize: 15 }}>{schedule.description || prettyName(schedule.name)}</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 12, alignItems: 'center' }}>
+          {patch.isPending ? <span className="saving">Saving…</span> : <span className="saved"><span className="dot" /> Saved</span>}
+          <OnOffSwitch on={schedule.is_active} busy={patch.isPending} onChange={(next) => patch.mutate({ is_active: next })} />
+        </div>
+      </div>
+
+      <div className="editor-split">
+        <div style={{ overflow: 'auto', padding: '40px 28px', display: 'flex', alignItems: 'flex-start', justifyContent: 'center' }}>
+          <StripCard kicker="When" title="On a schedule" icon={<Clock size={15} />} tone="trigger">
+            <div style={{ display: 'flex', gap: 10 }}>
+              <div className="field" style={{ flex: 1 }}>
+                <label>How often</label>
+                <select
+                  className="input"
+                  value={parsed?.preset ?? ''}
+                  onChange={(e) =>
+                    patch.mutate({ cron_expression: cronFromPreset(e.target.value as SchedulePreset, parsed?.time ?? '09:00') })
+                  }
+                >
+                  {!parsed && <option value="">Custom: {schedule.cron_expression}</option>}
+                  {SCHEDULE_PRESETS.map((p) => (
+                    <option key={p.value} value={p.value}>{p.label}</option>
+                  ))}
+                </select>
+              </div>
+              {parsed && parsed.preset !== 'hourly' && (
+                <div className="field">
+                  <label>At</label>
+                  <input
+                    type="time"
+                    className="input"
+                    value={parsed.time}
+                    onChange={(e) => patch.mutate({ cron_expression: cronFromPreset(parsed.preset, e.target.value) })}
+                  />
+                </div>
+              )}
+            </div>
+            <p style={{ margin: 0, fontSize: 11.5, color: 'var(--faint)' }}>
+              Timezone: {schedule.timezone}
+              {schedule.last_run ? ` · last ran ${new Date(schedule.last_run).toLocaleString()}` : ' · has not run yet'}
+            </p>
+          </StripCard>
+
+          <StripArrow />
+
+          <StripCard
+            kicker="Then"
+            title={schedule.schedule_type === 'agent' ? 'Ask an assistant' : 'Run a step'}
+            icon={<Bot size={15} />}
+            tone="action"
+          >
+            {schedule.schedule_type === 'agent' ? (
+              <>
+                <div className="field">
+                  <label>Assistant</label>
+                  <AssistantSelect
+                    agents={agents ?? []}
+                    value={`${schedule.target_namespace}/${schedule.target_name}`}
+                    onChange={(ref) => {
+                      const [target_namespace, target_name] = ref.split('/');
+                      if (target_name) patch.mutate({ target_namespace, target_name });
+                    }}
+                  />
+                </div>
+                <div className="field">
+                  <label>With this request, each run</label>
+                  <textarea
+                    className="input"
+                    style={{ minHeight: 70 }}
+                    value={content ?? schedule.content ?? ''}
+                    onChange={(e) => setContent(e.target.value)}
+                    onBlur={() => {
+                      if (content !== null && content !== schedule.content) patch.mutate({ content });
+                    }}
+                  />
+                </div>
+                <Link
+                  to={`/projects/${pns}/${pname}/assistants/${schedule.target_namespace}/${schedule.target_name}`}
+                  className="link-btn"
+                  style={{ alignSelf: 'flex-start' }}
+                >
+                  Open assistant editor →
+                </Link>
+              </>
+            ) : (
+              <p style={{ margin: 0, fontSize: 13, color: 'var(--muted)' }}>
+                Runs the step <b style={{ color: 'var(--ink)' }}>{schedule.target_namespace}/{schedule.target_name}</b> —
+                a reusable step set up by your admin.
+              </p>
+            )}
+          </StripCard>
+        </div>
+
+        <RunsRail
+          triggerType="schedule"
+          triggerId={schedule.id}
+          emptyNote={
+            schedule.schedule_type === 'agent'
+              ? 'Assistant schedules start conversations rather than recorded runs — check the assistant’s chats for results.'
+              : 'No runs recorded yet.'
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------- webhook workflow ----------
+
+export function WebhookWorkflow() {
+  const { pns, pname } = useParams<{ pns: string; pname: string }>();
+  const path = useParams()['*'] ?? '';
+  const queryClient = useQueryClient();
+
+  const { data: webhooks } = useQuery({ queryKey: ['webhooks'], queryFn: api.listWebhooks });
+  const { data: agents } = useQuery({ queryKey: ['agents'], queryFn: api.listAgents });
+  const { data: functions } = useQuery({ queryKey: ['functions'], queryFn: api.listFunctions });
+  const webhook = webhooks?.find((w) => w.path === path);
+  const adapter = functions?.find((f) => webhook && f.namespace === webhook.function_namespace && f.name === webhook.function_name);
+
+  const patch = useMutation({
+    mutationFn: (data: Parameters<typeof api.updateWebhook>[1]) => api.updateWebhook(path, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['webhooks'] }),
+  });
+
+  const [template, setTemplate] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  if (!webhooks) return <Loader2 size={20} className="spin" style={{ margin: '40px auto', display: 'block' }} />;
+  if (!webhook) {
+    return (
+      <div className="empty">
+        This webhook no longer exists in the workspace. <Link to={`/projects/${pns}/${pname}`}>Back to the project</Link>
+      </div>
+    );
+  }
+
+  const url = `${getConnection()?.baseUrl}/webhooks/${webhook.path}`;
+  const defaults = webhook.default_values ?? {};
+  const isAdapterHook = adapter ? isAdapter(adapter) : 'studio_agent' in defaults;
+  const payloadFields = adapter ? adapterPayloadFields(adapter) : [];
+
+  const saveDefaults = (patchValues: Record<string, any>) =>
+    patch.mutate({ default_values: { ...defaults, ...patchValues } });
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      <div className="topbar" style={{ height: 50 }}>
+        <Link to={`/projects/${pns}/${pname}`} style={{ color: 'var(--muted)', display: 'flex' }}>
+          <ArrowLeft size={17} />
+        </Link>
+        <span className="row-logo" style={{ width: 28, height: 28, background: 'var(--warn-soft)', color: 'var(--warn)' }}>
+          <WebhookIcon size={14} />
+        </span>
+        <span style={{ fontWeight: 700, color: 'var(--ink)', fontSize: 15 }}>{webhook.description || `/webhooks/${webhook.path}`}</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 12, alignItems: 'center' }}>
+          {patch.isPending ? <span className="saving">Saving…</span> : <span className="saved"><span className="dot" /> Saved</span>}
+          <OnOffSwitch on={webhook.is_active} busy={patch.isPending} onChange={(next) => patch.mutate({ is_active: next })} />
+        </div>
+      </div>
+
+      <div className="editor-split">
+        <div style={{ overflow: 'auto', padding: '40px 28px', display: 'flex', alignItems: 'flex-start', justifyContent: 'center' }}>
+          <StripCard kicker="When" title="A request arrives" icon={<WebhookIcon size={15} />} tone="trigger">
+            <div>
+              <div className="label">This address receives it</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: 'var(--ground)', border: '1px solid var(--line-soft)', borderRadius: 8, padding: '8px 10px', fontFamily: 'ui-monospace, monospace', fontSize: 11.5, color: 'var(--ink)' }}>
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{url}</span>
+                <button
+                  className="link-btn"
+                  style={{ marginLeft: 'auto', fontFamily: 'system-ui', flexShrink: 0 }}
+                  onClick={() => {
+                    navigator.clipboard.writeText(url);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1500);
+                  }}
+                >
+                  {copied ? 'Copied' : <Copy size={12} />}
+                </button>
+              </div>
+            </div>
+            {!webhook.requires_auth && (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', background: 'var(--warn-soft)', border: '1px solid var(--warn-line)', borderRadius: 8, padding: '8px 10px', fontSize: 12, color: 'var(--warn)' }}>
+                <AlertTriangle size={13} style={{ flexShrink: 0, marginTop: 1 }} />
+                <span>{PUBLIC_WARNING}</span>
+              </div>
+            )}
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12.5, color: 'var(--body)' }}>
+              <input
+                type="checkbox"
+                checked={!webhook.requires_auth}
+                onChange={(e) => patch.mutate({ requires_auth: !e.target.checked })}
+              />
+              Public — callable without signing in
+            </label>
+            {payloadFields.length > 0 && (
+              <p style={{ margin: 0, fontSize: 12, color: 'var(--faint)' }}>
+                Accepts fields:{' '}
+                {payloadFields.map((f) => (
+                  <span key={f} className="token" style={{ marginRight: 4 }}>@{f}</span>
+                ))}
+                <span style={{ opacity: 0.75 }}> — declared by {adapter ? prettyName(adapter.name) : 'the intake step'}</span>
+              </p>
+            )}
+          </StripCard>
+
+          <StripArrow />
+
+          {isAdapterHook ? (
+            <StripCard kicker="Then" title="Ask an assistant" icon={<Bot size={15} />} tone="action">
+              <div className="field">
+                <label>Assistant</label>
+                <AssistantSelect
+                  agents={agents ?? []}
+                  value={typeof defaults.studio_agent === 'string' ? defaults.studio_agent : ''}
+                  onChange={(ref) => ref && saveDefaults({ studio_agent: ref })}
+                />
+              </div>
+              <div className="field">
+                <label>With this request — @field inserts what the sender sent</label>
+                <textarea
+                  className="input"
+                  style={{ minHeight: 80 }}
+                  placeholder={'e.g. New support request from @name (@email):\n"@message"\n\nHandle it end to end.'}
+                  value={template ?? (typeof defaults.studio_message_template === 'string' ? defaults.studio_message_template : '')}
+                  onChange={(e) => setTemplate(e.target.value)}
+                  onBlur={() => {
+                    if (template !== null && template !== defaults.studio_message_template) {
+                      saveDefaults({ studio_message_template: template });
+                    }
+                  }}
+                />
+              </div>
+              <p style={{ margin: 0, fontSize: 11.5, color: 'var(--faint)' }}>
+                Assistant and request are saved as settings on the intake step — no code involved.
+              </p>
+              {typeof defaults.studio_agent === 'string' && defaults.studio_agent.includes('/') && (
+                <Link
+                  to={`/projects/${pns}/${pname}/assistants/${defaults.studio_agent}`}
+                  className="link-btn"
+                  style={{ alignSelf: 'flex-start' }}
+                >
+                  Open assistant editor →
+                </Link>
+              )}
+            </StripCard>
+          ) : (
+            <StripCard kicker="Then" title="Run a step" icon={<Bot size={15} />} tone="action">
+              <p style={{ margin: 0, fontSize: 13, color: 'var(--muted)' }}>
+                Runs <b style={{ color: 'var(--ink)' }}>{webhook.function_namespace}/{webhook.function_name}</b> — a
+                reusable step set up by your admin. Its settings aren't editable here.
+              </p>
+            </StripCard>
+          )}
+        </div>
+
+        <RunsRail triggerType="webhook" triggerId={webhook.id} emptyNote="No runs recorded yet — send a request to the address on the left to try it." />
+      </div>
+    </div>
+  );
+}
+
+// ---------- create flow ----------
+
+export function NewWorkflow() {
+  const { pns, pname } = useParams<{ pns: string; pname: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: project } = useQuery({ queryKey: ['project', pns, pname], queryFn: () => api.getProject(pns!, pname!) });
+  const { data: agents } = useQuery({ queryKey: ['agents'], queryFn: api.listAgents });
+  const { data: functions } = useQuery({ queryKey: ['functions'], queryFn: api.listFunctions });
+
+  const adapters = (functions ?? []).filter(isAdapter);
+
+  const [kind, setKind] = useState<'schedule' | 'webhook' | null>(null);
+  const [description, setDescription] = useState('');
+  const [assistant, setAssistant] = useState('');
+  const [message, setMessage] = useState('');
+  const [preset, setPreset] = useState<SchedulePreset>('daily');
+  const [time, setTime] = useState('09:00');
+  const [hookPath, setHookPath] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [adapterRef, setAdapterRef] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (adapters.length > 0 && !adapterRef) setAdapterRef(`${adapters[0].namespace}/${adapters[0].name}`);
+  }, [adapters, adapterRef]);
+
+  const addMembership = async (manifest: Manifest, type: string, name: string) =>
+    api.updateProject(manifest.namespace, manifest.name, {
+      required_resources: [...(manifest.required_resources ?? []), { type, namespace: 'default', name }],
+    });
+
+  const create = async () => {
+    if (!project) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (kind === 'schedule') {
+        const [target_namespace, target_name] = assistant.split('/');
+        const scheduleName = `${project.name}-${kebab(description) || 'schedule'}`.slice(0, 250);
+        await api.createSchedule({
+          name: scheduleName,
+          schedule_type: 'agent',
+          target_namespace,
+          target_name,
+          description: description || undefined,
+          cron_expression: cronFromPreset(preset, time),
+          content: message || 'Run now.',
+        });
+        // Workflows assemble inert; the on/off switch is the publish moment.
+        await api.updateSchedule(scheduleName, { is_active: false });
+        await addMembership(project, 'schedule', scheduleName);
+        queryClient.invalidateQueries();
+        navigate(`/projects/${pns}/${pname}/workflows/schedule/${encodeURIComponent(scheduleName)}`);
+      } else if (kind === 'webhook') {
+        const [fns, fname] = adapterRef.split('/');
+        const path = `${project.name}/${kebab(hookPath) || 'incoming'}`;
+        await api.createWebhook({
+          path,
+          function_namespace: fns,
+          function_name: fname,
+          description: description || undefined,
+          requires_auth: !isPublic,
+          default_values: { studio_agent: assistant, studio_message_template: message },
+        });
+        await api.updateWebhook(path, { is_active: false });
+        await addMembership(project, 'webhook', path);
+        queryClient.invalidateQueries();
+        navigate(`/projects/${pns}/${pname}/workflows/webhook/${path}`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not create the workflow');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const canCreate = !!kind && assistant.includes('/') && (kind === 'schedule' || adapterRef.includes('/'));
+
+  return (
+    <div className="page" style={{ width: '100%', maxWidth: 640 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 18 }}>
+        <Link to={`/projects/${pns}/${pname}`} style={{ color: 'var(--muted)', display: 'flex' }}>
+          <ArrowLeft size={18} />
+        </Link>
+        <h1 style={{ fontSize: 20 }}>New workflow</h1>
+      </div>
+
+      <div className="field" style={{ marginBottom: 16 }}>
+        <label>What starts it?</label>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <button
+            className="card"
+            style={{ padding: 14, textAlign: 'left', cursor: 'pointer', borderColor: kind === 'schedule' ? 'var(--accent)' : undefined }}
+            onClick={() => setKind('schedule')}
+          >
+            <Clock size={16} style={{ color: 'var(--warn)', marginBottom: 6 }} />
+            <div style={{ fontWeight: 650, color: 'var(--ink)', fontSize: 13.5 }}>On a schedule</div>
+            <div style={{ fontSize: 12, color: 'var(--faint)' }}>Runs automatically at set times</div>
+          </button>
+          <button
+            className="card"
+            style={{ padding: 14, textAlign: 'left', cursor: adapters.length ? 'pointer' : 'not-allowed', opacity: adapters.length ? 1 : 0.55, borderColor: kind === 'webhook' ? 'var(--accent)' : undefined }}
+            disabled={adapters.length === 0}
+            title={adapters.length === 0 ? 'Needs Studio setup — ask your admin to install the studio-runtime package' : undefined}
+            onClick={() => setKind('webhook')}
+          >
+            <WebhookIcon size={16} style={{ color: 'var(--warn)', marginBottom: 6 }} />
+            <div style={{ fontWeight: 650, color: 'var(--ink)', fontSize: 13.5 }}>A web request</div>
+            <div style={{ fontSize: 12, color: 'var(--faint)' }}>
+              {adapters.length ? 'A form or another tool calls a URL' : 'Needs Studio setup — ask your admin'}
+            </div>
+          </button>
+        </div>
+      </div>
+
+      {kind && (
+        <div className="card" style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div className="field">
+            <label>{kind === 'schedule' ? 'What is this workflow for?' : 'What starts this, in your words?'}</label>
+            <input
+              className="input"
+              placeholder={kind === 'schedule' ? 'e.g. Morning digest of open tickets' : 'e.g. A support form is submitted'}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          {kind === 'schedule' && (
+            <div style={{ display: 'flex', gap: 10 }}>
+              <div className="field" style={{ flex: 1 }}>
+                <label>How often</label>
+                <select className="input" value={preset} onChange={(e) => setPreset(e.target.value as SchedulePreset)}>
+                  {SCHEDULE_PRESETS.map((p) => (
+                    <option key={p.value} value={p.value}>{p.label}</option>
+                  ))}
+                </select>
+              </div>
+              {preset !== 'hourly' && (
+                <div className="field">
+                  <label>At</label>
+                  <input type="time" className="input" value={time} onChange={(e) => setTime(e.target.value)} />
+                </div>
+              )}
+            </div>
+          )}
+
+          {kind === 'webhook' && (
+            <>
+              <div className="field">
+                <label>Address name (becomes /webhooks/{project?.name}/…)</label>
+                <input className="input" placeholder="e.g. form" value={hookPath} onChange={(e) => setHookPath(e.target.value)} />
+              </div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12.5, color: 'var(--body)' }}>
+                <input type="checkbox" checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />
+                Public — callable without signing in
+              </label>
+              {isPublic && (
+                <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', background: 'var(--warn-soft)', border: '1px solid var(--warn-line)', borderRadius: 8, padding: '8px 10px', fontSize: 12, color: 'var(--warn)' }}>
+                  <AlertTriangle size={13} style={{ flexShrink: 0, marginTop: 1 }} />
+                  <span>{PUBLIC_WARNING}</span>
+                </div>
+              )}
+              {adapters.length > 1 && (
+                <div className="field">
+                  <label>Intake step</label>
+                  <select className="input" value={adapterRef} onChange={(e) => setAdapterRef(e.target.value)}>
+                    {adapters.map((a) => (
+                      <option key={a.id} value={`${a.namespace}/${a.name}`}>
+                        {prettyName(a.name)} — {a.description || `${a.namespace}/${a.name}`}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="field">
+            <label>Then ask which assistant?</label>
+            <AssistantSelect agents={agents ?? []} value={assistant} onChange={setAssistant} />
+          </div>
+
+          <div className="field">
+            <label>
+              {kind === 'schedule' ? 'With this request, each run' : 'With this request — @field inserts what the sender sent'}
+            </label>
+            <textarea
+              className="input"
+              style={{ minHeight: 70 }}
+              placeholder={kind === 'schedule' ? 'e.g. Prepare the morning ticket digest.' : 'e.g. New support request from @name: "@message"'}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </div>
+
+          {error && <div className="error-box">{error}</div>}
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button className="btn btn-primary" disabled={!canCreate || busy} onClick={create}>
+              {busy ? <Loader2 size={14} className="spin" /> : 'Create workflow (starts off)'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/studio/app/src/styles.css
+++ b/studio/app/src/styles.css
@@ -1,224 +1,281 @@
-/* Studio design tokens & components — light-first, from the settled design mocks. */
+/* Sinas Studio — visual system.
+   Warm paper ground, ink typography (Schibsted Grotesk), confident orange
+   accent, soft depth. Class names are the contract; restyle here, not in
+   components. */
 :root {
-  --ground: #FAF9F7;
+  --ground: #F6F4F1;
+  --ground-deep: #EFECE7;
   --surface: #FFFFFF;
-  --ink: #1C1917;
-  --body: #44403C;
-  --muted: #78716C;
-  --faint: #A8A29E;
-  --line: #E7E5E4;
-  --line-soft: #F0EEEC;
+  --ink: #1B1613;
+  --body: #453C35;
+  --muted: #7A7067;
+  --faint: #A89E94;
+  --line: #E6E1DA;
+  --line-soft: #EFEBE5;
   --accent: #EA580C;
-  --accent-ink: #C2410C;
-  --accent-soft: #FEF0E6;
-  --good: #15803D;
-  --good-soft: #F0FDF4;
-  --warn: #B45309;
-  --warn-soft: #FFFBEB;
-  --warn-line: #FDE68A;
-  --bad: #B91C1C;
-  --bad-soft: #FEF2F2;
-  --chip: #F5F5F4;
-  --token: #EEF4FF;
-  --token-ink: #3730A3;
-  --shadow: 0 1px 2px rgba(28, 25, 23, .05), 0 4px 16px rgba(28, 25, 23, .04);
-  --pop-shadow: 0 4px 12px rgba(28, 25, 23, .10), 0 12px 40px rgba(28, 25, 23, .12);
+  --accent-deep: #C2410C;
+  --accent-ink: #B4400E;
+  --accent-soft: #FCEEE3;
+  --accent-wash: #FDF6EF;
+  --good: #1B7C3D;
+  --good-soft: #EAF7EE;
+  --warn: #A16207;
+  --warn-soft: #FDF6E3;
+  --warn-line: #F2E1AC;
+  --bad: #B42323;
+  --bad-soft: #FCEEEC;
+  --chip: #F1EEE9;
+  --token: #EDF1FD;
+  --token-ink: #3B47B0;
+  --r-sm: 8px;
+  --r-md: 11px;
+  --r-lg: 16px;
+  --shadow:
+    0 1px 2px rgba(27, 22, 19, .04),
+    0 6px 24px -8px rgba(27, 22, 19, .07);
+  --shadow-lift:
+    0 2px 4px rgba(27, 22, 19, .05),
+    0 16px 40px -12px rgba(27, 22, 19, .14);
+  --font: 'Schibsted Grotesk Variable', system-ui, -apple-system, sans-serif;
 }
 
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; }
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-family: var(--font);
   background: var(--ground);
   color: var(--body);
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
 }
 button { font: inherit; cursor: pointer; }
 a { color: var(--accent-ink); text-decoration: none; }
-a:hover { text-decoration: underline; }
-:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+a:hover { text-decoration: underline; text-underline-offset: 2px; }
+::selection { background: var(--accent-soft); }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
 
-h1, h2, h3 { color: var(--ink); margin: 0; }
+h1, h2, h3 { color: var(--ink); margin: 0; letter-spacing: -0.015em; font-weight: 700; }
 
-/* Layout */
+/* ---------- Wordmark ---------- */
+.wordmark { display: inline-flex; align-items: baseline; gap: 7px; text-decoration: none !important; }
+.wordmark .wm-name { font-weight: 800; font-size: 16px; color: var(--ink); letter-spacing: -0.03em; }
+.wordmark .wm-app {
+  font-size: 10.5px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--accent-deep); background: var(--accent-soft);
+  padding: 2.5px 7px; border-radius: 6px; transform: translateY(-1px);
+}
+
+/* ---------- Layout ---------- */
 .app-shell { display: flex; flex-direction: column; height: 100vh; }
 .topbar {
   display: flex; align-items: center; gap: 14px;
-  padding: 0 20px; height: 54px; flex-shrink: 0;
+  padding: 0 22px; height: 56px; flex-shrink: 0;
   background: var(--surface); border-bottom: 1px solid var(--line);
 }
 .main-scroll { flex: 1; overflow-y: auto; }
-.page { max-width: 880px; margin: 0 auto; padding: 28px 24px 64px; }
+.page { max-width: 880px; margin: 0 auto; padding: 32px 24px 72px; }
 
-/* Cards */
+/* ---------- Cards ---------- */
 .card {
   background: var(--surface); border: 1px solid var(--line);
-  border-radius: 12px; box-shadow: var(--shadow);
+  border-radius: var(--r-lg); box-shadow: var(--shadow);
 }
-.card-head { display: flex; align-items: baseline; gap: 10px; padding: 16px 20px 0; }
-.card-title { font-size: 13px; font-weight: 700; color: var(--ink); letter-spacing: .02em; }
+.card-head { display: flex; align-items: baseline; gap: 10px; padding: 18px 22px 0; }
+.card-title { font-size: 14px; font-weight: 750; color: var(--ink); letter-spacing: -0.01em; }
 .card-hint { font-size: 12.5px; color: var(--faint); }
-.card-body { padding: 12px 20px 18px; }
+.card-body { padding: 12px 22px 20px; }
 
-/* Buttons */
+/* ---------- Buttons ---------- */
 .btn {
   display: inline-flex; align-items: center; gap: 7px;
-  border-radius: 9px; padding: 8px 14px; font-weight: 600; font-size: 13.5px;
-  border: 1px solid transparent; transition: filter .12s, background .12s;
+  border-radius: var(--r-md); padding: 8px 15px; font-weight: 650; font-size: 13.5px;
+  border: 1px solid transparent; transition: filter .12s, background .12s, box-shadow .12s;
 }
-.btn-primary { background: var(--accent); color: #fff; }
-.btn-primary:hover { filter: brightness(.95); }
-.btn-primary:disabled { opacity: .5; cursor: not-allowed; }
-.btn-secondary { background: var(--surface); color: var(--body); border-color: var(--line); }
-.btn-secondary:hover { background: var(--chip); }
+.btn-primary {
+  background: linear-gradient(180deg, #F1660F, var(--accent-deep));
+  color: #fff;
+  box-shadow: 0 1px 2px rgba(194, 65, 12, .35), inset 0 1px 0 rgba(255, 255, 255, .18);
+}
+.btn-primary:hover { filter: brightness(1.05); }
+.btn-primary:disabled { opacity: .45; cursor: not-allowed; filter: none; }
+.btn-secondary { background: var(--surface); color: var(--ink); border-color: var(--line); box-shadow: 0 1px 2px rgba(27,22,19,.04); }
+.btn-secondary:hover { background: var(--ground); border-color: var(--faint); }
 .btn-sm { padding: 5px 11px; font-size: 12.5px; }
 .link-btn {
-  background: none; border: none; padding: 4px 6px; border-radius: 6px;
-  color: var(--accent-ink); font-size: 12.5px; font-weight: 600;
+  background: none; border: none; padding: 4px 7px; border-radius: 7px;
+  color: var(--accent-ink); font-size: 12.5px; font-weight: 650;
 }
 .link-btn:hover { background: var(--accent-soft); }
 .link-btn:disabled { color: var(--faint); cursor: not-allowed; background: none; }
-.kebab { background: none; border: none; color: var(--faint); font-size: 16px; padding: 2px 8px; border-radius: 6px; }
+.kebab { background: none; border: none; color: var(--faint); font-size: 16px; padding: 3px 8px; border-radius: 7px; display: inline-flex; align-items: center; }
 .kebab:hover { background: var(--chip); color: var(--muted); }
 
-/* Inputs */
-.field label, .label { display: block; font-size: 12.5px; font-weight: 600; color: var(--muted); margin-bottom: 5px; }
-.input {
-  width: 100%; border: 1px solid var(--line); border-radius: 9px;
-  padding: 9px 12px; font: inherit; font-size: 13.5px;
-  background: var(--surface); color: var(--ink);
+/* ---------- Inputs ---------- */
+.field label, .label {
+  display: block; font-size: 11.5px; font-weight: 750; color: var(--muted);
+  margin-bottom: 6px; letter-spacing: .02em; text-transform: uppercase;
 }
-.input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.input {
+  width: 100%; border: 1px solid var(--line); border-radius: var(--r-md);
+  padding: 9px 13px; font: inherit; font-size: 14px;
+  background: var(--surface); color: var(--ink);
+  box-shadow: inset 0 1px 2px rgba(27, 22, 19, .03);
+  transition: border-color .12s, box-shadow .12s;
+}
+.input::placeholder { color: var(--faint); }
+.input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3.5px var(--accent-soft); }
 textarea.input { resize: vertical; line-height: 1.65; }
 select.input { appearance: auto; }
 
-/* Pills & chips */
+/* ---------- Pills, tokens, chips ---------- */
 .pill {
-  font-size: 11.5px; font-weight: 600; padding: 3px 9px; border-radius: 999px;
-  background: var(--chip); color: var(--muted); border: 1px solid var(--line);
-  white-space: nowrap;
+  font-size: 11px; font-weight: 700; padding: 3.5px 10px; border-radius: 999px;
+  background: var(--chip); color: var(--muted); border: 1px solid transparent;
+  white-space: nowrap; letter-spacing: .01em;
 }
-.pill-good { background: var(--good-soft); color: var(--good); border-color: transparent; }
-.pill-warn { background: var(--warn-soft); color: var(--warn); border: 1px solid var(--warn-line); }
-.pill-bad { background: var(--bad-soft); color: var(--bad); border-color: transparent; }
+.pill-good { background: var(--good-soft); color: var(--good); }
+.pill-warn { background: var(--warn-soft); color: var(--warn); border-color: var(--warn-line); }
+.pill-bad { background: var(--bad-soft); color: var(--bad); }
 .token {
-  display: inline-block; padding: 0 6px; border-radius: 6px;
+  display: inline-block; padding: 1px 7px; border-radius: 7px;
   background: var(--token); color: var(--token-ink);
-  font-weight: 600; font-size: 13px;
+  font-weight: 650; font-size: 12.5px;
 }
 
-/* Rows (tool/file/member lists) */
+/* ---------- Rows ---------- */
 .rows { display: flex; flex-direction: column; }
-.row { display: flex; align-items: center; gap: 14px; padding: 13px 20px; border-top: 1px solid var(--line-soft); }
+.row { display: flex; align-items: center; gap: 14px; padding: 14px 22px; border-top: 1px solid var(--line-soft); transition: background .1s; }
 .rows .row:first-child { border-top: 0; }
+a.row:hover { background: var(--accent-wash); }
 .row-logo {
-  width: 34px; height: 34px; border-radius: 9px; flex-shrink: 0;
+  width: 38px; height: 38px; border-radius: 12px; flex-shrink: 0;
   display: grid; place-items: center; font-weight: 800; font-size: 14px;
   background: var(--chip); color: var(--muted);
+  box-shadow: inset 0 0 0 1px rgba(27, 22, 19, .05);
 }
 .row-main { min-width: 0; flex: 1; }
-.row-name { font-weight: 600; color: var(--ink); font-size: 14px; }
-.row-desc { font-size: 12.5px; color: var(--muted); margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.row-name { font-weight: 700; color: var(--ink); font-size: 14px; letter-spacing: -0.01em; }
+.row-desc { font-size: 12.5px; color: var(--muted); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .row-side { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
 .add-row {
-  display: flex; align-items: center; gap: 8px; padding: 12px 20px;
-  border: none; border-top: 1px solid var(--line-soft);
-  color: var(--accent-ink); font-weight: 600; font-size: 13px;
-  background: none; width: 100%; text-align: left; border-radius: 0 0 12px 12px;
+  display: flex; align-items: center; gap: 9px; padding: 13px 22px;
+  border: none; border-top: 1px dashed var(--line);
+  color: var(--accent-ink); font-weight: 700; font-size: 13px;
+  background: none; width: 100%; text-align: left; border-radius: 0 0 var(--r-lg) var(--r-lg);
 }
-.add-row:hover { background: var(--accent-soft); }
+.add-row:hover { background: var(--accent-wash); }
 .group-label {
-  font-size: 10.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
-  color: var(--faint); padding: 12px 20px 2px;
+  font-size: 10.5px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--faint); padding: 14px 22px 2px;
 }
 
-/* Guidance chips */
+/* ---------- Guidance chips ---------- */
 .skill-chip {
   display: inline-flex; align-items: center; gap: 7px;
   border: 1px solid var(--line); border-radius: 999px; background: var(--surface);
-  padding: 4px 11px; font-size: 12.5px; color: var(--body);
+  padding: 5px 12px; font-size: 12.5px; color: var(--body);
+  box-shadow: 0 1px 2px rgba(27, 22, 19, .04);
 }
-.skill-chip b { color: var(--ink); font-weight: 600; }
-.skill-chip .mode { font-size: 10.5px; color: var(--faint); text-transform: uppercase; letter-spacing: .05em; }
+.skill-chip b { color: var(--ink); font-weight: 700; }
+.skill-chip .mode { font-size: 10px; font-weight: 800; color: var(--faint); text-transform: uppercase; letter-spacing: .07em; }
 .skill-chip:hover { border-color: var(--faint); }
 .chip-add {
-  border: 1px dashed var(--line); border-radius: 999px; background: none;
-  padding: 4px 11px; font-size: 12.5px; color: var(--accent-ink); font-weight: 600;
+  border: 1px dashed var(--faint); border-radius: 999px; background: none;
+  padding: 5px 12px; font-size: 12.5px; color: var(--accent-ink); font-weight: 700;
 }
 .chip-add:hover { background: var(--accent-soft); border-color: var(--accent); }
-.chip-x { border: none; background: none; color: var(--faint); padding: 0 0 0 2px; font-size: 13px; }
+.chip-x { border: none; background: none; color: var(--faint); padding: 0 0 0 2px; display: inline-flex; }
 .chip-x:hover { color: var(--bad); }
 
-/* Toggle */
+/* ---------- Toggle ---------- */
 .toggle {
-  display: inline-flex; align-items: center; gap: 7px;
-  border: 1px solid var(--line); border-radius: 8px;
-  background: var(--surface); padding: 5px 10px; font-size: 12.5px; color: var(--body);
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid var(--line); border-radius: 9px;
+  background: var(--surface); padding: 6px 11px; font-size: 12.5px; color: var(--body);
+  box-shadow: 0 1px 2px rgba(27, 22, 19, .04);
 }
-.toggle .sw { width: 26px; height: 15px; border-radius: 999px; background: var(--line); position: relative; transition: background .15s; flex-shrink: 0; }
+.toggle .sw { width: 28px; height: 16px; border-radius: 999px; background: var(--line); position: relative; transition: background .15s; flex-shrink: 0; }
 .toggle .sw::after {
-  content: ""; position: absolute; top: 2px; left: 2px; width: 11px; height: 11px; border-radius: 50%;
-  background: var(--surface); box-shadow: 0 1px 2px rgba(0,0,0,.2); transition: left .15s;
+  content: ""; position: absolute; top: 2px; left: 2px; width: 12px; height: 12px; border-radius: 50%;
+  background: var(--surface); box-shadow: 0 1px 2px rgba(0, 0, 0, .25); transition: left .15s;
 }
 .toggle.on .sw { background: var(--accent); }
-.toggle.on .sw::after { left: 13px; }
+.toggle.on .sw::after { left: 14px; }
 .toggle:hover { border-color: var(--faint); }
 
-/* Modal & popover */
-.overlay { position: fixed; inset: 0; z-index: 50; background: rgba(28,25,23,.35); display: grid; place-items: center; padding: 20px; }
-.modal { background: var(--surface); border: 1px solid var(--line); border-radius: 14px; box-shadow: var(--pop-shadow); width: 100%; max-width: 460px; padding: 22px; }
+/* ---------- Modal & popover ---------- */
+.overlay { position: fixed; inset: 0; z-index: 50; background: rgba(27, 22, 19, .38); backdrop-filter: blur(2px); display: grid; place-items: center; padding: 20px; }
+.modal { background: var(--surface); border: 1px solid var(--line); border-radius: 18px; box-shadow: var(--shadow-lift); width: 100%; max-width: 460px; padding: 24px; }
 .pop {
   position: absolute; z-index: 40; background: var(--surface);
-  border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--pop-shadow);
+  border: 1px solid var(--line); border-radius: 14px; box-shadow: var(--shadow-lift);
   width: 340px; max-height: 380px; overflow-y: auto;
 }
 @media (prefers-reduced-motion: no-preference) {
-  .pop, .modal { animation: rise .14s ease-out; }
-  @keyframes rise { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+  .pop, .modal { animation: rise .16s cubic-bezier(.2, .9, .3, 1.2); }
+  @keyframes rise { from { opacity: 0; transform: translateY(5px) scale(.99); } to { opacity: 1; transform: none; } }
 }
-.pop-item { display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: none; border: none; border-radius: 8px; padding: 8px 10px; }
-.pop-item:hover { background: var(--chip); }
+.pop-item { display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: none; border: none; border-radius: 9px; padding: 9px 10px; }
+.pop-item:hover { background: var(--accent-wash); }
 
-/* Test chat */
+/* ---------- Test chat / side rail ---------- */
 .chat-pane { border-left: 1px solid var(--line); background: var(--surface); display: flex; flex-direction: column; min-height: 0; }
-.pane-head { display: flex; align-items: center; gap: 8px; padding: 14px 18px; border-bottom: 1px solid var(--line-soft); flex-shrink: 0; }
-.pane-title { font-weight: 700; font-size: 13px; color: var(--ink); }
+.pane-head { display: flex; align-items: center; gap: 8px; padding: 15px 18px; border-bottom: 1px solid var(--line-soft); flex-shrink: 0; }
+.pane-title { font-weight: 750; font-size: 13.5px; color: var(--ink); }
 .pane-sub { font-size: 11.5px; color: var(--faint); }
-.pane-scroll { flex: 1; overflow-y: auto; padding: 18px; display: flex; flex-direction: column; gap: 14px; }
-.msg-user { align-self: flex-end; max-width: 85%; background: var(--accent-soft); color: var(--ink); border-radius: 14px 14px 4px 14px; padding: 9px 13px; font-size: 13.5px; white-space: pre-wrap; }
+.pane-scroll { flex: 1; overflow-y: auto; padding: 18px; display: flex; flex-direction: column; gap: 14px; background: linear-gradient(180deg, var(--ground) 0%, var(--surface) 140px); }
+.msg-user {
+  align-self: flex-end; max-width: 85%;
+  background: linear-gradient(180deg, #FBEADC, var(--accent-soft));
+  color: var(--ink); border: 1px solid #F5DCC5;
+  border-radius: 16px 16px 5px 16px; padding: 9px 14px; font-size: 13.5px; white-space: pre-wrap;
+}
 .msg-bot { display: flex; gap: 10px; max-width: 95%; }
-.bot-avatar { width: 26px; height: 26px; border-radius: 8px; flex-shrink: 0; margin-top: 2px; background: var(--chip); color: var(--accent-ink); display: grid; place-items: center; font-weight: 700; font-size: 11px; }
+.bot-avatar {
+  width: 28px; height: 28px; border-radius: 9px; flex-shrink: 0; margin-top: 2px;
+  color: #fff; display: grid; place-items: center; font-weight: 800; font-size: 10.5px;
+}
 .bot-bubble { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
-.bot-text { font-size: 13.5px; color: var(--body); white-space: pre-wrap; }
+.bot-text {
+  font-size: 13.5px; color: var(--body); white-space: pre-wrap;
+  background: var(--surface); border: 1px solid var(--line-soft);
+  border-radius: 5px 16px 16px 16px; padding: 9px 14px; box-shadow: var(--shadow);
+}
 .tool-call {
   display: inline-flex; align-items: center; gap: 8px; align-self: flex-start;
-  font-size: 12px; color: var(--muted); border: 1px solid var(--line); border-radius: 8px;
-  padding: 5px 10px; background: var(--ground);
+  font-size: 11.5px; font-weight: 600; color: var(--muted);
+  border: 1px solid var(--line); border-radius: 999px; padding: 4.5px 11px;
+  background: var(--surface);
 }
-.tool-call .tc-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--good); flex-shrink: 0; }
-.chat-input { display: flex; gap: 8px; padding: 14px 16px; border-top: 1px solid var(--line-soft); flex-shrink: 0; }
-.hint-strip { padding: 8px 18px; font-size: 11.5px; color: var(--faint); border-top: 1px solid var(--line-soft); flex-shrink: 0; background: var(--ground); }
+.tool-call .tc-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--good); flex-shrink: 0; }
+.chat-input { display: flex; gap: 8px; padding: 14px 16px; border-top: 1px solid var(--line-soft); flex-shrink: 0; background: var(--surface); }
+.hint-strip { padding: 9px 18px; font-size: 11.5px; color: var(--faint); border-top: 1px solid var(--line-soft); flex-shrink: 0; background: var(--ground); }
 
-/* Editor split */
+/* ---------- Editor split ---------- */
 .editor-split { display: grid; grid-template-columns: minmax(0, 1fr) 400px; flex: 1; min-height: 0; }
 @media (max-width: 980px) { .editor-split { grid-template-columns: 1fr; } .chat-pane { display: none; } }
-.editor-scroll { overflow-y: auto; padding: 24px 28px 80px; display: flex; flex-direction: column; gap: 18px; max-width: 780px; width: 100%; margin: 0 auto; }
+.editor-scroll { overflow-y: auto; padding: 26px 28px 88px; display: flex; flex-direction: column; gap: 20px; max-width: 780px; width: 100%; margin: 0 auto; }
 
-/* Summary strip */
+/* ---------- Summary strip ---------- */
 .summary {
-  padding: 12px 20px; background: var(--surface); border-bottom: 1px solid var(--line);
-  font-size: 13.5px; color: var(--muted); flex-shrink: 0;
+  padding: 12px 22px; background: var(--accent-wash); border-bottom: 1px solid var(--line);
+  font-size: 13px; color: var(--muted); flex-shrink: 0; line-height: 1.7;
 }
-.summary b { color: var(--ink); font-weight: 600; }
-.summary .cap { color: var(--accent-ink); font-weight: 600; }
+.summary b { color: var(--ink); font-weight: 700; }
+.summary .cap { color: var(--accent-deep); font-weight: 700; }
 
-/* Misc */
-.saved { display: flex; align-items: center; gap: 6px; color: var(--good); font-size: 12.5px; }
+/* ---------- Misc ---------- */
+.saved { display: flex; align-items: center; gap: 6px; color: var(--good); font-size: 12.5px; font-weight: 650; }
 .saved .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--good); }
 .saving { color: var(--faint); font-size: 12.5px; }
-.empty { text-align: center; padding: 48px 20px; color: var(--muted); }
-.error-box { background: var(--bad-soft); border: 1px solid #FECACA; border-radius: 8px; padding: 10px 12px; font-size: 13px; color: var(--bad); }
+.empty { text-align: center; padding: 52px 20px; color: var(--muted); }
+.empty-icon {
+  width: 52px; height: 52px; border-radius: 16px; margin: 0 auto 14px;
+  display: grid; place-items: center; background: var(--surface);
+  border: 1px solid var(--line); box-shadow: var(--shadow); color: var(--faint);
+}
+.error-box { background: var(--bad-soft); border: 1px solid #F2CFC9; border-radius: 10px; padding: 10px 13px; font-size: 13px; color: var(--bad); }
 .spin { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/studio/app/src/styles.css
+++ b/studio/app/src/styles.css
@@ -1,0 +1,224 @@
+/* Studio design tokens & components — light-first, from the settled design mocks. */
+:root {
+  --ground: #FAF9F7;
+  --surface: #FFFFFF;
+  --ink: #1C1917;
+  --body: #44403C;
+  --muted: #78716C;
+  --faint: #A8A29E;
+  --line: #E7E5E4;
+  --line-soft: #F0EEEC;
+  --accent: #EA580C;
+  --accent-ink: #C2410C;
+  --accent-soft: #FEF0E6;
+  --good: #15803D;
+  --good-soft: #F0FDF4;
+  --warn: #B45309;
+  --warn-soft: #FFFBEB;
+  --warn-line: #FDE68A;
+  --bad: #B91C1C;
+  --bad-soft: #FEF2F2;
+  --chip: #F5F5F4;
+  --token: #EEF4FF;
+  --token-ink: #3730A3;
+  --shadow: 0 1px 2px rgba(28, 25, 23, .05), 0 4px 16px rgba(28, 25, 23, .04);
+  --pop-shadow: 0 4px 12px rgba(28, 25, 23, .10), 0 12px 40px rgba(28, 25, 23, .12);
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--ground);
+  color: var(--body);
+  font-size: 14px;
+  line-height: 1.5;
+}
+button { font: inherit; cursor: pointer; }
+a { color: var(--accent-ink); text-decoration: none; }
+a:hover { text-decoration: underline; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+h1, h2, h3 { color: var(--ink); margin: 0; }
+
+/* Layout */
+.app-shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  display: flex; align-items: center; gap: 14px;
+  padding: 0 20px; height: 54px; flex-shrink: 0;
+  background: var(--surface); border-bottom: 1px solid var(--line);
+}
+.main-scroll { flex: 1; overflow-y: auto; }
+.page { max-width: 880px; margin: 0 auto; padding: 28px 24px 64px; }
+
+/* Cards */
+.card {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 12px; box-shadow: var(--shadow);
+}
+.card-head { display: flex; align-items: baseline; gap: 10px; padding: 16px 20px 0; }
+.card-title { font-size: 13px; font-weight: 700; color: var(--ink); letter-spacing: .02em; }
+.card-hint { font-size: 12.5px; color: var(--faint); }
+.card-body { padding: 12px 20px 18px; }
+
+/* Buttons */
+.btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  border-radius: 9px; padding: 8px 14px; font-weight: 600; font-size: 13.5px;
+  border: 1px solid transparent; transition: filter .12s, background .12s;
+}
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { filter: brightness(.95); }
+.btn-primary:disabled { opacity: .5; cursor: not-allowed; }
+.btn-secondary { background: var(--surface); color: var(--body); border-color: var(--line); }
+.btn-secondary:hover { background: var(--chip); }
+.btn-sm { padding: 5px 11px; font-size: 12.5px; }
+.link-btn {
+  background: none; border: none; padding: 4px 6px; border-radius: 6px;
+  color: var(--accent-ink); font-size: 12.5px; font-weight: 600;
+}
+.link-btn:hover { background: var(--accent-soft); }
+.link-btn:disabled { color: var(--faint); cursor: not-allowed; background: none; }
+.kebab { background: none; border: none; color: var(--faint); font-size: 16px; padding: 2px 8px; border-radius: 6px; }
+.kebab:hover { background: var(--chip); color: var(--muted); }
+
+/* Inputs */
+.field label, .label { display: block; font-size: 12.5px; font-weight: 600; color: var(--muted); margin-bottom: 5px; }
+.input {
+  width: 100%; border: 1px solid var(--line); border-radius: 9px;
+  padding: 9px 12px; font: inherit; font-size: 13.5px;
+  background: var(--surface); color: var(--ink);
+}
+.input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+textarea.input { resize: vertical; line-height: 1.65; }
+select.input { appearance: auto; }
+
+/* Pills & chips */
+.pill {
+  font-size: 11.5px; font-weight: 600; padding: 3px 9px; border-radius: 999px;
+  background: var(--chip); color: var(--muted); border: 1px solid var(--line);
+  white-space: nowrap;
+}
+.pill-good { background: var(--good-soft); color: var(--good); border-color: transparent; }
+.pill-warn { background: var(--warn-soft); color: var(--warn); border: 1px solid var(--warn-line); }
+.pill-bad { background: var(--bad-soft); color: var(--bad); border-color: transparent; }
+.token {
+  display: inline-block; padding: 0 6px; border-radius: 6px;
+  background: var(--token); color: var(--token-ink);
+  font-weight: 600; font-size: 13px;
+}
+
+/* Rows (tool/file/member lists) */
+.rows { display: flex; flex-direction: column; }
+.row { display: flex; align-items: center; gap: 14px; padding: 13px 20px; border-top: 1px solid var(--line-soft); }
+.rows .row:first-child { border-top: 0; }
+.row-logo {
+  width: 34px; height: 34px; border-radius: 9px; flex-shrink: 0;
+  display: grid; place-items: center; font-weight: 800; font-size: 14px;
+  background: var(--chip); color: var(--muted);
+}
+.row-main { min-width: 0; flex: 1; }
+.row-name { font-weight: 600; color: var(--ink); font-size: 14px; }
+.row-desc { font-size: 12.5px; color: var(--muted); margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.row-side { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+.add-row {
+  display: flex; align-items: center; gap: 8px; padding: 12px 20px;
+  border: none; border-top: 1px solid var(--line-soft);
+  color: var(--accent-ink); font-weight: 600; font-size: 13px;
+  background: none; width: 100%; text-align: left; border-radius: 0 0 12px 12px;
+}
+.add-row:hover { background: var(--accent-soft); }
+.group-label {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--faint); padding: 12px 20px 2px;
+}
+
+/* Guidance chips */
+.skill-chip {
+  display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line); border-radius: 999px; background: var(--surface);
+  padding: 4px 11px; font-size: 12.5px; color: var(--body);
+}
+.skill-chip b { color: var(--ink); font-weight: 600; }
+.skill-chip .mode { font-size: 10.5px; color: var(--faint); text-transform: uppercase; letter-spacing: .05em; }
+.skill-chip:hover { border-color: var(--faint); }
+.chip-add {
+  border: 1px dashed var(--line); border-radius: 999px; background: none;
+  padding: 4px 11px; font-size: 12.5px; color: var(--accent-ink); font-weight: 600;
+}
+.chip-add:hover { background: var(--accent-soft); border-color: var(--accent); }
+.chip-x { border: none; background: none; color: var(--faint); padding: 0 0 0 2px; font-size: 13px; }
+.chip-x:hover { color: var(--bad); }
+
+/* Toggle */
+.toggle {
+  display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--surface); padding: 5px 10px; font-size: 12.5px; color: var(--body);
+}
+.toggle .sw { width: 26px; height: 15px; border-radius: 999px; background: var(--line); position: relative; transition: background .15s; flex-shrink: 0; }
+.toggle .sw::after {
+  content: ""; position: absolute; top: 2px; left: 2px; width: 11px; height: 11px; border-radius: 50%;
+  background: var(--surface); box-shadow: 0 1px 2px rgba(0,0,0,.2); transition: left .15s;
+}
+.toggle.on .sw { background: var(--accent); }
+.toggle.on .sw::after { left: 13px; }
+.toggle:hover { border-color: var(--faint); }
+
+/* Modal & popover */
+.overlay { position: fixed; inset: 0; z-index: 50; background: rgba(28,25,23,.35); display: grid; place-items: center; padding: 20px; }
+.modal { background: var(--surface); border: 1px solid var(--line); border-radius: 14px; box-shadow: var(--pop-shadow); width: 100%; max-width: 460px; padding: 22px; }
+.pop {
+  position: absolute; z-index: 40; background: var(--surface);
+  border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--pop-shadow);
+  width: 340px; max-height: 380px; overflow-y: auto;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .pop, .modal { animation: rise .14s ease-out; }
+  @keyframes rise { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+}
+.pop-item { display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: none; border: none; border-radius: 8px; padding: 8px 10px; }
+.pop-item:hover { background: var(--chip); }
+
+/* Test chat */
+.chat-pane { border-left: 1px solid var(--line); background: var(--surface); display: flex; flex-direction: column; min-height: 0; }
+.pane-head { display: flex; align-items: center; gap: 8px; padding: 14px 18px; border-bottom: 1px solid var(--line-soft); flex-shrink: 0; }
+.pane-title { font-weight: 700; font-size: 13px; color: var(--ink); }
+.pane-sub { font-size: 11.5px; color: var(--faint); }
+.pane-scroll { flex: 1; overflow-y: auto; padding: 18px; display: flex; flex-direction: column; gap: 14px; }
+.msg-user { align-self: flex-end; max-width: 85%; background: var(--accent-soft); color: var(--ink); border-radius: 14px 14px 4px 14px; padding: 9px 13px; font-size: 13.5px; white-space: pre-wrap; }
+.msg-bot { display: flex; gap: 10px; max-width: 95%; }
+.bot-avatar { width: 26px; height: 26px; border-radius: 8px; flex-shrink: 0; margin-top: 2px; background: var(--chip); color: var(--accent-ink); display: grid; place-items: center; font-weight: 700; font-size: 11px; }
+.bot-bubble { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+.bot-text { font-size: 13.5px; color: var(--body); white-space: pre-wrap; }
+.tool-call {
+  display: inline-flex; align-items: center; gap: 8px; align-self: flex-start;
+  font-size: 12px; color: var(--muted); border: 1px solid var(--line); border-radius: 8px;
+  padding: 5px 10px; background: var(--ground);
+}
+.tool-call .tc-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--good); flex-shrink: 0; }
+.chat-input { display: flex; gap: 8px; padding: 14px 16px; border-top: 1px solid var(--line-soft); flex-shrink: 0; }
+.hint-strip { padding: 8px 18px; font-size: 11.5px; color: var(--faint); border-top: 1px solid var(--line-soft); flex-shrink: 0; background: var(--ground); }
+
+/* Editor split */
+.editor-split { display: grid; grid-template-columns: minmax(0, 1fr) 400px; flex: 1; min-height: 0; }
+@media (max-width: 980px) { .editor-split { grid-template-columns: 1fr; } .chat-pane { display: none; } }
+.editor-scroll { overflow-y: auto; padding: 24px 28px 80px; display: flex; flex-direction: column; gap: 18px; max-width: 780px; width: 100%; margin: 0 auto; }
+
+/* Summary strip */
+.summary {
+  padding: 12px 20px; background: var(--surface); border-bottom: 1px solid var(--line);
+  font-size: 13.5px; color: var(--muted); flex-shrink: 0;
+}
+.summary b { color: var(--ink); font-weight: 600; }
+.summary .cap { color: var(--accent-ink); font-weight: 600; }
+
+/* Misc */
+.saved { display: flex; align-items: center; gap: 6px; color: var(--good); font-size: 12.5px; }
+.saved .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--good); }
+.saving { color: var(--faint); font-size: 12.5px; }
+.empty { text-align: center; padding: 48px 20px; color: var(--muted); }
+.error-box { background: var(--bad-soft); border: 1px solid #FECACA; border-radius: 8px; padding: 10px 12px; font-size: 13px; color: var(--bad); }
+.spin { animation: spin 1s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/studio/app/src/vite-env.d.ts
+++ b/studio/app/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+// The studio-runtime package YAML is bundled into the app at build time so
+// setup installs a package version that always matches this Studio build.
+declare module '*.yaml?raw' {
+  const content: string;
+  export default content;
+}

--- a/studio/app/tsconfig.json
+++ b/studio/app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/studio/app/vite.config.ts
+++ b/studio/app/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5180 },
+});

--- a/studio/app/vite.config.ts
+++ b/studio/app/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Served at /studio/ on the workspace origin by default (bundled mode);
+// a standalone deployment mounts it at /studio/ too.
 export default defineConfig({
+  base: '/studio/',
   plugins: [react()],
   server: { port: 5180 },
 });

--- a/studio/packages/studio-runtime.yaml
+++ b/studio/packages/studio-runtime.yaml
@@ -61,6 +61,11 @@ spec:
     - namespace: studio
       name: ask-agent
       description: "Generic trigger adapter: forwards a webhook payload to an assistant. Configure via default_values on the webhook (studio_agent, studio_message_template, studio_input_map)."
+      # Trusted, admin-installed code -> shared pool: pre-warmed workers (low
+      # webhook latency) and context['secrets'] for future signature checks.
+      # Note: shared workers still run on the isolated sandbox network, so the
+      # callback must use WORKSPACE_URL, not internal service names.
+      sharedPool: true
       timeout: 115
       code: |
         def handler(input_data, context):

--- a/studio/packages/studio-runtime.yaml
+++ b/studio/packages/studio-runtime.yaml
@@ -1,0 +1,144 @@
+# Studio companion package — see studio/README.md §6.
+# Installed once per workspace by an admin ("connect Studio" setup step).
+# Contents: the studio/copilot agent (AI assist, explain-error) and the
+# generic webhook->assistant adapter (studio/ask-agent).
+apiVersion: sinas.co/v1
+kind: SinasPackage
+package:
+  name: studio-runtime
+  version: "0.1.0"
+  description: "Runtime resources for Sinas Studio: the copilot agent and the generic trigger adapter"
+  url: "https://github.com/sinas-platform/sinas/tree/main/studio"
+spec:
+  variables:
+    - name: WORKSPACE_URL
+      type: text
+      description: >-
+        The public URL of this workspace's API, reachable from function
+        sandboxes (they run on an isolated network). For local development
+        use http://host.docker.internal:8000
+      required: true
+      example: "https://sinas.yourcompany.com"
+
+  agents:
+    - namespace: studio
+      name: copilot
+      description: "Sinas Studio's built-in assistant: improves instructions, explains errors, and answers questions about what an assistant is set up to do"
+      temperature: 0.2
+      systemPrompt: |
+        You are the Sinas Studio copilot. Studio is a visual editor used by
+        business analysts — people who do not read code. Every request you
+        receive starts with a "Mode:" line; follow the matching contract
+        exactly, because Studio inserts your reply directly into the UI.
+
+        Mode: improve-instructions
+          You receive assistant instructions written by a business user.
+          Rewrite them to be clearer, better structured, and more complete
+          without changing their intent or inventing new behavior. Reply with
+          ONLY the improved instructions text — no preamble, no commentary,
+          no markdown fences.
+
+        Mode: draft-instructions
+          You receive a plain-language description of what an assistant
+          should do. Write first-draft instructions for it: role, how to
+          behave, when to use its tools, tone. Reply with ONLY the
+          instructions text.
+
+        Mode: explain-error
+          You receive a technical error message and traceback from a failed
+          run. Explain in two or three plain sentences what went wrong and
+          what the user could check or change. Never invent details that are
+          not supported by the error text. No markdown, no code blocks.
+
+        Mode: explain-setup
+          You receive an assistant's configuration summary. Read it back in
+          plain language: what it can do, what it reads, when it runs.
+
+        For any request without a Mode line, answer briefly and honestly; if
+        you are unsure, say so.
+
+  functions:
+    - namespace: studio
+      name: ask-agent
+      description: "Generic trigger adapter: forwards a webhook payload to an assistant. Configure via default_values on the webhook (studio_agent, studio_message_template, studio_input_map)."
+      timeout: 115
+      code: |
+        def handler(input_data, context):
+            """Forward a trigger payload to an assistant.
+
+            Reserved parameters (set as webhook default_values, merged into
+            input_data by the platform):
+              studio_agent            "namespace/name" of the assistant to run
+              studio_message_template message text; @field inserts payload fields
+              studio_input_map        optional {payload_field: assistant_input}
+            Everything else in input_data is the trigger payload.
+            """
+            import json
+            import urllib.request
+
+            agent = input_data.get("studio_agent") or ""
+            if "/" not in agent:
+                raise ValueError(
+                    "studio_agent must be configured on the trigger as 'namespace/name'"
+                )
+            template = input_data.get("studio_message_template") or ""
+            input_map = input_data.get("studio_input_map") or {}
+
+            payload = {
+                k: v for k, v in input_data.items() if not k.startswith("studio_")
+            }
+
+            message = template
+            for key, value in sorted(payload.items(), key=lambda kv: -len(kv[0])):
+                message = message.replace("@" + key, str(value))
+            if not message.strip():
+                message = json.dumps(payload)
+
+            agent_input = {
+                str(target): payload[source]
+                for source, target in input_map.items()
+                if source in payload
+            }
+
+            namespace, name = agent.split("/", 1)
+            body = {"message": message}
+            if agent_input:
+                body["input"] = agent_input
+
+            request = urllib.request.Request(
+                "${{ vars.WORKSPACE_URL }}" + f"/agents/{namespace}/{name}/invoke",
+                data=json.dumps(body).encode(),
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer " + context["access_token"],
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=110) as response:
+                result = json.loads(response.read().decode())
+
+            return {
+                "status": "ok",
+                "chat_id": result.get("chat_id"),
+                "reply": result.get("reply"),
+            }
+      inputSchema:
+        type: object
+        properties:
+          studio_agent:
+            type: string
+            description: "Assistant to run, as namespace/name"
+          studio_message_template:
+            type: string
+            description: "Message sent to the assistant; @field inserts payload fields"
+          studio_input_map:
+            type: object
+            description: "Optional map of payload field -> assistant input name"
+        required: [studio_agent]
+        additionalProperties: true
+      outputSchema:
+        type: object
+        properties:
+          status: { type: string }
+          chat_id: { type: string }
+          reply: { type: string }


### PR DESCRIPTION
## What this adds

**Studio** — a business-analyst-facing app that lives in this monorepo at `studio/` and ships bundled inside the console image, served same-origin with the API at `/studio/`.

### The app (`studio/app`)
- **Connect flow** with same-origin workspace auto-detect (`GET /info` on its own origin skips the workspace step; "connect to a different workspace" is tucked behind a link). Password and OTP sign-in, refresh-token rotation.
- **Projects** built on manifests (`required_resources` = board membership) — no new tables, no schema change.
- **Assistant editor**: instructions with debounced autosave, guidance (skills) with preload toggles, tools (per-operation connector toggles), files & memory (auto-created `<agent>-files` / `<agent>-memory`), friendly inputs over `input_schema`, and a live test chat that renders tool use as chips.
- **Workflow editor** (When → Then strip) for schedules and webhooks. Workflows are created **inert**; the On/Off switch is the publish moment. Public webhooks get a UI warning. A runs rail shows real executions with honest empty states.
- **Honesty rule** throughout: every UI string traces to a stored field (documented in `studio/README.md` §4).

### The companion package (`studio/packages/studio-runtime.yaml`)
- `studio/ask-agent` — the webhook→assistant adapter (recognized by its reserved `studio_*` schema params, `sharedPool: true`), and `studio/copilot` — the moded agent behind "Improve with AI". Admin-installed; the app degrades gracefully without it.

### Bundled serving
- `console/Dockerfile` builds Studio in its own stage (repo-root context; root `.dockerignore` allowlists `console/` + `studio/app/`), nginx serves `/studio/` with SPA fallback, Caddy routes `{$DOMAIN}/studio*` to the console container. Dev compose + CI image matrix updated. Console sidebar gets an "Open Studio" link.

### Docs
- `studio/README.md` is the founding contract: BA/admin boundary, concept translation table, adapter contract, distribution, and tracked backend follow-ups (§7) — including two gaps found during live testing: webhook admission failures record no execution row, and `@sinas/cli install` can't pass package variables.

## Testing

End-to-end against a real locally running Sinas (native Postgres 16 + Redis + backend + arq worker): sign-in, project + assistant creation, instruction autosave, input editing, package validate/install, webhook workflow created inert → published → fired live through the adapter. nginx routing for the bundled layout verified by serving both real dists through the exact `nginx.conf` (redirect, deep-link fallbacks, asset types). `tsc` + Vite builds green for both apps; the Studio Docker stage's `npm ci` + build reproduced from a clean copy.

Not machine-verified: the full `docker build` and the Caddyfile change (sandbox couldn't pull base images) — worth a glance on first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAhchxz1C8Efu2AGjeYhav

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAhchxz1C8Efu2AGjeYhav)_