### PR TITLE
feat(dashboard): surface LLM token usage on the home dashboard

### DIFF
--- a/backend/app/api/v1/endpoints/messages.py
+++ b/backend/app/api/v1/endpoints/messages.py
@@ -10,6 +10,7 @@ from app.core.auth import get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
 from app.core.permissions import check_permission
 from app.models import Chat, Message, User
+from app.models.llm_usage import LLMUsage
 from app.services.message_service import strip_base64_data
 
 router = APIRouter(prefix="/messages", tags=["messages"])
@@ -219,11 +220,33 @@ async def get_message_stats(
     role_rows = (await db.execute(role_q)).all()
     role_distribution = {r.role: r.count for r in role_rows}
 
+    # LLM token usage over the same window (same read:all / read:own scoping).
+    usage_filter = LLMUsage.created_at >= since
+    if not has_all:
+        usage_filter = and_(usage_filter, LLMUsage.user_id == user_id)
+    usage_q = select(
+        func.coalesce(func.sum(LLMUsage.prompt_tokens), 0),
+        func.coalesce(func.sum(LLMUsage.completion_tokens), 0),
+        func.coalesce(func.sum(LLMUsage.total_tokens), 0),
+        func.coalesce(func.sum(LLMUsage.cache_read_tokens), 0),
+        func.coalesce(func.sum(LLMUsage.cache_write_tokens), 0),
+        func.count(),
+    ).where(usage_filter)
+    u_prompt, u_completion, u_total, u_cache_read, u_cache_write, u_calls = (
+        await db.execute(usage_q)
+    ).one()
+
     return {
         "total_messages": total,
         "tool_calls": tool_calls,
         "activity_by_day": activity_by_day,
         "agent_usage": agent_usage,
         "role_distribution": role_distribution,
+        "llm_prompt_tokens": int(u_prompt),
+        "llm_completion_tokens": int(u_completion),
+        "llm_total_tokens": int(u_total),
+        "llm_cache_read_tokens": int(u_cache_read),
+        "llm_cache_write_tokens": int(u_cache_write),
+        "llm_calls": u_calls,
         "days": days,
     }

--- a/console/src/pages/Dashboard.tsx
+++ b/console/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../lib/api';
 import { useAuth } from '../lib/auth-context';
-import { MessageSquare, Bot, Code, TrendingUp, Zap, CheckCircle, X, Brain, ArrowRight } from 'lucide-react';
+import { MessageSquare, Bot, Code, TrendingUp, Zap, CheckCircle, X, Brain, ArrowRight, Coins } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 import { useState } from 'react';
@@ -79,11 +79,26 @@ export function Dashboard() {
 
   const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#6366f1'];
 
-  const stats = [
+  // Compact token counts: 1234 -> "1.2K", 3400000 -> "3.4M".
+  const formatTokens = (n: number): string => {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+    return `${n}`;
+  };
+  const cacheTokens = (messageStats?.llm_cache_read_tokens || 0) + (messageStats?.llm_cache_write_tokens || 0);
+
+  const stats: Array<{ name: string; value: number | string; icon: any; color: string; subtitle?: string }> = [
     { name: 'Messages (7d)', value: messageStats?.total_messages || 0, icon: MessageSquare, color: 'blue' },
     { name: 'Active Agents', value: agents?.filter((a) => a.is_active).length || 0, icon: Bot, color: 'purple' },
     { name: 'Functions', value: functions?.length || 0, icon: Code, color: 'green' },
     { name: 'Tool Calls', value: messageStats?.tool_calls || 0, icon: Zap, color: 'orange' },
+    {
+      name: 'Tokens (7d)',
+      value: formatTokens(messageStats?.llm_total_tokens || 0),
+      icon: Coins,
+      color: 'cyan',
+      subtitle: cacheTokens > 0 ? `${formatTokens(cacheTokens)} cached` : undefined,
+    },
   ];
 
   const getColorClasses = (color: string) => {
@@ -92,6 +107,7 @@ export function Dashboard() {
       purple: { bg: 'bg-purple-900/20', text: 'text-purple-400', icon: 'text-purple-400' },
       green: { bg: 'bg-green-900/20', text: 'text-green-400', icon: 'text-green-600' },
       orange: { bg: 'bg-orange-900/20', text: 'text-orange-400', icon: 'text-orange-400' },
+      cyan: { bg: 'bg-cyan-900/20', text: 'text-cyan-400', icon: 'text-cyan-400' },
     };
     return colors[color] || colors.blue;
   };
@@ -177,7 +193,7 @@ export function Dashboard() {
       )}
 
       {/* Key Stats */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
         {stats.map((stat) => {
           const Icon = stat.icon;
           const colors = getColorClasses(stat.color);
@@ -187,6 +203,9 @@ export function Dashboard() {
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-gray-400 truncate">{stat.name}</p>
                   <p className="text-2xl font-bold text-gray-100 mt-2">{stat.value}</p>
+                  {stat.subtitle && (
+                    <p className="text-xs text-gray-500 mt-1 truncate">{stat.subtitle}</p>
+                  )}
                 </div>
                 <div className={`p-3 ${colors.bg} rounded-lg flex-shrink-0`}>
                   <Icon className={`w-6 h-6 ${colors.icon}`} />


### PR DESCRIPTION
## What

Token usage is recorded per LLM call in `llm_usage`, but nothing surfaced it. This adds a **Tokens (7d)** tile to the home dashboard.

- **No new endpoint** — extends the existing `/messages/stats` (which the dashboard already calls) with token totals over the same window: prompt / completion / total tokens, cache read/write, and call count. Same `read:all` / `read:own` permission scoping as the rest of the stats.
- Dashboard tile shows the total (compact `1.2M`-style formatting) with a `"… cached"` subtitle when prompt caching is active.

Makes 0.3.0's "per-call token tracking + prompt caching" actually *visible*, not just written to a table.

## Test

Full backend suite green (124/124) on a fresh migrated DB; console `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)