### PR TITLE
feat(providers): Anthropic prompt caching + cache token tracking

### DIFF
--- a/backend/alembic/versions/c1a2c3h4e5t6_llm_usage_cache_tokens.py
+++ b/backend/alembic/versions/c1a2c3h4e5t6_llm_usage_cache_tokens.py
@@ -1,0 +1,30 @@
+"""add prompt-cache token columns to llm_usage
+
+Revision ID: c1a2c3h4e5t6
+Revises: d1e2l3g4t5e6
+Create Date: 2026-07-17
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1a2c3h4e5t6"
+down_revision = "d1e2l3g4t5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llm_usage",
+        sa.Column("cache_read_tokens", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "llm_usage",
+        sa.Column("cache_write_tokens", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llm_usage", "cache_write_tokens")
+    op.drop_column("llm_usage", "cache_read_tokens")

--- a/backend/app/models/llm_usage.py
+++ b/backend/app/models/llm_usage.py
@@ -38,6 +38,9 @@ class LLMUsage(Base):
     prompt_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     completion_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     total_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Prompt-cache portions of prompt_tokens (0 for providers without caching)
+    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cache_write_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     latency_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     streamed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -10,9 +10,15 @@ from .base import BaseLLMProvider
 class AnthropicProvider(BaseLLMProvider):
     """Anthropic (Claude) API provider."""
 
-    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        enable_prompt_caching: bool = True,
+    ):
         super().__init__(api_key, base_url)
         self.client = AsyncAnthropic(api_key=api_key, base_url=base_url)
+        self.enable_prompt_caching = enable_prompt_caching
 
     async def complete(
         self,
@@ -40,6 +46,9 @@ class AnthropicProvider(BaseLLMProvider):
         if tools:
             # Convert OpenAI tool format to Anthropic format
             params["tools"] = self._convert_tools_to_anthropic(tools)
+
+        if self.enable_prompt_caching:
+            self._apply_cache_control(params)
 
         response = await self.client.messages.create(**params)
 
@@ -97,14 +106,19 @@ class AnthropicProvider(BaseLLMProvider):
         if tools:
             params["tools"] = self._convert_tools_to_anthropic(tools)
 
+        if self.enable_prompt_caching:
+            self._apply_cache_control(params)
+
         # Track tool calls being built across chunks
         current_tool_calls = {}
         current_content = ""
 
-        # Token usage arrives in message_start (input) and message_delta
-        # (cumulative output); emitted on the final chunk.
+        # Token usage arrives in message_start (input + cache counts) and
+        # message_delta (cumulative output); emitted on the final chunk.
         input_tokens = 0
         output_tokens = 0
+        cache_read_tokens = 0
+        cache_write_tokens = 0
 
         async with self.client.messages.stream(**params) as stream:
             async for event in stream:
@@ -119,6 +133,8 @@ class AnthropicProvider(BaseLLMProvider):
                     if usage:
                         input_tokens = getattr(usage, "input_tokens", 0) or 0
                         output_tokens = getattr(usage, "output_tokens", 0) or 0
+                        cache_read_tokens = getattr(usage, "cache_read_input_tokens", 0) or 0
+                        cache_write_tokens = getattr(usage, "cache_creation_input_tokens", 0) or 0
 
                 elif event.type == "content_block_start":
                     if event.content_block.type == "text":
@@ -181,13 +197,60 @@ class AnthropicProvider(BaseLLMProvider):
 
                 elif event.type == "message_stop":
                     chunk_data["finish_reason"] = chunk_data["finish_reason"] or "stop"
+                    # input_tokens excludes cache reads/writes; prompt_tokens
+                    # includes them (see extract_usage).
+                    prompt_tokens = input_tokens + cache_read_tokens + cache_write_tokens
                     chunk_data["usage"] = {
-                        "prompt_tokens": input_tokens,
+                        "prompt_tokens": prompt_tokens,
                         "completion_tokens": output_tokens,
-                        "total_tokens": input_tokens + output_tokens,
+                        "total_tokens": prompt_tokens + output_tokens,
+                        "cache_read_tokens": cache_read_tokens,
+                        "cache_write_tokens": cache_write_tokens,
                     }
 
                 yield chunk_data
+
+    def _apply_cache_control(self, params: dict[str, Any]) -> None:
+        """Mark prompt-cache breakpoints on the request (in place).
+
+        Anthropic caches the request prefix up to each ``cache_control``
+        marker (prefix order: tools, then system, then messages). Three
+        breakpoints (of max 4 allowed): the last tool and the system prompt
+        cover the static per-agent part; the last message gives a rolling
+        breakpoint so each call in a tool loop reuses the previous call's
+        cache. Prefixes shorter than the model's cacheable minimum are
+        silently not cached — the markers are harmless then.
+        """
+        cache_control = {"type": "ephemeral"}
+
+        tools = params.get("tools")
+        if tools:
+            tools[-1]["cache_control"] = cache_control
+
+        system = params.get("system")
+        if isinstance(system, str) and system:
+            params["system"] = [
+                {"type": "text", "text": system, "cache_control": cache_control}
+            ]
+
+        messages = params.get("messages")
+        if messages:
+            last = messages[-1]
+            content = last.get("content")
+            if isinstance(content, str):
+                if content:
+                    last["content"] = [
+                        {"type": "text", "text": content, "cache_control": cache_control}
+                    ]
+            elif isinstance(content, list) and content:
+                last_block = content[-1]
+                if isinstance(last_block, dict):
+                    # Copy instead of mutating: the block list may be shared
+                    # with the caller's message objects.
+                    last["content"] = [
+                        *content[:-1],
+                        {**last_block, "cache_control": cache_control},
+                    ]
 
     def _convert_messages_to_anthropic(
         self, messages: list[dict[str, Any]]
@@ -390,11 +453,29 @@ class AnthropicProvider(BaseLLMProvider):
         return tool_calls
 
     def extract_usage(self, response: Any) -> dict[str, int]:
-        """Extract token usage from Anthropic response."""
+        """Extract token usage from Anthropic response.
+
+        Anthropic's input_tokens EXCLUDES tokens read from or written to the
+        prompt cache; prompt_tokens here includes them (matching OpenAI
+        semantics), with the cache portions also reported separately.
+        """
         if hasattr(response, "usage") and response.usage:
+            usage = response.usage
+            cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+            cache_write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+            prompt_tokens = (usage.input_tokens or 0) + cache_read + cache_write
+            completion_tokens = usage.output_tokens or 0
             return {
-                "prompt_tokens": response.usage.input_tokens or 0,
-                "completion_tokens": response.usage.output_tokens or 0,
-                "total_tokens": (response.usage.input_tokens or 0) + (response.usage.output_tokens or 0),
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+                "cache_read_tokens": cache_read,
+                "cache_write_tokens": cache_write,
             }
-        return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        return {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }

--- a/backend/app/providers/factory.py
+++ b/backend/app/providers/factory.py
@@ -90,7 +90,12 @@ async def create_provider(
     elif provider_type == "mistral":
         provider = MistralProvider(api_key=api_key, base_url=base_url)
     elif provider_type == "anthropic":
-        provider = AnthropicProvider(api_key=api_key, base_url=base_url)
+        config = provider_config.config or {}
+        provider = AnthropicProvider(
+            api_key=api_key,
+            base_url=base_url,
+            enable_prompt_caching=config.get("prompt_caching", True),
+        )
     elif provider_type == "ollama":
         provider = OllamaProvider(base_url=base_url or "http://localhost:11434")
     else:

--- a/backend/app/providers/tracking.py
+++ b/backend/app/providers/tracking.py
@@ -67,6 +67,8 @@ class UsageTrackingProvider(BaseLLMProvider):
             "prompt_tokens": usage.get("prompt_tokens", 0) or 0,
             "completion_tokens": usage.get("completion_tokens", 0) or 0,
             "total_tokens": usage.get("total_tokens", 0) or 0,
+            "cache_read_tokens": usage.get("cache_read_tokens", 0) or 0,
+            "cache_write_tokens": usage.get("cache_write_tokens", 0) or 0,
             "latency_ms": latency_ms,
             "streamed": streamed,
             "error": error,

--- a/backend/tests/unit/test_anthropic_prompt_caching.py
+++ b/backend/tests/unit/test_anthropic_prompt_caching.py
@@ -1,0 +1,139 @@
+"""Unit tests for Anthropic prompt caching (cache_control breakpoints + usage).
+
+No network calls: these exercise the request-mutation hook
+(`_apply_cache_control`) and usage extraction directly.
+"""
+from types import SimpleNamespace
+
+from app.providers import AnthropicProvider
+
+EPHEMERAL = {"type": "ephemeral"}
+
+
+def _params(**overrides):
+    params = {
+        "model": "claude-sonnet-5",
+        "messages": [{"role": "user", "content": "hello"}],
+        "temperature": 0.7,
+        "max_tokens": 100,
+    }
+    params.update(overrides)
+    return params
+
+
+def _provider(**kwargs):
+    return AnthropicProvider(api_key="test-key", **kwargs)
+
+
+def test_caching_enabled_by_default():
+    assert _provider().enable_prompt_caching is True
+    assert _provider(enable_prompt_caching=False).enable_prompt_caching is False
+
+
+def test_marks_system_last_tool_and_last_message():
+    params = _params(
+        system="You are a helpful agent.",
+        tools=[
+            {"name": "search", "description": "", "input_schema": {}},
+            {"name": "fetch", "description": "", "input_schema": {}},
+        ],
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ],
+    )
+    _provider()._apply_cache_control(params)
+
+    # System becomes a block list with a breakpoint on it
+    assert params["system"] == [
+        {"type": "text", "text": "You are a helpful agent.", "cache_control": EPHEMERAL}
+    ]
+    # Only the LAST tool is marked
+    assert "cache_control" not in params["tools"][0]
+    assert params["tools"][1]["cache_control"] == EPHEMERAL
+    # Only the LAST message is marked, converted to block form
+    assert params["messages"][0]["content"] == "first"
+    assert params["messages"][2]["content"] == [
+        {"type": "text", "text": "second", "cache_control": EPHEMERAL}
+    ]
+
+
+def test_marks_last_block_of_list_content_without_mutating_input():
+    original_blocks = [
+        {"type": "tool_result", "tool_use_id": "tc_1", "content": "result one"},
+        {"type": "tool_result", "tool_use_id": "tc_2", "content": "result two"},
+    ]
+    params = _params(messages=[{"role": "user", "content": original_blocks}])
+    _provider()._apply_cache_control(params)
+
+    marked = params["messages"][0]["content"]
+    assert "cache_control" not in marked[0]
+    assert marked[1]["cache_control"] == EPHEMERAL
+    # The caller's block objects must not be mutated (they may be reused
+    # across requests; stale markers would accumulate breakpoints).
+    assert "cache_control" not in original_blocks[1]
+
+
+def test_no_tools_no_system_still_marks_last_message():
+    params = _params()
+    _provider()._apply_cache_control(params)
+    assert params["messages"][0]["content"] == [
+        {"type": "text", "text": "hello", "cache_control": EPHEMERAL}
+    ]
+    assert "tools" not in params
+    assert "system" not in params
+
+
+def test_empty_content_left_untouched():
+    params = _params(messages=[{"role": "user", "content": ""}])
+    _provider()._apply_cache_control(params)
+    assert params["messages"][0]["content"] == ""
+
+
+def test_at_most_three_breakpoints():
+    params = _params(
+        system="sys",
+        tools=[{"name": "t", "description": "", "input_schema": {}}],
+        messages=[
+            {"role": "user", "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]},
+        ],
+    )
+    _provider()._apply_cache_control(params)
+
+    marker_count = 0
+    for tool in params["tools"]:
+        marker_count += "cache_control" in tool
+    for block in params["system"]:
+        marker_count += "cache_control" in block
+    for msg in params["messages"]:
+        for block in msg["content"]:
+            marker_count += "cache_control" in block
+    assert marker_count == 3  # Anthropic allows max 4
+
+
+def test_extract_usage_includes_cache_tokens():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_input_tokens=9000,
+            cache_creation_input_tokens=400,
+        )
+    )
+    usage = _provider().extract_usage(response)
+    # prompt_tokens includes cached portions (input_tokens excludes them)
+    assert usage["prompt_tokens"] == 9500
+    assert usage["completion_tokens"] == 50
+    assert usage["total_tokens"] == 9550
+    assert usage["cache_read_tokens"] == 9000
+    assert usage["cache_write_tokens"] == 400
+
+
+def test_extract_usage_without_cache_fields():
+    response = SimpleNamespace(usage=SimpleNamespace(input_tokens=100, output_tokens=50))
+    usage = _provider().extract_usage(response)
+    assert usage["prompt_tokens"] == 100
+    assert usage["total_tokens"] == 150
+    assert usage["cache_read_tokens"] == 0
+    assert usage["cache_write_tokens"] == 0

--- a/backend/tests/unit/test_llm_usage_tracking.py
+++ b/backend/tests/unit/test_llm_usage_tracking.py
@@ -277,6 +277,12 @@ async def test_anthropic_stream_emits_usage_on_message_stop():
     out = [c async for c in provider.stream(messages=[{"role": "user", "content": "x"}], model="m")]
 
     final = out[-1]
-    assert final["usage"] == {"prompt_tokens": 12, "completion_tokens": 9, "total_tokens": 21}
+    assert final["usage"] == {
+        "prompt_tokens": 12,
+        "completion_tokens": 9,
+        "total_tokens": 21,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
     # stop_reason from message_delta still surfaces
     assert any(c["finish_reason"] == "end_turn" for c in out)


### PR DESCRIPTION
## Summary
- Mark `cache_control: {"type": "ephemeral"}` breakpoints on Anthropic requests (last tool definition, system prompt, last message) so every follow-up call in a tool loop reuses the previous call's cached prefix instead of re-paying full input price for the whole history. Deep-research turns with ~38 model calls should see input costs drop 75-85%.
- Enabled by default for `anthropic` providers; per-provider opt-out via config `{"prompt_caching": false}`.
- Usage dicts now report `cache_read_tokens` / `cache_write_tokens`, persisted as new columns on `llm_usage` (migration `c1a2c3h4e5t6`). `prompt_tokens` now *includes* cached tokens (Anthropic's raw `input_tokens` excludes them), matching OpenAI semantics so cross-provider totals stay comparable.

## Notes
- Cache hit rate per chat: `sum(cache_read_tokens)::float / sum(prompt_tokens)` on `llm_usage`.
- Single-shot calls pay the 1.25x cache-write premium without reuse benefit — negligible, and the opt-out covers it.
- Prefixes under the model's cacheable minimum (1024 tokens) are silently not cached; markers are harmless.

## Test plan
- [x] 8 new unit tests (breakpoint placement, opt-out, caller-object no-mutation, breakpoint count, usage extraction)
- [x] Existing provider/tracking tests pass; alembic resolves to a single head
- [ ] Live verification on local dev stack (next step after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)