### PR TITLE
Agent delegation: sub-agent queue, depth bound, and suspend-on-delegate (#90)

### DIFF
--- a/backend/alembic/versions/d1e2l3g4t5e6_pending_delegations.py
+++ b/backend/alembic/versions/d1e2l3g4t5e6_pending_delegations.py
@@ -1,0 +1,56 @@
+"""pending_delegations table for suspend-on-delegate (issue #90)
+
+Also serves as the merge point for the two heads dev grew from
+b1a2t3c4h5e6 (0a1u2t3h4t5k connector-oauth and l1l2m3u4s5g6 llm-usage) —
+without a merge, `alembic upgrade head` fails on a multi-head graph.
+
+Revision ID: d1e2l3g4t5e6
+Revises: 0a1u2t3h4t5k, l1l2m3u4s5g6
+Create Date: 2026-07-14
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "d1e2l3g4t5e6"
+down_revision = ("0a1u2t3h4t5k", "l1l2m3u4s5g6")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pending_delegations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chats.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column("channel_id", sa.String(255), nullable=False),
+        sa.Column("pending", sa.JSON(), nullable=False),
+        sa.Column("results", sa.JSON(), nullable=False),
+        sa.Column("remaining", sa.Integer(), nullable=False),
+        sa.Column("conversation_context", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_pending_delegations_chat_id", "pending_delegations", ["chat_id"])
+    op.create_index("ix_pending_delegations_user_id", "pending_delegations", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pending_delegations_user_id", table_name="pending_delegations")
+    op.drop_index("ix_pending_delegations_chat_id", table_name="pending_delegations")
+    op.drop_table("pending_delegations")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -142,6 +142,7 @@ class Settings(BaseSettings):
     redis_url: str = "redis://redis:6379/0"
     queue_function_concurrency: int = 10
     queue_agent_concurrency: int = 5
+    queue_agent_sub_concurrency: int = 5  # concurrency of the sub-agent queue worker
     queue_default_timeout: int = 300
     queue_max_retries: int = 3
     queue_retry_delay: int = 10
@@ -149,6 +150,24 @@ class Settings(BaseSettings):
     # Agent job settings
     agent_job_timeout: int = 600  # Default timeout for agent jobs (10 minutes)
     code_execution_timeout: int = 120  # Default timeout for code execution (2 minutes)
+
+    # Agent-to-agent delegation (call_agent_* tools). See issue #90.
+    # - agent_delegate_timeout: how long a parent waits for a sub-agent result.
+    #   Must be < agent_job_timeout in "block" mode, since the parent's own job
+    #   clock keeps running while it waits.
+    # - agent_subagent_queue: route delegated (depth > 0) agent jobs to the
+    #   dedicated sub-agent queue so children never compete with top-level
+    #   parents for worker slots. Requires the sub-agent worker process
+    #   (SubAgentWorkerSettings); disable to restore single-queue routing.
+    # - agent_max_delegation_depth: reject delegation chains deeper than this.
+    # - agent_delegate_mode: "block" (parent holds its worker slot while
+    #   awaiting the child) or "suspend" (parent job ends at delegation and a
+    #   resume job continues the conversation when the children finish —
+    #   frees the slot, at the cost of a brief stream gap between jobs).
+    agent_delegate_timeout: int = 600
+    agent_subagent_queue: bool = True
+    agent_max_delegation_depth: int = 5
+    agent_delegate_mode: str = "block"
 
     # Encryption
     encryption_key: Optional[str] = None  # Fernet key for encrypting sensitive data

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ from .dependency import Dependency
 from .package import Package
 from .query import Query
 from .pending_approval import PendingToolApproval
+from .pending_delegation import PendingDelegation
 from .schedule import ScheduledJob
 from .secret import Secret
 from .skill import Skill
@@ -66,6 +67,7 @@ __all__ = [
     "State",
     "Store",
     "PendingToolApproval",
+    "PendingDelegation",
     "Secret",
     "Template",
     "Skill",

--- a/backend/app/models/pending_delegation.py
+++ b/backend/app/models/pending_delegation.py
@@ -1,0 +1,42 @@
+"""Pending agent-to-agent delegation tracking (suspend-on-delegate, issue #90)."""
+import uuid
+from typing import Any
+
+from sqlalchemy import JSON, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base, created_at, uuid_pk
+
+
+class PendingDelegation(Base):
+    """A parent agent turn suspended while its delegated sub-agents run.
+
+    Created when `agent_delegate_mode="suspend"` and an LLM turn contains
+    `call_agent_*` tool calls: the parent job ends (freeing its worker slot)
+    after enqueueing the children; each child reports back on completion, and
+    the last one enqueues a delegate-resume job that continues the parent
+    conversation. One row per suspended tool round (covers all delegate calls
+    in that round). Mirrors `PendingToolApproval`'s checkpoint pattern.
+    """
+
+    __tablename__ = "pending_delegations"
+
+    id: Mapped[uuid_pk]
+    chat_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("chats.id"), nullable=False, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+
+    # Parent's SSE stream channel — the resume job keeps publishing here.
+    channel_id: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # {tool_call_id: {"sub_chat_id": ..., "agent": ...}} still outstanding.
+    pending: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    # {tool_call_id: result content} collected from finished children.
+    results: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    # Outstanding count; decremented atomically as children finish. 0 → resume.
+    remaining: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Provider/model/tools/etc. needed by the follow-up LLM turn — same shape
+    # the approval flow stashes (see PendingToolApproval.conversation_context).
+    conversation_context: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+
+    created_at: Mapped[created_at]

--- a/backend/app/queue/agent_jobs.py
+++ b/backend/app/queue/agent_jobs.py
@@ -90,6 +90,27 @@ async def execute_agent_message_job(ctx: dict, **kwargs: Any) -> None:
     channel_id = kwargs["channel_id"]
     # Optional — set by batch_service so the Execution row mirrors the job lifecycle.
     execution_id = kwargs.get("execution_id")
+    # Agent-to-agent delegation metadata (issue #90). depth bounds chains and
+    # routes to the sub-agent queue; the pending_delegation fields mean a
+    # suspended parent is waiting on this job's result.
+    depth = kwargs.get("depth", 0)
+    pending_delegation_id = kwargs.get("pending_delegation_id")
+    parent_tool_call_id = kwargs.get("parent_tool_call_id")
+
+    from app.services.delegation import (
+        current_channel_id,
+        current_delegation_depth,
+        current_job_meta,
+    )
+
+    current_delegation_depth.set(depth)
+    current_channel_id.set(channel_id)
+    current_job_meta.set({
+        "execution_id": execution_id,
+        "stream_ttl": kwargs.get("stream_ttl"),
+        "parent_pending_delegation_id": pending_delegation_id,
+        "parent_tool_call_id": parent_tool_call_id,
+    })
 
     redis: Redis = ctx.get("redis") or Redis.from_url(settings.redis_url, decode_responses=True)
 
@@ -149,6 +170,7 @@ async def execute_agent_message_job(ctx: dict, **kwargs: Any) -> None:
         },
     ):
         _agent_output_parts: list[str] = []
