### PR TITLE
fix(auth): real user soft-delete, token revocation on delete, and login anti-enumeration

### DIFF
--- a/backend/alembic/versions/u1s2r3a4c5t6_add_is_active_to_users.py
+++ b/backend/alembic/versions/u1s2r3a4c5t6_add_is_active_to_users.py
@@ -1,0 +1,28 @@
+"""add is_active column to users
+
+Revision ID: u1s2r3a4c5t6
+Revises: b1a2t3c4h5e6
+Create Date: 2026-07-16
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "u1s2r3a4c5t6"
+down_revision = "b1a2t3c4h5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+    )
+    op.create_index("ix_users_is_active", "users", ["is_active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_is_active", table_name="users")
+    op.drop_column("users", "is_active")

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -1,5 +1,7 @@
 """Authentication endpoints."""
 
+import uuid
+
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -44,6 +46,11 @@ from app.schemas.auth import (
 )
 
 
+# Verified in place of a real hash for unknown accounts so login timing does
+# not reveal whether an email exists.
+_DUMMY_PASSWORD_HASH = hash_password("enumeration-resistant-dummy")
+
+
 async def _issue_tokens(db: AsyncSession, user: User) -> tuple[str, str, AuthUserResponse]:
     """Mint an access + refresh token pair and build the user response."""
     access_token = create_access_token(user_id=str(user.id), email=user.email)
@@ -72,7 +79,8 @@ async def login(request: LoginRequest, http_request: Request, db: AsyncSession =
     - password:     email + password → returns tokens immediately (session_id=None)
     - password+otp: email + password → verifies password, sends OTP, returns session_id
 
-    User must exist — users are created by admins only.
+    User must exist — users are created by admins only. Responses never reveal
+    whether an email has an account (anti-enumeration).
     """
     await rate_limit_by_ip(http_request, "login", settings.rate_limit_login_ip_max, settings.rate_limit_window_seconds)
     await rate_limit_by_value(request.email, "login:email", settings.rate_limit_login_email_max, settings.rate_limit_window_seconds)
@@ -87,29 +95,31 @@ async def login(request: LoginRequest, http_request: Request, db: AsyncSession =
             detail="Password required for this auth mode.",
         )
 
-    # Check if user exists - no auto-provisioning
+    # Check if user exists and is active - no auto-provisioning. To prevent
+    # account enumeration, unknown and deactivated (soft-deleted) emails must
+    # get responses indistinguishable from real accounts: a decoy session in
+    # OTP-only mode, the generic 401 in password modes.
     result = await db.execute(select(User).where(User.email == normalize_email(request.email)))
     user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="User not found. Contact your administrator.",
-        )
+    valid_account = user is not None and user.is_active
 
-    # Verify password before any OTP send so we don't email on bad credentials
+    # Verify password before any OTP send so we don't email on bad credentials.
+    # Unknown accounts and accounts without a password verify against a dummy
+    # hash to keep response timing uniform, then get the same generic 401.
     if requires_password:
-        if not user.password_hash:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="No password set for this account. Contact your administrator for a reset link.",
-            )
-        if not verify_password(request.password or "", user.password_hash):
+        real_hash = user.password_hash if valid_account else None
+        password_ok = verify_password(request.password or "", real_hash or _DUMMY_PASSWORD_HASH)
+        if not (real_hash and password_ok):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid email or password.",
             )
 
     if requires_otp:
+        if not valid_account:
+            # Decoy: no email is sent; verifying any code against this session
+            # id fails with the same "Invalid or expired OTP" as a wrong code.
+            return LoginResponse(message="OTP sent to your email", session_id=uuid.uuid4())
         try:
             otp_session = await create_otp_session(db, request.email)
         except Exception as e:
@@ -148,10 +158,11 @@ async def verify_otp(request: OTPVerifyRequest, http_request: Request, db: Async
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OTP"
         )
 
-    # Get user (must exist - checked during login)
+    # Get user (must exist and be active - checked during login, re-checked here
+    # in case the user was deactivated between OTP send and verification)
     user = await get_user_by_email(db, otp_session.email)
 
