### PR TITLE
ci: build images for versions, RCs, dev, and any branch on demand

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,14 +1,39 @@
 name: Build & Push Docker Images
 
+# Builds the four Sinas images (backend, builder, executor, console) and pushes them to
+# GHCR. See RELEASING.md for the full versioning/release flow.
+#
+# Triggers & resulting image tags:
+#   push to dev            -> :dev            (+ :sha-…)      integration builds
+#   push to main           -> :edge           (+ :sha-…)
+#   tag 0.3.0-rc.1         -> :0.3.0-rc.1                     release candidate (prerelease)
+#   tag 0.3.0              -> :0.3.0 :0.3 :latest             final release
+#   manual dispatch        -> :<image_tag or sanitized ref>  build ANY branch/SHA on demand
+#
+# Only a final (non-prerelease) semver tag moves :latest (metadata-action latest=auto).
 on:
   push:
-    branches: [main]
-    tags: ['v*']
+    branches: [main, dev]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'          # 0.3.0        (final)
+      - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+' # 0.3.0-rc.1   (release candidate)
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to build (e.g. a feature branch)
+        required: true
+        default: dev
+      image_tag:
+        description: 'Tag for the built images (optional; default: sanitized ref name)'
+        required: false
 
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository }}
+  # Multi-arch so images run on amd64 cloud nodes AND arm64 (Apple Silicon, arm nodes).
+  # arm64 builds via QEMU emulation add build time; see RELEASING.md for the native-runner
+  # optimization if CI feels slow.
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build:
@@ -35,6 +60,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # On workflow_dispatch, build the requested ref; otherwise the triggering ref.
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Resolve dispatch image tag
+        if: github.event_name == 'workflow_dispatch'
+        id: disp
+        run: |
+          TAG="${{ github.event.inputs.image_tag }}"
+          [ -z "$TAG" ] && TAG="${{ github.event.inputs.ref }}"
+          # Sanitize to a valid, readable image tag.
+          TAG=$(printf '%s' "$TAG" | sed 's#[^a-zA-Z0-9._-]#-#g' | cut -c1-120)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,13 +92,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}
+          # metadata-action skips {{major}}.{{minor}} and :latest for prereleases, so a
+          # -rc tag only ever produces its own exact tag.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=edge,enable={{is_default_branch}}
-            type=sha,prefix=
-          # latest=auto (default): applied only to non-prerelease semver tags,
-          # so v0.1.0 updates `latest` but v0.2.0-rc.1 does not.
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=sha,prefix=,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value=${{ steps.disp.outputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -67,6 +110,32 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          # Per-image cache scope so the four images don't clobber each other's cache.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          platforms: ${{ env.PLATFORMS }}
+
+  # On a version tag, publish a GitHub Release with a ready-to-run, version-pinned
+  # docker-compose.yml attached. Prerelease flag is set automatically for -rc tags.
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate version-pinned docker-compose
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          # Pin the image tag to this release; the registry default already points at GHCR,
+          # so the file runs as-is (users still supply their own .env for secrets/config).
+          sed "s/\${IMAGE_TAG:-latest}/${VERSION}/g" docker-compose.yml > "docker-compose-${VERSION}.yml"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: docker-compose-${{ github.ref_name }}.yml
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,97 @@
+# Releasing Sinas
+
+Container images for every version, release candidate, and (on demand) any feature branch
+are built and pushed to GHCR by [`.github/workflows/build-images.yml`](.github/workflows/build-images.yml).
+
+Images: `ghcr.io/sinas-platform/sinas/{backend,builder,executor,console}`.
+
+## Versioning
+
+- **Final releases:** `0.3.0` (plain semver, no `v` prefix).
+- **Release candidates:** `0.3.0-rc.1`, `0.3.0-rc.2`, …
+- The version literal lives in **one place**: `backend/app/_version.py`. Bump it there and
+  nowhere else.
+
+## What gets built, and the tags produced
+
+| Trigger | Image tags | Moves `:latest`? |
+| --- | --- | --- |
+| push to `dev` | `:dev`, `:sha-<sha>` | no |
+| push to `main` | `:edge`, `:sha-<sha>` | no |
+| tag `0.3.0-rc.1` | `:0.3.0-rc.1` | no (prerelease) |
+| tag `0.3.0` | `:0.3.0`, `:0.3`, `:latest` | **yes** |
+| manual dispatch | `:<image_tag>` (or sanitized ref name) | no |
+
+Only a **final** semver tag updates `:latest` — release candidates never do.
+
+## Cutting a release (with RCs)
+
+```bash
+# 1. Freeze: branch off dev once all the release's features have landed there.
+git checkout dev && git pull
+git checkout -b release/0.3.0
+
+# 2. Bump the version (single source of truth).
+#    edit backend/app/_version.py -> __version__ = "0.3.0"
+git commit -am "chore(release): 0.3.0"
+git push -u origin release/0.3.0
+
+# 3. Publish a release candidate. This builds :0.3.0-rc.1 images and a
+#    PRE-release on GitHub with a pinned docker-compose attached.
+git tag 0.3.0-rc.1 && git push origin 0.3.0-rc.1
+#    -> testers run:  IMAGE_TAG=0.3.0-rc.1 docker compose up -d
+#    Fixes land on release/0.3.0; tag 0.3.0-rc.2, etc., until green.
+
+# 4. Ship. Merge the release branch to main and tag the final version.
+#    (open a PR release/0.3.0 -> main, merge, then:)
+git checkout main && git pull
+git tag 0.3.0 && git push origin 0.3.0
+#    -> builds :0.3.0 :0.3 :latest and a GitHub Release with pinned compose.
+
+# 5. Back-merge so main's release commit(s) return to dev.
+git checkout dev && git merge main && git push
+```
+
+## Running a specific version
+
+Every release attaches a **version-pinned `docker-compose-<version>.yml`** to its GitHub
+Release — download it and:
+
+```bash
+docker compose -f docker-compose-0.3.0.yml up -d   # provide your own .env
+```
+
+Or, from a repo checkout, pin via the env var the compose file already honors:
+
+```bash
+IMAGE_TAG=0.3.0 docker compose up -d          # or 0.3.0-rc.1, dev, edge, …
+```
+
+## Building a feature branch on demand (no merge needed)
+
+To test a branch's images before merging (e.g. the k8s work):
+
+1. **Actions → Build & Push Docker Images → Run workflow**
+2. **ref:** the branch/tag/SHA (e.g. `69-helm-chart-for-deploying-sinas-on-k8s`)
+3. **image_tag:** an optional short name (e.g. `k8s-test`); omit to use a sanitized ref name
+
+Then consume the images:
+
+```bash
+IMAGE_TAG=k8s-test docker compose up -d            # docker-compose
+helm upgrade --install sinas charts/sinas \
+  --set image.tag=k8s-test --set executor.image=ghcr.io/sinas-platform/sinas/executor:k8s-test
+```
+
+Dispatching with an explicit **ref** input runs the current workflow from `dev`/`main` while
+building the target ref, so you can build a branch even if its own copy of the workflow is
+out of date.
+
+## Notes
+
+- **Multi-arch:** images are built for `linux/amd64` + `linux/arm64`. The arm64 build uses
+  QEMU emulation, which adds wall-clock time. If CI gets slow, switch arm64 to a native
+  `ubuntu-24.04-arm` runner and merge manifests (matrix over platform), or restrict
+  multi-arch to release tags only.
+- Merges to `dev`/`main` may require `--admin` to bypass the branch ruleset; that shows as
+  `mergeStateStatus: BLOCKED`, not a real conflict.


### PR DESCRIPTION
## Why

The image build (`build-images.yml`) only triggered on `v*` tags, but releases are tagged **without** the `v` prefix (`0.2.0`, `0.1.1`). So no tag push ever matched and **per-version container images were never built** — only `main` pushes (`edge`) and manual runs produced anything.

## What this does

Reworks `.github/workflows/build-images.yml`:

- **Triggers on the real tag scheme:** `X.Y.Z` (final) and `X.Y.Z-rc.N` (release candidate), plus `dev` pushes (`:dev` integration images) and `main` (`:edge`).
- **On-demand feature-branch builds** via `workflow_dispatch` with `ref` + `image_tag` inputs — build *any* branch/SHA (e.g. the k8s branch) without merging. Tagged with a custom or sanitized-ref name; never moves `:latest`.
- **Multi-arch** `linux/amd64` + `linux/arm64` (QEMU).
- **Per-image GHA cache scope** so the four images don't clobber each other's cache.
- **Release automation:** a version tag publishes a GitHub Release (prerelease auto-set for `-rc`) with a **version-pinned `docker-compose-<version>.yml`** attached — one-file `docker compose up` per release.

Adds `RELEASING.md` (versioning, the RC release flow, running a pinned version, on-demand feature builds).

### Resulting tag matrix

| Trigger | Tags | Moves `:latest`? |
|---|---|---|
| push `dev` | `:dev`, `:sha-…` | no |
| push `main` | `:edge`, `:sha-…` | no |
| tag `0.3.0-rc.1` | `:0.3.0-rc.1` | no |
| tag `0.3.0` | `:0.3.0` `:0.3` `:latest` | yes |
| manual dispatch | `:<image_tag or ref>` | no |

## Notes / choices

- **Multi-arch on every `dev` push** is enabled per request. arm64-via-QEMU adds build time; if CI feels slow, the one-line knob is to restrict `platforms` to tags only, or move arm64 to a native `ubuntu-24.04-arm` runner (noted in RELEASING.md).
- No app code touched. Verified: YAML parses; the compose-pinning `sed` produces correct GHCR image refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)