+        _suspended = False
         try:
             async with AsyncSessionLocal() as db:
                 message_service = MessageService(db)
@@ -165,6 +187,8 @@ async def execute_agent_message_job(ctx: dict, **kwargs: Any) -> None:
 
                     if chunk.get("content"):
                         _agent_output_parts.append(chunk["content"])
+                    if chunk.get("type") == "delegation_pending":
+                        _suspended = True
                     await stream_relay.publish(channel_id, chunk, ttl=stream_ttl)
 
             # Set agent output on the current span
@@ -172,6 +196,19 @@ async def execute_agent_message_job(ctx: dict, **kwargs: Any) -> None:
             _current_span = trace.get_current_span()
             if _agent_output and _current_span:
                 _current_span.set_attribute(otel_attr("output"), _agent_output)
+
+            if _suspended:
+                # The conversation continues in a delegate-resume job (issue
+                # #90): no "done" event, no Execution termination, no report
+                # to our own parent — the resume job owns all of that.
+                await redis.set(
+                    f"{JOB_STATUS_PREFIX}{job_id}",
+                    json.dumps({**base_fields, "status": "suspended"}),
+                    ex=JOB_TTL,
+                )
+                completed = True
+                logger.info(f"Agent message job {job_id} suspended on delegation")
+                return
 
             # Signal completion
             await stream_relay.publish_done(channel_id)
@@ -188,6 +225,21 @@ async def execute_agent_message_job(ctx: dict, **kwargs: Any) -> None:
                 final_output = {"final_message": "".join(_agent_output_parts)}
                 await _terminate_execution_row(
                     execution_id, ExecutionStatus.COMPLETED, output=final_output,
+                )
+
+            # Suspend-on-delegate hook (issue #90): report our final content to
+            # the suspended parent; the last child triggers the parent's resume.
+            if pending_delegation_id and parent_tool_call_id:
+                from app.services.delegation import on_child_complete
+
+                await on_child_complete(
+                    pending_delegation_id,
+                    parent_tool_call_id,
+                    json.dumps({
+                        "response": "".join(_agent_output_parts),
+                        "chat_id": chat_id,
+                    }),
+                    user_token=user_token,
                 )
 
             completed = True
@@ -211,6 +263,24 @@ async def execute_agent_message_job(ctx: dict, **kwargs: Any) -> None:
                 await _terminate_execution_row(
                     execution_id, ExecutionStatus.FAILED, error=str(e),
                 )
+
+            # A failed child must still report back, or the suspended parent
+            # would wait forever on a result that is never coming.
+            if pending_delegation_id and parent_tool_call_id:
+                from app.services.delegation import on_child_complete
+
+                try:
+                    await on_child_complete(
+                        pending_delegation_id,
+                        parent_tool_call_id,
+                        json.dumps({"error": str(e), "chat_id": chat_id}),
+                        user_token=user_token,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to report child failure to pending delegation %s",
+                        pending_delegation_id,
+                    )
 
             completed = True
             raise
@@ -254,6 +324,11 @@ async def execute_agent_resume_job(ctx: dict, **kwargs: Any) -> None:
     pending_approval_id = kwargs["pending_approval_id"]
     approved = kwargs["approved"]
     channel_id = kwargs["channel_id"]
+
+    from app.services.delegation import current_channel_id, current_delegation_depth
+
+    current_delegation_depth.set(kwargs.get("depth", 0))
+    current_channel_id.set(channel_id)
 
     redis: Redis = ctx.get("redis") or Redis.from_url(settings.redis_url, decode_responses=True)
 
@@ -386,3 +461,179 @@ async def execute_agent_resume_job(ctx: dict, **kwargs: Any) -> None:
                 )
             except Exception:
                 logger.error(f"Failed to update status for cancelled agent resume job {job_id}")