-    if not user:
+    if not user or not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User not found. Contact your administrator.",
@@ -273,7 +284,7 @@ async def redeem_password_reset(
 
     result = await db.execute(select(User).where(User.id == record.user_id))
     user = result.scalar_one_or_none()
-    if not user:
+    if not user or not user.is_active:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     user.password_hash = hash_password(request.new_password)

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -195,8 +195,9 @@ async def update_agent(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Agent '{namespace}/{name}' not found"
         )
 
-    # Additional ownership check for non-admin users
-    if not has_all_permission and agent.user_id != user_id:
+    # Additional ownership check for non-admin users (user_id from the token is
+    # a str; agent.user_id is a UUID — compare as strings)
+    if not has_all_permission and str(agent.user_id) != str(user_id):
         raise HTTPException(status_code=403, detail="Not authorized to update this agent")
 
     detach_if_package_managed(agent)
@@ -301,8 +302,9 @@ async def delete_agent(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Agent '{namespace}/{name}' not found"
         )
 
-    # Additional ownership check for non-admin users
-    if not has_all_permission and agent.user_id != user_id:
+    # Additional ownership check for non-admin users (user_id from the token is
+    # a str; agent.user_id is a UUID — compare as strings)
+    if not has_all_permission and str(agent.user_id) != str(user_id):
         raise HTTPException(status_code=403, detail="Not authorized to delete this agent")
 
     agent.is_active = False

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -1,6 +1,6 @@
 """User management endpoints."""
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -17,7 +17,7 @@ from app.core.auth import (
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.permissions import check_permission
-from app.models.user import Role, User, UserRole
+from app.models.user import APIKey, RefreshToken, Role, User, UserRole
 from app.schemas import UserResponse, UserUpdate
 from app.schemas.auth import AdminCreateResetLinkResponse, CreateUserRequest
 from app.schemas.user import UserWithRolesResponse
@@ -69,6 +69,7 @@ async def list_users(
         UserWithRolesResponse(
             id=u.id,
             email=u.email,
+            is_active=u.is_active,
             last_login_at=u.last_login_at,
             created_at=u.created_at,
             roles=roles_by_user.get(u.id, []),
@@ -107,19 +108,26 @@ async def create_user(
     result = await db.execute(select(User).where(User.email == normalized_email))
     user = result.scalar_one_or_none()
 
-    if user:
+    if user and user.is_active:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"User with email '{user_request.email}' already exists",
         )
 
-    # Create new user
-    user = User(email=normalized_email)
-    db.add(user)
-    await db.flush()
+    if user:
+        # Reactivate a soft-deleted user (role memberships were deactivated on
+        # delete, so they fall through to the GuestUsers assignment below)
+        user.is_active = True
+        await db.flush()
+    else:
+        user = User(email=normalized_email)
+        db.add(user)
+        await db.flush()
 
-    # Check if already has roles
-    memberships_result = await db.execute(select(UserRole).where(UserRole.user_id == user.id))
+    # Check if already has active roles
+    memberships_result = await db.execute(
+        select(UserRole).where(UserRole.user_id == user.id, UserRole.active == True)
+    )
     existing_memberships = memberships_result.scalars().all()
 
     # Only add to GuestUsers if no roles assigned yet
@@ -173,6 +181,7 @@ async def get_user(
     return UserWithRolesResponse(
         id=user.id,
         email=user.email,
+        is_active=user.is_active,
         last_login_at=user.last_login_at,
         created_at=user.created_at,
         roles=role_names,
@@ -242,7 +251,7 @@ async def admin_create_password_reset(
 
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
-    if not user:
+    if not user or not user.is_active:
         raise HTTPException(status_code=404, detail="User not found")
 
     plain_token, record = await create_password_reset_token(
@@ -286,17 +295,36 @@ async def delete_user(
 
     set_permission_used(request, "sinas.users.delete")
 
-    # Soft delete: deactivate user and remove all role memberships
+    # Soft delete: deactivate the user, remove all role memberships, and revoke
+    # their credentials so existing API keys and refresh tokens stop working
+    # immediately (access tokens die at expiry via the is_active check in auth)
+    now = datetime.now(UTC)
     user.is_active = False
-    from app.models.user import UserRole
-    from datetime import datetime as dt
+
     result = await db.execute(
         select(UserRole).where(UserRole.user_id == user_id, UserRole.active == True)
     )
     for membership in result.scalars().all():
         membership.active = False
-        membership.removed_at = dt.utcnow()
+        membership.removed_at = now
         membership.removed_by = uuid.UUID(current_user_id)
+
+    result = await db.execute(
+        select(APIKey).where(APIKey.user_id == user_id, APIKey.is_active == True)
+    )
+    for api_key in result.scalars().all():
+        api_key.is_active = False
+        api_key.revoked_at = now
+        api_key.revoked_by = uuid.UUID(current_user_id)
+
+    result = await db.execute(
+        select(RefreshToken).where(
+            RefreshToken.user_id == user_id, RefreshToken.is_revoked == False
+        )
+    )
+    for token in result.scalars().all():
+        token.is_revoked = True
+        token.revoked_at = now
 
     await db.flush()
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -431,7 +431,7 @@ async def validate_refresh_token(db: AsyncSession, plain_token: str) -> Optional
     result = await db.execute(select(User).where(User.id == refresh_token.user_id))
     user = result.scalar_one_or_none()
 
-    if not user:
+    if not user or not user.is_active:
         return None
 
     # Update last login timestamp
@@ -581,7 +581,7 @@ async def validate_api_key(db: AsyncSession, key: str) -> Optional[tuple[User, d
     result = await db.execute(select(User).where(User.id == api_key.user_id))
     user = result.scalar_one_or_none()
 
-    if not user:
+    if not user or not user.is_active:
         return None
 
     # Update last login timestamp
@@ -644,11 +644,11 @@ async def verify_jwt_or_api_key(
         # This ensures permissions are always current (no stale token permissions)
         permissions = await get_user_permissions(db, str(user_id))
 
-        # Verify user exists
+        # Verify user exists and is active (soft-deleted users lose access immediately)
         result = await db.execute(select(User).where(User.id == user_id))
         user = result.scalar_one_or_none()
 
-        if not user:
+        if not user or not user.is_active:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
         return str(user_id), email, permissions
@@ -885,6 +885,12 @@ async def initialize_superadmin(db: AsyncSession):
         await db.commit()
         await db.refresh(user)
         logger.info(f"Admin user created: {email}")
+
+    if not user.is_active:
+        # Escape hatch: a soft-deleted superadmin is reactivated on restart
+        user.is_active = True
+        await db.commit()
+        logger.info(f"Superadmin user reactivated: {email}")
 
     result = await db.execute(
         select(UserRole).where(UserRole.role_id == admins_role.id, UserRole.user_id == user.id)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -14,6 +14,9 @@ class User(Base, PermissionMixin):
 
     id: Mapped[uuid_pk]
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False, server_default="true", index=True
+    )
     last_login_at: Mapped[Optional[DateTime]] = mapped_column(DateTime(timezone=True), index=True)
     created_at: Mapped[created_at]
     updated_at: Mapped[updated_at]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 class UserResponse(BaseModel):
     id: uuid.UUID
     email: str
+    is_active: bool = True
     last_login_at: Optional[datetime]
     created_at: datetime
 
@@ -19,6 +20,7 @@ class UserResponse(BaseModel):
 class UserWithRolesResponse(BaseModel):
     id: uuid.UUID
     email: str
+    is_active: bool = True
     last_login_at: Optional[datetime] = None
     created_at: datetime
     roles: list[str]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared test fixtures for SINAS backend tests."""
+import os
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -17,7 +18,27 @@ from app.models.user import Role, RolePermission, User, UserRole
 # Engine is created per-fixture to avoid event loop conflicts.
 # ---------------------------------------------------------------------------
 
-_test_db_url = f"postgresql+asyncpg://{settings.database_user}:{settings.database_password}@localhost:5433/{settings.database_name}"
+_test_db_url = os.environ.get(
+    "TEST_DATABASE_URL",
+    f"postgresql+asyncpg://{settings.database_user}:{settings.database_password}@localhost:5433/{settings.database_name}",
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_redis_client() -> AsyncGenerator[None, None]:
+    """The Redis client is cached at module level and binds to the event loop
+    that first used it; each test runs in a fresh loop, so drop it per test."""
+    import app.core.redis as redis_module
+
+    yield
+    if redis_module._redis_client is not None:
+        try:
+            # Drop rate-limit counters etc. so tests don't bleed into each other
+            await redis_module._redis_client.flushdb()
+            await redis_module._redis_client.aclose()
+        except Exception:
+            pass
+        redis_module._redis_client = None
 
 
 @pytest_asyncio.fixture
@@ -39,13 +60,18 @@ async def db() -> AsyncGenerator[AsyncSession, None]:
 async def app(db: AsyncSession):
     """Create a FastAPI app with the test DB session injected."""
     from app.main import app as _app
+    from app.main import management_app
 
     async def _override_get_db():
         yield db
 
+    # /api/v1 is a mounted sub-application; dependency overrides do not
+    # propagate from the parent app, so both apps need the override
     _app.dependency_overrides[get_db] = _override_get_db
+    management_app.dependency_overrides[get_db] = _override_get_db
     yield _app
     _app.dependency_overrides.clear()
+    management_app.dependency_overrides.clear()
 
 
 @pytest_asyncio.fixture
@@ -71,20 +97,28 @@ async def test_role(db: AsyncSession) -> Role:
     await db.flush()
     await db.refresh(role)
 
+    # Create endpoints check flat keys (sinas.<resource>.create:own); read/update/
+    # delete go through PermissionMixin which builds namespaced keys
+    # (sinas.<resource>/*/*.<action>:scope) for namespaced resources.
     for perm_key in [
-        "sinas.agents.read:all",
         "sinas.agents.create:own",
-        "sinas.agents.update:own",
-        "sinas.agents.delete:own",
-        "sinas.functions.read:all",
+        "sinas.agents/*/*.read:all",
+        "sinas.agents/*/*.update:own",
+        "sinas.agents/*/*.delete:own",
         "sinas.functions.create:own",
-        "sinas.functions.update:own",
-        "sinas.functions.delete:own",
-        "sinas.queries.read:all",
+        "sinas.functions/*/*.read:all",
+        "sinas.functions/*/*.update:own",
+        "sinas.functions/*/*.delete:own",
         "sinas.queries.create:own",
-        "sinas.queries.update:own",
-        "sinas.queries.delete:own",
+        "sinas.queries/*/*.read:all",
+        "sinas.queries/*/*.update:own",
+        "sinas.queries/*/*.delete:own",
         "sinas.users.read:own",
+        # Flat read keys kept alongside the namespaced ones: the
+        # /auth/check-permissions tests assert on these exact keys
+        "sinas.agents.read:all",
+        "sinas.functions.read:all",
+        "sinas.queries.read:all",
     ]:
         db.add(RolePermission(role_id=role.id, permission_key=perm_key, permission_value=True))
     await db.flush()

--- a/backend/tests/unit/test_auth.py
+++ b/backend/tests/unit/test_auth.py
@@ -39,9 +39,20 @@ async def test_login_existing_user(client: AsyncClient, test_user: User):
 
 
 async def test_login_nonexistent_user(client: AsyncClient):
-    """POST /auth/login returns 403 for an unknown email."""
+    """Unknown emails get a decoy OTP response indistinguishable from a real one
+    (anti-enumeration), and the decoy session id never verifies."""
     resp = await client.post("/auth/login", json={"email": "nobody@example.com"})
-    assert resp.status_code == 403
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["message"] == "OTP sent to your email"
+    assert body["session_id"]
+
+    verify = await client.post(
+        "/auth/verify-otp",
+        json={"session_id": body["session_id"], "otp_code": "123456"},
+    )
+    assert verify.status_code == 400
+    assert verify.json()["detail"] == "Invalid or expired OTP"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_crud.py
+++ b/backend/tests/unit/test_crud.py
@@ -40,6 +40,8 @@ FUNCTION_PAYLOAD = {
     "name": "hello",
     "code": "def main(input): return {'result': 'hello'}",
     "description": "test fn",
+    "input_schema": {"type": "object"},
+    "output_schema": {"type": "object"},
 }
 
 
@@ -52,7 +54,7 @@ class TestFunctionsCRUD:
             json=FUNCTION_PAYLOAD,
             headers=auth_headers(test_user),
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         data = resp.json()
         assert data["namespace"] == "test"
         assert data["name"] == "hello"
@@ -96,7 +98,7 @@ class TestFunctionsCRUD:
         resp = await client.delete(
             "/api/v1/functions/test/hello", headers=auth_headers(test_user)
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 204
 
         resp = await client.get(
             "/api/v1/functions/test/hello", headers=auth_headers(test_user)
@@ -290,7 +292,7 @@ class TestQueriesCRUD:
             json=self._query_payload(db_connection),
             headers=auth_headers(test_user),
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         data = resp.json()
         assert data["namespace"] == "test"
         assert data["name"] == "get-users"


### PR DESCRIPTION
## What

`User.is_active` did not exist as a column — the delete endpoint's "soft delete" set a plain Python attribute and persisted nothing, so deleted users stayed fully active. This PR:

- Adds `users.is_active` (migration `u1s2r3a4c5t6`, server default true)
- Rejects inactive users in JWT verification, API-key auth, refresh-token validation, login, OTP verify, and password reset
- Revokes all API keys and refresh tokens when a user is deleted
- Re-creating a soft-deleted email reactivates the account instead of a permanent 409
- **Anti-enumeration**: login no longer reveals whether an email has an account. OTP mode returns a decoy `session_id` for unknown/inactive emails (verifies to the same "Invalid or expired OTP"); password modes return a generic 401 with dummy-hash timing equalization
- Fixes agents update/delete ownership check (`UUID != str` always true → non-admins could never modify their own agents)
- Repairs the backend test suite (the `/api/v1` mounted sub-app never received the `get_db` override, so ~all API tests had rotted at 401). 74/74 pass.

## Instructions for the merge + release session

**Conflicts (expected, direction matters):** `backend/app/api/runtime/endpoints/authentication.py` and `backend/app/api/v1/endpoints/users.py` conflict with dev's user-identities/custom-fields work (#92, #99). When resolving:
- Keep dev's `custom_fields` / identity additions **and** this branch's `is_active` checks + decoy-session logic.
- Dev's login handler still returns 403 "User not found. Contact your administrator." for unknown emails (that's the enumeration flaw this PR fixes) — that branch of the conflict must NOT survive in the login path. The post-merge login flow must be: lookup → `valid_account` flag → dummy-hash password check (generic 401) → decoy `session_id` for invalid accounts in OTP mode. The 403 wording may remain only in `verify-otp`'s re-check and authenticated endpoints.
- `tests/unit/test_auth.py::test_login_nonexistent_user` asserts the new behavior; it fails if resolution regresses this.

**Alembic:** after merging there will be two heads (`u1s2r3a4c5t6` from this PR; dev's head after `u1i2d3e4n5t6_user_identities_and_custom_fields` + 4 others). Run `alembic heads` and create a merge revision: `alembic merge -m "merge is_active and identities heads" <head_a> <head_b>`.

**Kjeld's local dev DB only:** the compose Postgres on 5433 already has `is_active` added via manual DDL — running `u1s2r3a4c5t6` there will fail with DuplicateColumn. `alembic stamp u1s2r3a4c5t6` (or drop the column first) on that machine only; all other environments migrate normally.

**Release (0.3.0):** include in the release notes — deleting a user now revokes their API keys and refresh tokens and blocks all auth immediately; login responses changed for unknown emails (200 + decoy session in OTP mode instead of 403; generic 401 in password modes — clients keying on the old 403 wording must not); accounts without a password now get the generic 401 instead of the "no password set" hint; non-admin users can now actually update/delete their own agents.

**Post-merge verification:** run `backend/tests` against throwaway containers, e.g. `TEST_DATABASE_URL=postgresql+asyncpg://... REDIS_URL=redis://localhost:<port>/0 python -m pytest tests/` — Redis must be reachable (rate-limit tests are real now) and the DB freshly migrated through the merge revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)