### PR TITLE
feat(context): expose user context to agents, functions, and queries

### DIFF
--- a/backend/app/api/runtime/endpoints/components.py
+++ b/backend/app/api/runtime/endpoints/components.py
@@ -20,13 +20,13 @@ from app.models.component import Component
 from app.models.component_share import ComponentShare
 from app.models.function import Function
 from app.models.query import Query
-from app.models.user import User
 from app.models.execution import TriggerType
 from app.schemas.component import ProxyExecuteRequest, StateProxyRequest
 from app.models.state import State
 from app.services.content_tokens import generate_component_render_token
 from app.services.database_pool import DatabasePoolManager
 from app.services.queue_service import queue_service
+from app.services.user_context import load_user_context, query_param_context
 
 router = APIRouter()
 
@@ -376,12 +376,8 @@ async def proxy_query_execute(
             raise HTTPException(status_code=400, detail=f"Input validation error: {e.message}")
 
     params = {**body.input}
-    params["user_id"] = str(user_id)
-
-    user_result = await db.execute(select(User).where(User.id == user_id))
-    user = user_result.scalar_one_or_none()
-    if user:
-        params["user_email"] = user.email
+    user_ctx = await load_user_context(db, user_id)
+    params.update(query_param_context(user_ctx))
 
     start_time = time.time()
     pool_manager = DatabasePoolManager.get_instance()

--- a/backend/app/api/runtime/endpoints/queries.py
+++ b/backend/app/api/runtime/endpoints/queries.py
@@ -3,16 +3,15 @@ import time
 
 import jsonschema
 from fastapi import APIRouter, Depends, HTTPException, Request
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
 from app.core.permissions import check_permission
 from app.models.query import Query
-from app.models.user import User
 from app.schemas.query import QueryExecuteRequest, QueryExecuteResponse
 from app.services.database_pool import DatabasePoolManager
+from app.services.user_context import load_user_context, query_param_context
 
 router = APIRouter()
 
@@ -50,14 +49,10 @@ async def execute_query(
         except jsonschema.ValidationError as e:
             raise HTTPException(status_code=400, detail=f"Input validation error: {e.message}")
 
-    # Merge context variables
+    # Merge context variables (user_id, user_email, user_custom_<field>)
     params = {**execute_request.input}
-    params["user_id"] = str(user_id)
-
-    user_result = await db.execute(select(User).where(User.id == user_id))
-    user = user_result.scalar_one_or_none()
-    if user:
-        params["user_email"] = user.email
+    user_ctx = await load_user_context(db, user_id)
+    params.update(query_param_context(user_ctx))
 
     start_time = time.time()
     try:

--- a/backend/app/services/container_pool.py
+++ b/backend/app/services/container_pool.py
@@ -376,6 +376,7 @@ class ContainerPool:
         chat_id: Optional[str],
         db: AsyncSession,
         timeout: Optional[int] = None,
+        user_custom_fields: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """
         Execute a function in a pooled container.
@@ -427,6 +428,7 @@ class ContainerPool:
                 "context": {
                     "user_id": user_id,
                     "user_email": user_email,
+                    "user_custom_fields": user_custom_fields or {},
                     "access_token": access_token,
                     "execution_id": execution_id,
                     "trigger_type": trigger_type,

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -154,6 +154,7 @@ class FunctionExecutor:
         chat_id: Optional[str],
         db: AsyncSession,
         timeout: Optional[int] = None,
+        user_custom_fields: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """
         Execute function in shared worker pool (separate worker containers).
@@ -165,6 +166,7 @@ class FunctionExecutor:
         exec_result = await self.worker_manager.execute_function(
             user_id=user_id,
             user_email=user_email,
+            user_custom_fields=user_custom_fields,
             access_token=access_token,
             function_namespace=function.namespace,
             function_name=function.name,
@@ -240,6 +242,7 @@ class FunctionExecutor:
             user_result = await db.execute(select(User).where(User.id == user_id))
             user = user_result.scalar_one_or_none()
             user_email = user.email if user else "unknown@unknown.com"
+            user_custom_fields = (user.custom_fields or {}) if user else {}
 
             # Load function early so we can size the access-token TTL to its
             # configured timeout. (load_function is cached, so this is cheap.)
@@ -320,6 +323,7 @@ class FunctionExecutor:
                                 execution_id=execution_id,
                                 user_id=user_id,
                                 user_email=user_email,
+                                user_custom_fields=user_custom_fields,
                                 access_token=access_token,
                                 trigger_type=trigger_type,
                                 chat_id=chat_id,
@@ -339,6 +343,7 @@ class FunctionExecutor:
                     exec_result = await self.container_pool.execute_function(
                         user_id=user_id,
                         user_email=user_email,
+                        user_custom_fields=user_custom_fields,
                         access_token=access_token,
                         function_namespace=function_namespace,
                         function_name=function_name,

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -31,6 +31,7 @@ from app.services.query_tools import QueryToolConverter
 from app.services.skill_tools import SkillToolConverter
 from app.services.state_tools import StateTools
 from app.services.template_renderer import render_template
+from app.services.user_context import load_user_context, merge_user_template_context
 from app.services.tool_discovery import (
     get_available_tools,
     strip_tool_metadata,
@@ -266,6 +267,13 @@ class MessageService:
         final_template_variables = template_variables
         if final_template_variables is None and chat.chat_metadata:
             final_template_variables = chat.chat_metadata.get("agent_input")
+
+        # Always expose the platform-provided user context as {{user.*}}
+        # (overrides any caller-supplied "user" variable — not spoofable)
+        user_ctx = await load_user_context(self.db, user_id)
+        final_template_variables = merge_user_template_context(
+            final_template_variables, user_ctx
+        )
 
         # Build conversation history
         messages = await build_conversation_history(

--- a/backend/app/services/query_tools.py
+++ b/backend/app/services/query_tools.py
@@ -10,6 +10,7 @@ from app.core.permissions import check_permission
 from app.models.query import Query
 from app.services.database_pool import DatabasePoolManager
 from app.services.template_renderer import render_function_parameters
+from app.services.user_context import load_user_context, query_param_context
 
 logger = logging.getLogger(__name__)
 
@@ -223,10 +224,11 @@ class QueryToolConverter:
         if locked_params:
             final_input.update(locked_params)
 
-        # Inject context variables
-        final_input["user_id"] = str(user_id)
-        if user_email:
-            final_input["user_email"] = user_email
+        # Inject context variables (user_id, user_email, user_custom_<field>)
+        user_ctx = await load_user_context(db, user_id)
+        if user_email and not user_ctx.get("email"):
+            user_ctx["email"] = user_email
+        final_input.update(query_param_context(user_ctx))
 
         start_time = time.time()
         try:

--- a/backend/app/services/shared_worker_manager.py
+++ b/backend/app/services/shared_worker_manager.py
@@ -667,6 +667,7 @@ class SharedWorkerManager:
         chat_id: Optional[str],
         db: AsyncSession,
         timeout: Optional[int] = None,
+        user_custom_fields: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """
         Execute function in a worker container using round-robin load balancing.
@@ -736,6 +737,7 @@ class SharedWorkerManager:
                 "context": {
                     "user_id": user_id,
                     "user_email": user_email,
+                    "user_custom_fields": user_custom_fields or {},
                     "access_token": access_token,
                     "execution_id": execution_id,
                     "trigger_type": trigger_type,

--- a/backend/app/services/tool_discovery.py
+++ b/backend/app/services/tool_discovery.py
@@ -18,6 +18,7 @@ from app.services.function_tools import FunctionToolConverter
 from app.services.query_tools import QueryToolConverter
 from app.services.skill_tools import SkillToolConverter
 from app.services.state_tools import StateTools
+from app.services.user_context import load_user_context, merge_user_template_context
 
 logger = logging.getLogger(__name__)
 
@@ -222,6 +223,12 @@ async def get_available_tools(
     agent_input_context = {}
     if chat.chat_metadata and "agent_input" in chat.chat_metadata:
         agent_input_context = chat.chat_metadata["agent_input"]
+
+    # Expose the platform-provided user context as {{user.*}} in locked and
+    # overridable tool parameters (overrides any "user" key from agent input —
+    # not spoofable)
+    user_ctx = await load_user_context(db, user_id)
+    agent_input_context = merge_user_template_context(agent_input_context, user_ctx)
 
     # Get function tools (only if list has items - opt-in)
     if agent.enabled_functions and len(agent.enabled_functions) > 0:

--- a/backend/app/services/user_context.py
+++ b/backend/app/services/user_context.py
@@ -1,0 +1,68 @@
+"""
+Per-user context exposed to agents, functions, and queries.
+
+The same user context dict is injected as:
+- the ``user`` template variable in agent system prompts and locked/overridable
+  tool parameters ({{user.email}}, {{user.custom_fields.department}})
+- the ``user_custom_fields`` entry in function execution context
+- ``user_custom_<key>`` bind parameters in query execution
+
+It is platform-provided data and always overrides caller-supplied template
+variables of the same name, so locked parameters like
+``{{user.custom_fields.region}}`` cannot be spoofed via agent input.
+"""
+import re
+import uuid
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+# Bind parameter names must be valid SQL identifiers (see
+# DatabasePoolManager._convert_params); skip custom field keys that aren't.
+_SQL_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+async def load_user_context(db: AsyncSession, user_id: str) -> dict[str, Any]:
+    """Load the user context dict: {"id", "email", "custom_fields"}."""
+    result = await db.execute(select(User).where(User.id == uuid.UUID(str(user_id))))
+    user = result.scalar_one_or_none()
+    if not user:
+        return {"id": str(user_id), "email": None, "custom_fields": {}}
+    return {
+        "id": str(user.id),
+        "email": user.email,
+        "custom_fields": user.custom_fields or {},
+    }
+
+
+def query_param_context(user_context: dict[str, Any]) -> dict[str, Any]:
+    """
+    Flatten a user context into SQL bind parameters:
+    user_id, user_email, and user_custom_<key> for scalar custom fields.
+    """
+    params: dict[str, Any] = {"user_id": user_context["id"]}
+    if user_context.get("email"):
+        params["user_email"] = user_context["email"]
+
+    for key, value in (user_context.get("custom_fields") or {}).items():
+        if not _SQL_IDENTIFIER.match(key):
+            continue
+        if value is None or isinstance(value, (str, int, float, bool)):
+            params[f"user_custom_{key}"] = value
+
+    return params
+
+
+def merge_user_template_context(
+    template_variables: Optional[dict[str, Any]], user_context: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge the user context into template variables under the ``user`` key.
+
+    The platform-provided user context wins over any caller-supplied ``user``
+    value — template variables come from chat metadata (agent input), which the
+    end user controls, and locked parameters must not be spoofable.
+    """
+    return {**(template_variables or {}), "user": user_context}

--- a/docs-mint/build-resources/agents.mdx
+++ b/docs-mint/build-resources/agents.mdx
@@ -157,3 +157,16 @@ curl -X POST https://yourdomain.com/agents/default/default/chats \
   }
 }
 ```
+
+**User context in templates** — the calling user is always available as the `user` variable in system prompts and in function/query/connector parameter templates:
+
+```jinja
+You are assisting {{user.email}} from the {{user.custom_fields.department}} department.
+Answer in the user's language: {{user.custom_fields.locale}}.
+```
+
+- `user.id` — user UUID
+- `user.email` — user email
+- `user.custom_fields` — the user's [custom fields](/admin/users-roles#custom-fields)
+
+The `user` variable is platform-provided and overrides any same-named agent input variable, so locked parameters like `{{user.custom_fields.region}}` cannot be spoofed by the caller.

--- a/docs-mint/build-resources/functions.mdx
+++ b/docs-mint/build-resources/functions.mdx
@@ -31,6 +31,7 @@ def handler(input_data, context):
     # {
     #     "user_id":        str,   # ID of the user who triggered execution
     #     "user_email":     str,   # Email of the triggering user
+    #     "user_custom_fields": dict,  # The user's custom fields (org-specific profile data)
     #     "access_token":   str,   # Short-lived JWT for calling the Sinas API
     #     "execution_id":   str,   # Unique execution ID
     #     "trigger_type":   str,   # "AGENT" | "API" | "WEBHOOK" | "SCHEDULE" | "CDC" | "HOOK" | "MANUAL"

--- a/docs-mint/build-resources/queries.mdx
+++ b/docs-mint/build-resources/queries.mdx
@@ -41,6 +41,7 @@ Locked parameters prevent the LLM from seeing or modifying security-sensitive va
 |---|---|
 | `:user_id` | UUID of the user who triggered the query |
 | `:user_email` | Email of the triggering user |
+| `:user_custom_<field>` | Each scalar entry in the user's [custom fields](/admin/users-roles#custom-fields) (e.g. `:user_custom_region` for `custom_fields.region`) |
 
 These are always available regardless of the query's `input_schema`. Use them for row-level security:
 
@@ -50,7 +51,12 @@ SELECT * FROM orders WHERE created_by = :user_id
 
 -- Audit trail
 INSERT INTO audit_log (action, performed_by) VALUES (:action, :user_email)
+
+-- Per-user scoping on an org-specific attribute
+SELECT * FROM accounts WHERE region = :user_custom_region
 ```
+
+Only scalar custom fields (string, number, boolean) whose names are valid SQL identifiers are exposed; nested objects and lists are skipped.
 
 **Endpoints:**
 

--- a/tests/integration/suites/user_context.py
+++ b/tests/integration/suites/user_context.py
@@ -1,0 +1,131 @@
+"""User context injection tests (custom fields in query bind parameters).
+
+The query tests need a reachable postgres to register as a database
+connection. Set SINAS_TEST_QUERY_DB_URL (postgresql://user:pass@host:port/db)
+to enable them; without it only the custom-fields setup test runs.
+"""
+
+import os
+import uuid
+from urllib.parse import urlparse
+
+_SUFFIX = uuid.uuid4().hex[:8]
+_NS = "test_user_ctx"
+_QUERY_NAME = f"ctx_probe_{_SUFFIX}"
+_DB_URL = os.environ.get("SINAS_TEST_QUERY_DB_URL")
+
+_admin_user_id = None
+_previous_custom_fields = None
+_connection_id = None
+_query_created = False
+
+
+def teardown(ctx):
+    if _query_created:
+        try:
+            ctx.client.delete(
+                f"/api/v1/queries/{_NS}/{_QUERY_NAME}", headers=ctx.admin_headers()
+            )
+        except Exception:
+            pass
+    if _connection_id:
+        try:
+            ctx.client.delete(
+                f"/api/v1/database-connections/{_connection_id}",
+                headers=ctx.admin_headers(),
+            )
+        except Exception:
+            pass
+    if _admin_user_id is not None:
+        try:
+            ctx.client.patch(
+                f"/api/v1/users/{_admin_user_id}",
+                headers=ctx.admin_headers(),
+                json={"custom_fields": _previous_custom_fields or {}},
+            )
+        except Exception:
+            pass
+
+
+def test_01_set_admin_custom_fields(ctx):
+    global _admin_user_id, _previous_custom_fields
+    r = ctx.client.get("/auth/me", headers=ctx.admin_headers())
+    assert r.status_code == 200, r.text
+    _admin_user_id = r.json()["id"]
+
+    r = ctx.client.get(f"/api/v1/users/{_admin_user_id}", headers=ctx.admin_headers())
+    assert r.status_code == 200, r.text
+    _previous_custom_fields = r.json().get("custom_fields")
+
+    r = ctx.client.patch(
+        f"/api/v1/users/{_admin_user_id}",
+        headers=ctx.admin_headers(),
+        json={
+            "custom_fields": {
+                "region": "eu-west",
+                "tier": 3,
+                "nested": {"skipped": True},
+                "bad-key!": "skipped",
+            }
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_02_create_database_connection(ctx):
+    global _connection_id
+    if not _DB_URL:
+        return  # SINAS_TEST_QUERY_DB_URL not set
+    parsed = urlparse(_DB_URL)
+    r = ctx.client.post(
+        "/api/v1/database-connections",
+        headers=ctx.admin_headers(),
+        json={
+            "name": f"test-user-ctx-{_SUFFIX}",
+            "connection_type": "postgresql",
+            "host": parsed.hostname,
+            "port": parsed.port or 5432,
+            "database": parsed.path.lstrip("/"),
+            "username": parsed.username,
+            "password": parsed.password,
+        },
+    )
+    assert r.status_code in (200, 201), f"Create connection failed: {r.text}"
+    _connection_id = r.json()["id"]
+
+
+def test_03_query_receives_user_custom_params(ctx):
+    global _query_created
+    if not _connection_id:
+        return  # depends on test_02
+    r = ctx.client.post(
+        "/api/v1/queries",
+        headers=ctx.admin_headers(),
+        json={
+            "namespace": _NS,
+            "name": _QUERY_NAME,
+            "description": "User context probe",
+            "database_connection_id": _connection_id,
+            "operation": "read",
+            "sql": (
+                "SELECT CAST(:user_custom_region AS TEXT) AS region, "
+                "CAST(:user_custom_tier AS INT) AS tier, "
+                "CAST(:user_email AS TEXT) AS email"
+            ),
+        },
+    )
+    assert r.status_code in (200, 201), f"Create query failed: {r.text}"
+    _query_created = True
+
+    r = ctx.client.post(
+        f"/queries/{_NS}/{_QUERY_NAME}/execute",
+        headers=ctx.admin_headers(),
+        json={"input": {}},
+    )
+    assert r.status_code == 200, f"Execute failed: {r.text}"
+    rows = r.json()["data"]
+    assert len(rows) == 1, rows
+    row = rows[0]
+    assert row["region"] == "eu-west", row
+    assert row["tier"] == 3, row
+    assert "@" in row["email"], row


### PR DESCRIPTION
Part 3 of #89 — stacked on #92 (base is `feat/user-identities-89`; retarget to `dev` after #92 merges). Independent of #93.

## What

One user context dict (`{id, email, custom_fields}`) from the new `user_context` service, injected everywhere resource execution happens:

- **Agents** — `{{user.*}}` is always available in system prompts and in locked/overridable function/query parameter templates: `{{user.email}}`, `{{user.custom_fields.department}}`. The platform value overrides any same-named agent-input variable, so a locked param like `{{user.custom_fields.region}}` cannot be spoofed by the caller.
- **Functions** — execution `context` gains `user_custom_fields` (both shared-pool and sandbox container paths; the executor passes context through verbatim, so no executor image change needed).
- **Queries** — every scalar custom field becomes a `:user_custom_<field>` bind parameter (e.g. `WHERE region = :user_custom_region`), in all three paths: runtime execute endpoint, agent query tools, and the component proxy — which previously had three hand-rolled copies of the `user_id`/`user_email` injection, now unified.

Non-identifier keys, nested objects, and lists are skipped for SQL binds; missing fields bind NULL (consistent with existing param semantics).

## Behavior note

System prompts are now always rendered through Jinja (previously only when agent input was present), because `user` is always in scope. Render failures keep their existing graceful fallback to the raw prompt.

## Verification

Against a locally booted backend (fresh postgres + full migrations): new `user_context` suite 3/3 — end-to-end proof that a query returned `region='eu-west', tier=3, email=<caller>` purely from the calling user's custom fields (the suite needs `SINAS_TEST_QUERY_DB_URL` to register a live postgres as a database connection; without it the query tests no-op). Template override/merge semantics unit-verified. Regression suites `users_identities` 9/9, `roles_permissions` 9/9, `config_apply` 5/5, `api_keys` 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)