+
+
+async def execute_agent_delegate_resume_job(ctx: dict, **kwargs: Any) -> None:
+    """Continue a parent conversation suspended on sub-agent delegations.
+
+    Enqueued by the LAST finishing child (see `delegation.on_child_complete`).
+    All delegate tool results are already persisted as tool-role Message rows,
+    so this job only runs the follow-up phase of the tool round: rebuild the
+    conversation from the DB, stream the next LLM turn, and keep going
+    (further tool rounds included). Issue #90.
+    """
+    from redis.asyncio import Redis
+
+    from app.core.database import AsyncSessionLocal
+    from app.services.delegation import (
+        current_channel_id,
+        current_delegation_depth,
+        current_job_meta,
+    )
+    from app.services.message_service import MessageService
+    from app.services.stream_relay import stream_relay
+
+    job_id = kwargs["job_id"]
+    chat_id = kwargs["chat_id"]
+    user_id = kwargs["user_id"]
+    user_token = kwargs["user_token"]
+    channel_id = kwargs["channel_id"]
+    context = kwargs["conversation_context"]
+    # Inherited from the suspended job (see message_service suspend block).
+    execution_id = context.get("execution_id")
+    parent_pending_delegation_id = context.get("parent_pending_delegation_id")
+    parent_tool_call_id = context.get("parent_tool_call_id")
+
+    current_delegation_depth.set(context.get("delegation_depth", 0))
+    current_channel_id.set(channel_id)
+    current_job_meta.set({
+        "execution_id": execution_id,
+        "stream_ttl": context.get("stream_ttl"),
+        "parent_pending_delegation_id": parent_pending_delegation_id,
+        "parent_tool_call_id": parent_tool_call_id,
+    })
+
+    redis: Redis = ctx.get("redis") or Redis.from_url(settings.redis_url, decode_responses=True)
+
+    logger.info(f"Agent worker resuming chat {chat_id} after delegation (job={job_id})")
+
+    base_fields = {
+        "channel_id": channel_id,
+        "queue": "agents",
+        "type": "delegate_resume",
+        "chat_id": chat_id,
+    }
+    await redis.set(
+        f"{JOB_STATUS_PREFIX}{job_id}",
+        json.dumps({**base_fields, "status": "running"}),
+        ex=JOB_TTL,
+    )
+
+    stream_ttl = context.get("stream_ttl")
+    ping_task = asyncio.create_task(_ping_loop(channel_id, ttl=stream_ttl))
+
+    completed = False
+    _suspended = False
+    _output_parts: list[str] = []
+    try:
+        async with AsyncSessionLocal() as db:
+            message_service = MessageService(db)
+            async for chunk in message_service._stream_followup_after_tools(
+                chat_id=chat_id,
+                user_id=user_id,
+                user_token=user_token,
+                provider=context.get("provider"),
+                model=context.get("model"),
+                temperature=context.get("temperature", 0.7),
+                max_tokens=context.get("max_tokens"),
+                tools=context.get("tools", []),
+                status_templates=context.get("status_templates", {}),
+                depth=context.get("tool_iteration_depth", 0),
+                agent_label=context.get("agent_label"),
+                tool_summary="delegated sub-agent results",
+            ):
+                if isinstance(chunk, dict):
+                    if chunk.get("content"):
+                        _output_parts.append(chunk["content"])
+                    if chunk.get("type") == "delegation_pending":
+                        _suspended = True
+                    await stream_relay.publish(channel_id, chunk, ttl=stream_ttl)
+
+        if _suspended:
+            # Suspended again on a further round of delegations — the next
+            # delegate-resume job carries the same inherited meta forward.
+            await redis.set(
+                f"{JOB_STATUS_PREFIX}{job_id}",
+                json.dumps({**base_fields, "status": "suspended"}),
+                ex=JOB_TTL,
+            )
+            completed = True
+            logger.info(f"Delegate-resume job {job_id} suspended again on delegation")
+            return
+
+        await stream_relay.publish_done(channel_id)
+        await redis.set(
+            f"{JOB_STATUS_PREFIX}{job_id}",
+            json.dumps({**base_fields, "status": "completed"}),
+            ex=JOB_TTL,
+        )
+
+        if execution_id:
+            await _terminate_execution_row(
+                execution_id,
+                ExecutionStatus.COMPLETED,
+                output={"final_message": "".join(_output_parts)},
+            )
+
+        # This conversation is itself a delegated child: report our final
+        # content to OUR suspended parent now that we're truly done.
+        if parent_pending_delegation_id and parent_tool_call_id:
+            from app.services.delegation import on_child_complete
+
+            await on_child_complete(
+                parent_pending_delegation_id,
+                parent_tool_call_id,
+                json.dumps({
+                    "response": "".join(_output_parts),
+                    "chat_id": chat_id,
+                }),
+                user_token=user_token,
+            )
+
+        completed = True
+        logger.info(f"Delegate-resume job {job_id} completed")
+
+    except Exception as e:
+        logger.error(f"Delegate-resume job {job_id} failed: {e}")
+        logger.error(f"Traceback: {traceback.format_exc()}")
+        await stream_relay.publish_error(channel_id, str(e))
+        await redis.set(
+            f"{JOB_STATUS_PREFIX}{job_id}",
+            json.dumps({**base_fields, "status": "failed", "error": str(e)}),
+            ex=JOB_TTL,
+        )
+        if execution_id:
+            await _terminate_execution_row(
+                execution_id, ExecutionStatus.FAILED, error=str(e),
+            )
+        if parent_pending_delegation_id and parent_tool_call_id:
+            from app.services.delegation import on_child_complete
+
+            try:
+                await on_child_complete(
+                    parent_pending_delegation_id,
+                    parent_tool_call_id,
+                    json.dumps({"error": str(e), "chat_id": chat_id}),
+                    user_token=user_token,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to report resume failure to pending delegation %s",
+                    parent_pending_delegation_id,
+                )
+        completed = True
+        raise
+
+    finally:
+        ping_task.cancel()
+        if not completed:
+            logger.warning(f"Delegate-resume job {job_id} cancelled/timed out")
+            try:
+                await stream_relay.publish_error(channel_id, "Job cancelled or timed out")
+                await redis.set(
+                    f"{JOB_STATUS_PREFIX}{job_id}",
+                    json.dumps({**base_fields, "status": "failed", "error": "Job cancelled or timed out"}),
+                    ex=JOB_TTL,
+                )
+            except Exception:
+                logger.error(f"Failed to update status for cancelled delegate-resume job {job_id}")

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -342,6 +342,7 @@ class WorkerSettings:
 
 # Import agent jobs for combined worker
 from app.queue.agent_jobs import (
+    execute_agent_delegate_resume_job,
     execute_agent_message_job,
     execute_agent_resume_job,
 )
@@ -350,11 +351,39 @@ from app.queue.agent_jobs import (
 class AgentWorkerSettings:
     """arq worker settings for agent message processing."""
 
-    functions = [execute_agent_message_job, execute_agent_resume_job]
+    functions = [
+        execute_agent_message_job,
+        execute_agent_resume_job,
+        execute_agent_delegate_resume_job,
+    ]
     on_startup = agent_worker_startup
     on_shutdown = shutdown
     redis_settings = get_redis_settings()
     queue_name = "sinas:queue:agents"
     max_jobs = settings.queue_agent_concurrency
     job_timeout = settings.agent_job_timeout  # Default timeout, can be overridden per-job
+    max_tries = 1  # No retry for agent conversations (side effects)
+
+
+class SubAgentWorkerSettings:
+    """arq worker settings for DELEGATED agent jobs (issue #90).
+
+    Same job handlers as AgentWorkerSettings, different queue: agent-to-agent
+    calls (depth > 0) land here so parents blocked on children can never
+    starve them of worker slots. Run as its own process:
+
+        python -m arq app.queue.worker.SubAgentWorkerSettings
+    """
+
+    functions = [
+        execute_agent_message_job,
+        execute_agent_resume_job,
+        execute_agent_delegate_resume_job,
+    ]
+    on_startup = agent_worker_startup
+    on_shutdown = shutdown
+    redis_settings = get_redis_settings()
+    queue_name = "sinas:queue:agents:sub"
+    max_jobs = settings.queue_agent_sub_concurrency
+    job_timeout = settings.agent_job_timeout
     max_tries = 1  # No retry for agent conversations (side effects)

--- a/backend/app/services/delegation.py
+++ b/backend/app/services/delegation.py
@@ -1,0 +1,208 @@
+"""Agent-to-agent delegation support (issue #90).
+
+Delegation depth is carried on the arq job (`depth` kwarg) and exposed to the
+tool layer through a ContextVar set by the agent job handlers — the tool code
+that enqueues a child runs deep inside the message loop and has no access to
+the job's kwargs.
+
+Depth 0 = user-initiated chat; every `call_agent_*` hop adds 1. Delegated
+jobs route to the dedicated sub-agent queue (see `queue_service`) so parents
+waiting on children can never starve them of worker slots, and chains are
+bounded by `settings.agent_max_delegation_depth`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+from sqlalchemy import select
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Set by execute_agent_message_job / execute_agent_resume_job from job kwargs.
+current_delegation_depth: ContextVar[int] = ContextVar(
+    "current_delegation_depth", default=0
+)
+
+# The stream channel of the job currently processing this conversation.
+# Needed to suspend: the resume job must publish to the same channel the
+# user is subscribed to. None when not running inside an agent job (e.g.
+# direct/synchronous API paths) — suspend mode falls back to blocking there.
+current_channel_id: ContextVar[str | None] = ContextVar(
+    "current_channel_id", default=None
+)
+
+# Job-level fields a suspension must carry into the resume job: the batch
+# Execution row to terminate, the stream TTL, and — when this job is itself
+# a delegated child — the parent checkpoint to report to when done.
+current_job_meta: ContextVar[dict] = ContextVar("current_job_meta", default={})
+
+
+def child_depth_or_error() -> tuple[int, str | None]:
+    """Depth for a would-be child delegation, or an error when over the bound."""
+    depth = current_delegation_depth.get() + 1
+    limit = settings.agent_max_delegation_depth
+    if limit and depth > limit:
+        return depth, (
+            f"Delegation depth limit reached ({limit}). This agent is already "
+            f"{depth - 1} delegation hop(s) deep; it cannot call another agent. "
+            "Answer with the information available, or raise "
+            "AGENT_MAX_DELEGATION_DEPTH if deeper chains are intended."
+        )
+    return depth, None
+
+
+async def suspend_delegations(
+    db,
+    *,
+    chat_id: str,
+    user_id: str,
+    user_token: str,
+    channel_id: str,
+    delegations: list[dict[str, Any]],
+    conversation_context: dict[str, Any],
+) -> str:
+    """Persist a PendingDelegation checkpoint, then enqueue the children.
+
+    `delegations`: [{"tool_call_id", "sub_chat_id", "agent", "content"}].
+    Order matters: the row must exist before any child is enqueued, or a fast
+    child could report completion against a checkpoint that isn't there yet.
+    Returns the pending_delegation row id.
+    """
+    from app.models.pending_delegation import PendingDelegation
+    from app.services.queue_service import queue_service
+
+    row = PendingDelegation(
+        chat_id=chat_id,
+        user_id=user_id,
+        channel_id=channel_id,
+        pending={
+            d["tool_call_id"]: {"sub_chat_id": d["sub_chat_id"], "agent": d["agent"]}
+            for d in delegations
+        },
+        results={},
+        remaining=len(delegations),
+        conversation_context=conversation_context,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+
+    for d in delegations:
+        await queue_service.enqueue_agent_message(
+            chat_id=d["sub_chat_id"],
+            user_id=user_id,
+            user_token=user_token,
+            content=d["content"],
+            channel_id=str(uuid.uuid4()),  # child's own stream channel
+            agent=d["agent"],
+            depth=conversation_context.get("delegation_depth", 0) + 1,
+            pending_delegation_id=str(row.id),
+            parent_tool_call_id=d["tool_call_id"],
+        )
+
+    logger.info(
+        "Suspended chat %s on %d delegated sub-agent(s) (pending_delegation=%s)",
+        chat_id, len(delegations), row.id,
+    )
+    return str(row.id)
+
+
+async def on_child_complete(
+    pending_delegation_id: str,
+    tool_call_id: str,
+    content: str,
+    *,
+    user_token: str,
+) -> None:
+    """Record a finished child; when it is the last one, wake the parent.
+
+    Writes the child's final content as the parent's tool-result Message row
+    (the source the follow-up LLM turn is rebuilt from), then — on the last
+    child — deletes the checkpoint and enqueues the delegate-resume job.
+    Concurrency-safe via SELECT ... FOR UPDATE on the checkpoint row.
+    """
+    from app.core.database import AsyncSessionLocal
+    from app.models.chat import Message
+    from app.models.pending_delegation import PendingDelegation
+    from app.services.queue_service import queue_service
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(PendingDelegation)
+            .where(PendingDelegation.id == pending_delegation_id)
+            .with_for_update()
+        )
+        row = result.scalar_one_or_none()
+        if not row:
+            logger.warning(
+                "PendingDelegation %s not found for tool_call %s — parent already resumed or cleaned up",
+                pending_delegation_id, tool_call_id,
+            )
+            return
+
+        info = (row.pending or {}).get(tool_call_id, {})
+
+        # Persist the tool result on the parent conversation NOW, in this
+        # transaction — the resume job rebuilds messages from the DB.
+        db.add(
+            Message(
+                chat_id=row.chat_id,
+                role="tool",
+                content=content,
+                tool_call_id=tool_call_id,
+                name=f"call_agent_{info.get('agent', '').replace('/', '__')}" if info.get("agent") else None,
+            )
+        )
+
+        # JSON columns need reassignment (in-place mutation isn't tracked).
+        results = dict(row.results or {})
+        results[tool_call_id] = content
+        row.results = results
+        pending = dict(row.pending or {})
+        pending.pop(tool_call_id, None)
+        row.pending = pending
+        row.remaining = row.remaining - 1
+
+        is_last = row.remaining <= 0
+        ctx = row.conversation_context
+        chat_id, user_id, channel_id = str(row.chat_id), str(row.user_id), row.channel_id
+        if is_last:
+            await db.delete(row)
+        await db.commit()
+
+    # Progressive UX: close this tool call on the parent's stream now, even
+    # though the conversation only continues when the last child lands.
+    try:
+        from app.services.stream_relay import stream_relay
+
+        await stream_relay.publish(
+            channel_id,
+            {
+                "type": "tool_end",
+                "tool_call_id": tool_call_id,
+                "name": f"call_agent_{info.get('agent', '').replace('/', '__')}",
+                "result": content,
+            },
+        )
+    except Exception:
+        logger.debug("Could not publish delegate tool_end to %s", channel_id)
+
+    if is_last:
+        await queue_service.enqueue_agent_delegate_resume(
+            chat_id=chat_id,
+            user_id=user_id,
+            user_token=user_token,
+            channel_id=channel_id,
+            conversation_context=ctx,
+        )
+        logger.info(
+            "All delegations done for chat %s — resume job enqueued", chat_id
+        )
+

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -855,6 +855,34 @@ class MessageService:
 
         # Separate tool calls into parallel and sequential groups
         valid_tool_calls = [tc for tc in tool_calls if tc.get("id")]
+
+        # Suspend-on-delegate (issue #90): in "suspend" mode, agent-delegation
+        # tools are split off — they don't execute (and block) here. After the
+        # regular tools finish, the children are enqueued and this generator
+        # ends, freeing the worker slot; a delegate-resume job continues the
+        # conversation when the last child reports back. Requires a job
+        # channel (current_channel_id) — direct/synchronous paths still block.
+        from app.services.delegation import current_channel_id
+
+        delegate_calls: list[dict[str, Any]] = []
+        _meta_by_name: dict[str, dict[str, Any]] = {}
+        if (
+            settings.agent_delegate_mode == "suspend"
+            and current_channel_id.get() is not None
+        ):
+            _meta_by_name = (
+                {t["function"]["name"]: t["function"].get("_metadata", {}) for t in tools}
+                if tools
+                else {}
+            )
+            non_delegate_calls = []
+            for tc in valid_tool_calls:
+                if _meta_by_name.get(tc["function"]["name"], {}).get("agent_id"):
+                    delegate_calls.append(tc)
+                else:
+                    non_delegate_calls.append(tc)
+            valid_tool_calls = non_delegate_calls
+
         parallel_calls = []
         sequential_calls = []
 
@@ -976,6 +1004,130 @@ class MessageService:
                 pass
         asyncio.create_task(_persist_results())
 
+        # Suspend on the delegated calls (issue #90): enqueue children and end
+        # this generator instead of blocking a worker slot on their streams.
+        if delegate_calls:
+            from app.services.delegation import (
+                current_delegation_depth,
+                suspend_delegations,
+            )
+            from app.services.tool_execution import prepare_agent_delegation
+
+            prepared: list[dict[str, Any]] = []
+            for tc in delegate_calls:
+                args = safe_parse_arguments(tc["function"].get("arguments", ""))
+                yield {
+                    "type": "tool_start",
+                    "tool_call_id": tc["id"],
+                    "name": tc["function"]["name"],
+                    "arguments": tc["function"].get("arguments", "{}"),
+                    "description": build_tool_status(tc["function"]["name"], args, status_templates),
+                }
+                meta = _meta_by_name.get(tc["function"]["name"], {})
+                prep = await prepare_agent_delegation(
+                    self.db, user_id, meta.get("agent_id"), args
+                )
+                if "error" in prep:
+                    # Failed before enqueue (unknown agent, permissions, depth
+                    # bound) — record as an immediate tool result instead.
+                    error_content = json.dumps(prep)
+                    tool_results[tc["id"]] = (tc["id"], tc["function"]["name"], error_content)
+                    self.db.add(Message(chat_id=chat_id, role="tool", content=error_content, tool_call_id=tc["id"], name=tc["function"]["name"]))
+                    await self.db.commit()
+                    yield {"type": "tool_end", "tool_call_id": tc["id"], "name": tc["function"]["name"], "result": error_content}
+                else:
+                    prepared.append(
+                        {
+                            "tool_call_id": tc["id"],
+                            "sub_chat_id": str(prep["sub_chat"].id),
+                            "agent": f"{prep['agent'].namespace}/{prep['agent'].name}",
+                            "content": prep["content"],
+                        }
+                    )
+
+            if prepared:
+                from app.services.delegation import current_job_meta
+
+                await suspend_delegations(
+                    self.db,
+                    chat_id=chat_id,
+                    user_id=user_id,
+                    user_token=user_token,
+                    channel_id=current_channel_id.get(),
+                    delegations=prepared,
+                    conversation_context={
+                        "provider": provider,
+                        "model": model,
+                        "temperature": temperature,
+                        "max_tokens": max_tokens,
+                        "tools": tools,
+                        "status_templates": status_templates,
+                        "agent_label": agent_label,
+                        "tool_iteration_depth": depth,
+                        "delegation_depth": current_delegation_depth.get(),
+                        # Job-level fields the resume job must inherit:
+                        # batch Execution row, stream TTL, and (when this
+                        # conversation is itself a delegated child) the
+                        # parent checkpoint to report to on completion.
+                        **current_job_meta.get(),
+                    },
+                )
+                yield {
+                    "type": "delegation_pending",
+                    "tool_call_ids": [d["tool_call_id"] for d in prepared],
+                }
+                return
+            # All delegations failed at prepare — fall through to the regular
+            # follow-up turn with their error results.
+
+        # Follow-up LLM turn — extracted so the delegate-resume job (issue
+        # #90) can re-enter the tool round from persisted state.
+        tool_summary = (
+            ", ".join(f"{r[1]}" for r in tool_results.values())[:500]
+            if tool_results
+            else "tool results"
+        )
+        async for chunk in self._stream_followup_after_tools(
+            chat_id=chat_id,
+            user_id=user_id,
+            user_token=user_token,
+            provider=provider,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            permissions=permissions,
+            status_templates=status_templates,
+            depth=depth,
+            agent_label=agent_label,
+            tool_summary=tool_summary,
+        ):
+            yield chunk
+
+    async def _stream_followup_after_tools(
+        self,
+        *,
+        chat_id: str,
+        user_id: str,
+        user_token: str,
+        provider: Optional[str],
+        model: Optional[str],
+        temperature: float,
+        max_tokens: Optional[int],
+        tools: list[dict[str, Any]],
+        permissions: Optional[dict[str, bool]] = None,
+        status_templates: dict[str, str] = {},
+        depth: int = 0,
+        agent_label: Optional[str] = None,
+        tool_summary: str = "tool results",
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Rebuild the conversation from the DB and stream the next LLM turn.
+
+        The second half of a tool round — everything after the tool results
+        are persisted as Message rows. Called inline by _handle_tool_calls,
+        and re-entered by execute_agent_delegate_resume_job once suspended
+        sub-agents have reported back (issue #90).
+        """
         result_chat = await self.db.execute(select(Chat).where(Chat.id == chat_id))
         chat = result_chat.scalar_one_or_none()
 
@@ -1099,7 +1251,7 @@ class MessageService:
         # Record follow-up LLM call as a span
         try:
             # Summarize: tool results that were fed back to the LLM
-            _tool_summary = ", ".join(f"{r[1]}" for r in tool_results.values())[:500] if tool_results else "tool results"
+            _tool_summary = tool_summary
             _labels = json.dumps([f"agent:{agent_label}"]) if agent_label else "[]"
             _s2 = _tracer.start_span("llm.call", attributes={
                 "gen_ai.request.model": model or "",

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 
 # Redis key prefixes
 JOB_STATUS_PREFIX = "sinas:job:status:"
+AGENT_QUEUE = "sinas:queue:agents"
+# Dedicated queue for delegated (agent-to-agent) jobs — see issue #90.
+SUB_AGENT_QUEUE = "sinas:queue:agents:sub"
 JOB_RESULT_PREFIX = "sinas:job:result:"
 JOB_DONE_CHANNEL_PREFIX = "sinas:job:done:"
 DLQ_KEY = "sinas:queue:dlq"
@@ -198,21 +201,34 @@ class QueueService:
         trigger_type: Optional[str] = None,
         job_timeout: Optional[int] = None,
         execution_id: Optional[str] = None,
+        depth: int = 0,
+        pending_delegation_id: Optional[str] = None,
+        parent_tool_call_id: Optional[str] = None,
     ) -> str:
         """Enqueue an agent message processing job.
 
         If `execution_id` is provided, the worker will update that Execution
         row to COMPLETED/FAILED on terminal status (used by batch_service).
+
+        `depth` is the agent-to-agent delegation depth (0 = user-initiated).
+        Delegated jobs (depth > 0) go to the dedicated sub-agent queue so
+        parents waiting on children can never starve them of worker slots
+        (issue #90). `pending_delegation_id`/`parent_tool_call_id` are set for
+        suspend-mode delegations: on terminal status the worker reports the
+        result back to the suspended parent.
         """
         pool = await get_arq_pool()
         redis = await get_redis()
 
         job_id = str(uuid.uuid4())
 
+        use_sub_queue = depth > 0 and settings.agent_subagent_queue
+        queue_label = "agents:sub" if use_sub_queue else "agents"
+
         status_data: dict[str, Any] = {
             "status": "queued",
             "channel_id": channel_id,
-            "queue": "agents",
+            "queue": queue_label,
             "type": "message",
             "chat_id": chat_id,
             "enqueued_at": time.time(),
@@ -230,7 +246,7 @@ class QueueService:
 
         enqueue_kwargs: dict[str, Any] = {
             "_job_id": job_id,
-            "_queue_name": "sinas:queue:agents",
+            "_queue_name": SUB_AGENT_QUEUE if use_sub_queue else AGENT_QUEUE,
         }
         if job_timeout is not None:
             enqueue_kwargs["_job_timeout"] = job_timeout
@@ -244,11 +260,17 @@ class QueueService:
             content=content,
             channel_id=channel_id,
             execution_id=execution_id,
+            depth=depth,
+            pending_delegation_id=pending_delegation_id,
+            parent_tool_call_id=parent_tool_call_id,
             trace_context=inject_trace_context(),
             **enqueue_kwargs,
         )
 
-        logger.info(f"Enqueued agent message job {job_id} for chat {chat_id}")
+        logger.info(
+            f"Enqueued agent message job {job_id} for chat {chat_id} "
+            f"(queue={queue_label}, depth={depth})"
+        )
         return job_id
 
     async def enqueue_agent_resume(
@@ -308,6 +330,67 @@ class QueueService:
         logger.info(f"Enqueued agent resume job {job_id} for chat {chat_id}")
         return job_id
 
+    async def enqueue_agent_delegate_resume(
+        self,
+        chat_id: str,
+        user_id: str,
+        user_token: str,
+        channel_id: str,
+        conversation_context: dict[str, Any],
+        job_timeout: Optional[int] = None,
+    ) -> str:
+        """Enqueue continuation of a parent suspended on delegations (issue #90).
+
+        Fired by the last finishing child. Routed by the parent's own
+        delegation depth, so a suspended sub-agent resumes on the sub-agent
+        queue and a top-level parent on the main queue.
+        """
+        pool = await get_arq_pool()
+        redis = await get_redis()
+
+        job_id = str(uuid.uuid4())
+        depth = conversation_context.get("delegation_depth", 0)
+        use_sub_queue = depth > 0 and settings.agent_subagent_queue
+        queue_label = "agents:sub" if use_sub_queue else "agents"
+
+        status_data: dict[str, Any] = {
+            "status": "queued",
+            "channel_id": channel_id,
+            "queue": queue_label,
+            "type": "delegate_resume",
+            "chat_id": chat_id,
+            "enqueued_at": time.time(),
+        }
+        await redis.set(
+            f"{JOB_STATUS_PREFIX}{job_id}",
+            json.dumps(status_data),
+            ex=JOB_TTL,
+        )
+
+        enqueue_kwargs: dict[str, Any] = {
+            "_job_id": job_id,
+            "_queue_name": SUB_AGENT_QUEUE if use_sub_queue else AGENT_QUEUE,
+        }
+        if job_timeout is not None:
+            enqueue_kwargs["_job_timeout"] = job_timeout
+
+        await pool.enqueue_job(
+            "execute_agent_delegate_resume_job",
+            job_id=job_id,
+            chat_id=chat_id,
+            user_id=user_id,
+            user_token=user_token,
+            channel_id=channel_id,
+            conversation_context=conversation_context,
+            trace_context=inject_trace_context(),
+            **enqueue_kwargs,
+        )
+
+        logger.info(
+            f"Enqueued delegate-resume job {job_id} for chat {chat_id} (queue={queue_label})"
+        )
+        return job_id
+
 
     async def get_queue_stats(self) -> dict[str, Any]:
         """Get aggregate queue statistics."""
@@ -315,7 +398,8 @@ class QueueService:
 
         # Queue depths (arq uses sorted sets)
         functions_pending = await redis.zcard("sinas:queue:functions")
-        agents_pending = await redis.zcard("sinas:queue:agents")
+        agents_pending = await redis.zcard(AGENT_QUEUE)
+        sub_agents_pending = await redis.zcard(SUB_AGENT_QUEUE)
 
         # DLQ size
         dlq_size = await redis.llen(DLQ_KEY)
@@ -343,6 +427,7 @@ class QueueService:
             "queues": {
                 "functions": {"pending": functions_pending},
                 "agents": {"pending": agents_pending},
+                "agents:sub": {"pending": sub_agents_pending},
             },
             "jobs": {
                 "queued": status_counts.get("queued", 0),

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -17,6 +17,7 @@ from app.core.database import AsyncSessionLocal
 from app.models import Agent, Chat, Message
 from app.models.function import Function
 from app.models.pending_approval import PendingToolApproval
+from app.core.config import settings
 from app.models.user import User
 from app.services.code_execution import execute as execute_code
 from app.services.collection_tools import CollectionToolConverter
@@ -268,28 +269,36 @@ async def check_approval_requirements(
     return requires_approval
 
 
-async def execute_agent_tool(
+async def prepare_agent_delegation(
     db: AsyncSession,
-    chat: Chat,
     user_id: str,
-    user_token: str,
     agent_id_str: str,
     arguments: dict[str, Any],
-    create_chat_with_agent_fn,
 ) -> dict[str, Any]:
-    """Execute an agent tool call by creating or resuming a chat."""
+    """Resolve a `call_agent_*` target and create (or load) its sub-chat.
+
+    Everything `execute_agent_tool` does before enqueueing — shared with the
+    suspend-on-delegate path in message_service (issue #90), which enqueues
+    the child itself and ends the parent job instead of blocking.
+
+    Returns {"error": ...} on failure, else
+    {"agent": Agent, "sub_chat": Chat, "content": str, "depth": int}.
+    """
     if not agent_id_str:
         return {"error": "Agent ID not provided"}
-
-    # Load agent
-    from app.core.telemetry import get_tracer, otel_attr
-    _agent_tracer = get_tracer()
 
     result = await db.execute(select(Agent).where(Agent.id == agent_id_str))
     agent = result.scalar_one_or_none()
 
     if not agent:
         return {"error": f"Agent not found: {agent_id_str}"}
+
+    # Bound delegation chains (issue #90) — reject before spending a sub-chat.
+    from app.services.delegation import child_depth_or_error
+
+    child_depth, depth_error = child_depth_or_error()
+    if depth_error:
+        return {"error": depth_error}
 
     # Check user has permission to use this sub-agent
     user_permissions = await get_user_permissions(db, user_id)
@@ -308,34 +317,58 @@ async def execute_agent_tool(
 
     # Resume existing chat or create a new one
     resume_chat_id = arguments.get("_chat_id")
+    if resume_chat_id:
+        # Verify the chat exists, belongs to this user and agent
+        result = await db.execute(
+            select(Chat).where(
+                Chat.id == resume_chat_id,
+                Chat.user_id == user_id,
+                Chat.agent_id == agent_id_str,
+            )
+        )
+        sub_chat = result.scalar_one_or_none()
+        if not sub_chat:
+            return {"error": f"Chat {resume_chat_id} not found or does not belong to this agent"}
+        logger.info(f"Resuming sub-agent chat {sub_chat.id} with {agent.namespace}/{agent.name}")
+    else:
+        # Create sub-chat using our own db session (not the parent's)
+        # to avoid cross-session issues with the parent MessageService.
+        sub_chat = Chat(
+            user_id=user_id,
+            agent_id=str(agent.id),
+            agent_namespace=agent.namespace,
+            agent_name=agent.name,
+            title=f"Sub-chat: {agent.name}",
+            chat_metadata={"agent_input": input_data} if input_data else None,
+        )
+        db.add(sub_chat)
+        await db.commit()
+        await db.refresh(sub_chat)
+
+    return {"agent": agent, "sub_chat": sub_chat, "content": content, "depth": child_depth}
+
+
+async def execute_agent_tool(
+    db: AsyncSession,
+    chat: Chat,
+    user_id: str,
+    user_token: str,
+    agent_id_str: str,
+    arguments: dict[str, Any],
+    create_chat_with_agent_fn,
+) -> dict[str, Any]:
+    """Execute an agent tool call by creating or resuming a chat."""
+    from app.core.telemetry import get_tracer, otel_attr
+    _agent_tracer = get_tracer()
+
     try:
-        if resume_chat_id:
-            # Verify the chat exists, belongs to this user and agent
-            result = await db.execute(
-                select(Chat).where(
-                    Chat.id == resume_chat_id,
-                    Chat.user_id == user_id,
-                    Chat.agent_id == agent_id_str,
-                )
-            )
-            sub_chat = result.scalar_one_or_none()
-            if not sub_chat:
-                return {"error": f"Chat {resume_chat_id} not found or does not belong to this agent"}
-            logger.info(f"Resuming sub-agent chat {sub_chat.id} with {agent.namespace}/{agent.name}")
-        else:
-            # Create sub-chat using our own db session (not the parent's)
-            # to avoid cross-session issues with the parent MessageService.
-            sub_chat = Chat(
-                user_id=user_id,
-                agent_id=str(agent.id),
-                agent_namespace=agent.namespace,
-                agent_name=agent.name,
-                title=f"Sub-chat: {agent.name}",
-                chat_metadata={"agent_input": input_data} if input_data else None,
-            )
-            db.add(sub_chat)
-            await db.commit()
-            await db.refresh(sub_chat)
+        prep = await prepare_agent_delegation(db, user_id, agent_id_str, arguments)
+        if "error" in prep:
+            return prep
+        agent = prep["agent"]
+        sub_chat = prep["sub_chat"]
+        content = prep["content"]
+        child_depth = prep["depth"]
 
         # Route agent-to-agent calls through the queue so each sub-agent
         # runs in its own worker — enables agent swarms without recursive blocking.
@@ -357,15 +390,20 @@ async def execute_agent_tool(
             content=content,
             channel_id=channel_id,
             agent=f"{agent.namespace}/{agent.name}",
+            depth=child_depth,
         )
 
         # Wait for the sub-agent to finish by reading the Redis stream.
         # Use a longer timeout than the default SUBSCRIBE_WAIT_TIMEOUT since
         # agent-to-agent calls can take minutes (the sub-agent may itself be
-        # making tool calls, calling other agents, etc.).
+        # making tool calls, calling other agents, etc.). NOTE: this "block"
+        # mode holds the parent's worker slot for the whole wait; see
+        # settings.agent_delegate_mode and issue #90.
         final_content = ""
         got_terminal = False
-        async for event in stream_relay.subscribe(channel_id, timeout=600):
+        async for event in stream_relay.subscribe(
+            channel_id, timeout=settings.agent_delegate_timeout
+        ):
             if event.get("content"):
                 final_content += event["content"]
             if event.get("type") in ("done", "error"):

--- a/backend/tests/unit/test_delegation.py
+++ b/backend/tests/unit/test_delegation.py
@@ -1,0 +1,76 @@
+"""Unit tests for agent-to-agent delegation plumbing (issue #90).
+
+Covers the pure pieces: depth propagation/bounding, queue topology, and job
+registration. The suspend/resume round-trip itself needs a live stack and is
+exercised in integration testing.
+"""
+
+from app.core.config import settings
+from app.queue.agent_jobs import (
+    execute_agent_delegate_resume_job,
+    execute_agent_message_job,
+    execute_agent_resume_job,
+)
+from app.queue.worker import AgentWorkerSettings, SubAgentWorkerSettings
+from app.services.delegation import child_depth_or_error, current_delegation_depth
+from app.services.queue_service import AGENT_QUEUE, SUB_AGENT_QUEUE
+
+
+def test_child_depth_increments_from_context():
+    token = current_delegation_depth.set(0)
+    try:
+        depth, err = child_depth_or_error()
+        assert depth == 1 and err is None
+    finally:
+        current_delegation_depth.reset(token)
+
+
+def test_child_depth_bounded():
+    token = current_delegation_depth.set(settings.agent_max_delegation_depth)
+    try:
+        depth, err = child_depth_or_error()
+        assert err is not None
+        assert str(settings.agent_max_delegation_depth) in err
+    finally:
+        current_delegation_depth.reset(token)
+
+
+def test_depth_limit_zero_disables_bound():
+    original = settings.agent_max_delegation_depth
+    token = current_delegation_depth.set(99)
+    try:
+        settings.agent_max_delegation_depth = 0
+        _, err = child_depth_or_error()
+        assert err is None
+    finally:
+        settings.agent_max_delegation_depth = original
+        current_delegation_depth.reset(token)
+
+
+def test_queue_topology():
+    # Two distinct queues, each with its own worker settings.
+    assert AgentWorkerSettings.queue_name == AGENT_QUEUE == "sinas:queue:agents"
+    assert (
+        SubAgentWorkerSettings.queue_name
+        == SUB_AGENT_QUEUE
+        == "sinas:queue:agents:sub"
+    )
+    assert SubAgentWorkerSettings.max_jobs == settings.queue_agent_sub_concurrency
+
+
+def test_all_agent_jobs_registered_on_both_workers():
+    # A delegated child (sub queue) can itself suspend and resume, so every
+    # agent job type must be runnable on both queues.
+    for job in (
+        execute_agent_message_job,
+        execute_agent_resume_job,
+        execute_agent_delegate_resume_job,
+    ):
+        assert job in AgentWorkerSettings.functions
+        assert job in SubAgentWorkerSettings.functions
+
+
+def test_delegate_mode_defaults_to_block():
+    # Suspend-on-delegate is opt-in; default behavior is unchanged.
+    assert settings.agent_delegate_mode == "block"
+    assert settings.agent_subagent_queue is True

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -58,6 +58,17 @@ services:
     environment:
       FUNCTION_CONTAINER_IMAGE: sinas-executor
 
+  queue-agent-sub:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    volumes:
+      - ./backend:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+      - file_storage:/var/sinas/files
+    environment:
+      FUNCTION_CONTAINER_IMAGE: sinas-executor
+
   scheduler:
     build:
       context: ./backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,6 +230,41 @@ services:
     deploy:
       replicas: ${QUEUE_AGENT_REPLICAS:-2}
 
+  # Dedicated worker for DELEGATED agent jobs (agent-to-agent calls). Keeps
+  # sub-agents on their own slot pool so parents waiting on children can't
+  # starve them (issue #90). Disable routing with AGENT_SUBAGENT_QUEUE=false.
+  queue-agent-sub:
+    image: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/backend:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - file_storage:/var/sinas/files
+    env_file:
+      - .env
+    environment:
+      DATABASE_USER: ${DATABASE_USER:-postgres}
+      DATABASE_HOST: pgbouncer
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: ${DATABASE_NAME:-sinas}
+      CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-clickhouse}
+      CLICKHOUSE_PORT: ${CLICKHOUSE_PORT:-8123}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+      CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-sinas}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set in .env file}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set in .env file}
+      DOCKER_NETWORK: ${DOCKER_NETWORK:-auto}
+      FUNCTION_CONTAINER_IMAGE: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/executor:${IMAGE_TAG:-latest}
+    depends_on:
+      redis:
+        condition: service_healthy
+      pgbouncer:
+        condition: service_healthy
+    command: python -m arq app.queue.worker.SubAgentWorkerSettings
+    deploy:
+      replicas: ${QUEUE_AGENT_SUB_REPLICAS:-2}
+
   scheduler:
     image: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/backend:${IMAGE_TAG:-latest}
     restart: unless-stopped

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -83,6 +83,10 @@ Required when `AUTH_MODE` is `otp` or `password+otp`. Skip entirely for `passwor
 | `MAX_TOOL_ITERATIONS` | `25` | Max consecutive tool-call rounds per message |
 | `MAX_HISTORY_MESSAGES` | `100` | Messages loaded for conversation context |
 | `AGENT_JOB_TIMEOUT` | `600` | Agent job timeout (seconds) |
+| `AGENT_DELEGATE_TIMEOUT` | `600` | How long a parent agent waits for a delegated sub-agent (block mode). Raise together with `AGENT_JOB_TIMEOUT` — in block mode the parent's own job clock keeps running while it waits |
+| `AGENT_DELEGATE_MODE` | `block` | `block`: parent holds its worker slot while awaiting sub-agents. `suspend`: parent job ends at delegation and a resume job continues the conversation when the children finish (frees the slot) |
+| `AGENT_MAX_DELEGATION_DEPTH` | `5` | Reject agent-to-agent delegation chains deeper than this (`0` disables the bound) |
+| `AGENT_SUBAGENT_QUEUE` | `true` | Route delegated (sub-agent) jobs to the dedicated `queue-agent-sub` worker so parents can never starve their children of worker slots |
 | `CODE_EXECUTION_TIMEOUT` | `120` | Code execution timeout (seconds) |
 
 ## Scaling
@@ -95,6 +99,8 @@ Required when `AUTH_MODE` is `otp` or `password+otp`. Skip entirely for `passwor
 | `QUEUE_AGENT_REPLICAS` | `2` | Agent queue worker replicas |
 | `QUEUE_FUNCTION_CONCURRENCY` | `10` | Concurrent functions per worker |
 | `QUEUE_AGENT_CONCURRENCY` | `5` | Concurrent agent jobs per worker |
+| `QUEUE_AGENT_SUB_REPLICAS` | `2` | Sub-agent queue worker replicas (delegated agent jobs) |
+| `QUEUE_AGENT_SUB_CONCURRENCY` | `5` | Concurrent jobs per sub-agent worker |
 | `DEFAULT_WORKER_COUNT` | `4` | Shared (trusted) worker containers for `shared_pool` functions. Also the default ceiling for `MAX_EXECUTION_DEPTH`. |
 
 ## Resource Limits (Docker)


### PR DESCRIPTION
## Summary

Fixes the parallel deep-research starvation described in #90: parent agents held their arq worker slot for up to 600s while blocked on sub-agent streams, children competed with new parents for the same 10 slots, and under contention everything died together at the timeout.

Three tiers, independently useful:

1. **`AGENT_DELEGATE_TIMEOUT`** — the parent's wait on a sub-agent stream was hardcoded to 600s in `tool_execution.py`; now a setting (raise together with `AGENT_JOB_TIMEOUT` in block mode).
2. **Dedicated sub-agent queue** (default on, `AGENT_SUBAGENT_QUEUE=false` to opt out) — agent-to-agent calls route to `sinas:queue:agents:sub`, consumed by a new `queue-agent-sub` worker (compose service included, `QUEUE_AGENT_SUB_REPLICAS`/`QUEUE_AGENT_SUB_CONCURRENCY`). Parents can no longer starve their own children of slots. Delegation depth rides on job kwargs (ContextVar-exposed) and chains are bounded by `AGENT_MAX_DELEGATION_DEPTH` (default 5).
3. **Suspend-on-delegate** (opt-in, `AGENT_DELEGATE_MODE=suspend`) — the structural fix: at delegation the parent job **ends**, freeing its slot. A `PendingDelegation` checkpoint (mirroring the existing `PendingToolApproval` pattern) persists the conversation context; children report results on completion (persisted as the parent's tool-result Message rows — the same rows the follow-up turn is rebuilt from), and the last child enqueues a delegate-resume job that re-enters the newly extracted `_stream_followup_after_tools` phase. Covers multi-child rounds, nested suspensions (a suspended child reporting to its own suspended parent), batch Execution rows, and failed children. In suspend mode a deep-research question occupies a slot only while an LLM turn is actually running.

## Also fixes: dev has two alembic heads

`0a1u2t3h4t5k` (connector-oauth) and `l1l2m3u4s5g6` (llm-usage) both revise `b1a2t3c4h5e6`, so `alembic upgrade head` on current dev fails with "Multiple head revisions". The `pending_delegations` migration doubles as the merge point.

## Testing

- `tests/unit/test_delegation.py` (6 tests): depth propagation/bounding, queue topology, job registration on both workers, block-by-default.
- Full unit suite: 48 passed (the 47 `test_permissions` errors are the pre-existing DB-fixture failures, also on dev).
- Compose (base + dev overlay) validates with the new service.
- Defaults preserve current behavior except child routing to the new queue; suspend mode is opt-in.

## Notes for review

- The resume job re-enters via `MessageService._stream_followup_after_tools` — a pure extraction of the second half of `_handle_tool_calls` (rebuild-from-DB → follow-up LLM turn → recursion); no behavior change on the inline path.
- Known limitation (documented in #90): if a child worker crashes so hard its failure path never runs, the parent stays suspended — a stale-`PendingDelegation` sweeper is future work.
- Helm chart support for `queue-agent-sub` should follow in the #69 chart once that branch merges.

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)