### PR TITLE
fix(tools): structure-aware context truncation with its own cap, and unmasked delegation errors

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -227,6 +227,12 @@ class Settings(BaseSettings):
     agent_job_timeout: int = 600  # Default timeout for agent jobs (10 minutes)
     code_execution_timeout: int = 120  # Default timeout for code execution (2 minutes)
 
+    # Tool results above this many characters are truncated (structure-aware,
+    # see services/tool_execution.truncate_tool_result) before they enter the
+    # LLM context. ~12K tokens: large enough for realistic listings on a
+    # 200K-context model, small enough that one call can't crowd the window.
+    tool_result_max_size: int = 50000
+
     # Agent-to-agent delegation (call_agent_* tools). See issue #90.
     # - agent_delegate_timeout: how long a parent waits for a sub-agent result.
     #   Must be < agent_job_timeout in "block" mode, since the parent's own job

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -230,10 +230,10 @@ class Settings(BaseSettings):
     # Tool results above this many characters are truncated (structure-aware,
     # see services/tool_execution.truncate_tool_result) before they enter the
     # LLM context. Distinct from tool_result_max_size above, which caps what
-    # the tool result store persists per row. ~12K tokens: large enough for
-    # realistic listings on a 200K-context model, small enough that one call
-    # can't crowd the window.
-    tool_result_context_max_size: int = 50000
+    # the tool result store persists per row; same 100KB default so the two
+    # caps stay aligned. ~25K tokens per result; deployments that want a
+    # tighter per-turn budget can lower it via TOOL_RESULT_CONTEXT_MAX_SIZE.
+    tool_result_context_max_size: int = 102400
 
     # Agent-to-agent delegation (call_agent_* tools). See issue #90.
     # - agent_delegate_timeout: how long a parent waits for a sub-agent result.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -229,9 +229,11 @@ class Settings(BaseSettings):
 
     # Tool results above this many characters are truncated (structure-aware,
     # see services/tool_execution.truncate_tool_result) before they enter the
-    # LLM context. ~12K tokens: large enough for realistic listings on a
-    # 200K-context model, small enough that one call can't crowd the window.
-    tool_result_max_size: int = 50000
+    # LLM context. Distinct from tool_result_max_size above, which caps what
+    # the tool result store persists per row. ~12K tokens: large enough for
+    # realistic listings on a 200K-context model, small enough that one call
+    # can't crowd the window.
+    tool_result_context_max_size: int = 50000
 
     # Agent-to-agent delegation (call_agent_* tools). See issue #90.
     # - agent_delegate_timeout: how long a parent waits for a sub-agent result.

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -570,7 +570,11 @@ async def execute_agent_tool(
         }
 
     except Exception as e:
-        logger.error(f"Failed to execute agent tool {tool_name}: {e}")
+        # agent_id_str, not tool_name: tool_name is not in scope here, and the
+        # NameError it raised replaced the real exception in the returned
+        # error, hiding every delegation failure cause from the caller.
+        logger.error(f"Failed to execute agent tool {agent_id_str}: {e}")
+        logger.debug("Delegation failure traceback:\n%s", traceback.format_exc())
         try:
             _delegate_span.set_status(trace.StatusCode.ERROR, str(e)[:200])
             _delegate_span.end()

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -38,6 +38,138 @@ from app.services.tool_result_store import get_tool_result, save_tool_result
 
 logger = logging.getLogger(__name__)
 
+# Per-tool overrides for the truncation budget, keyed by tool name. Empty by
+# default; deployments or callers can register exceptions for tools whose
+# results are known-large and structurally safe.
+TOOL_RESULT_SIZE_OVERRIDES: dict[str, int] = {}
+
+_TRUNCATION_SUFFIX = "\n\n[... result truncated]"
+
+
+def _clean_text_cut(content: str, max_size: int) -> str:
+    """Fallback: cut plain text at a whitespace boundary and mark it."""
+    budget = max_size - len(_TRUNCATION_SUFFIX)
+    cut = content[:budget]
+    boundary = max(cut.rfind("\n"), cut.rfind(" "))
+    if boundary > budget // 2:
+        cut = cut[:boundary]
+    return cut + _TRUNCATION_SUFFIX
+
+
+def _largest_string_slot(container):
+    """Find the (parent, key) of the largest string value, looking one level
+    into nested dicts (a connector response's `body`). Returns (None, None)
+    when there is no string worth clipping."""
+    best_parent, best_key, best_len = None, None, 0
+    stack = [container]
+    seen_depth = {id(container): 0}
+    while stack:
+        node = stack.pop()
+        depth = seen_depth[id(node)]
+        for key, value in node.items():
+            if isinstance(value, str) and len(value) > best_len:
+                best_parent, best_key, best_len = node, key, len(value)
+            elif isinstance(value, dict) and depth < 1:
+                seen_depth[id(value)] = depth + 1
+                stack.append(value)
+    return best_parent, best_key
+
+
+def truncate_tool_result(result_content: str, max_size: int) -> str:
+    """Cap an oversized tool result without breaking its structure.
+
+    A blind byte-slice leaves the model with unparseable JSON and no way to
+    reach the remainder, so it retries the same call forever. Instead:
+      - JSON arrays (bare, or the largest list inside a dict, e.g. a
+        connector response's `body`) are trimmed to whole elements and a
+        marker {"_truncated": true, "returned": n, "total": N} tells the
+        model there is more to page through.
+      - JSON objects dominated by one string (a document body) get that
+        string clipped, with the same marker shape describing the clip.
+      - Anything unparseable is cut at a whitespace boundary with a visible
+        text suffix, as before.
+    Always returns content of at most max_size characters.
+    """
+    if len(result_content) <= max_size:
+        return result_content
+    try:
+        parsed = json.loads(result_content)
+    except (ValueError, TypeError):
+        return _clean_text_cut(result_content, max_size)
+
+    def _fit_list(items: list, overhead_probe) -> str | None:
+        """Keep a prefix of whole elements such that the rebuilt payload
+        fits. Returns the serialized payload, or None if impossible."""
+        total = len(items)
+        kept = list(items)
+        while True:
+            marker = {"_truncated": True, "returned": len(kept), "total": total}
+            candidate = overhead_probe(kept, marker)
+            if len(candidate) <= max_size:
+                return candidate
+            if not kept:
+                return None
+            kept.pop()
+
+    if isinstance(parsed, list):
+        fitted = _fit_list(
+            parsed, lambda kept, marker: json.dumps(kept + [marker])
+        )
+        if fitted is not None:
+            return fitted
+        return _clean_text_cut(result_content, max_size)
+
+    if isinstance(parsed, dict):
+        # Prefer trimming the largest list value (one level deep covers the
+        # connector envelope's `body`).
+        list_slots = [
+            (parent, key)
+            for parent in [parsed]
+            + [v for v in parsed.values() if isinstance(v, dict)]
+            for key, value in parent.items()
+            if isinstance(value, list) and value
+        ]
+        if list_slots:
+            parent, key = max(
+                list_slots, key=lambda slot: len(json.dumps(slot[0][slot[1]]))
+            )
+            original = parent[key]
+
+            def probe(kept, marker):
+                parent[key] = kept
+                parsed["_truncated"] = {**marker, "field": key}
+                return json.dumps(parsed)
+
+            fitted = _fit_list(original, probe)
+            if fitted is not None:
+                return fitted
+            parent[key] = original
+            parsed.pop("_truncated", None)
+
+        s_parent, s_key = _largest_string_slot(parsed)
+        if s_parent is not None:
+            original_str = s_parent[s_key]
+            total_len = len(original_str)
+            # JSON escaping inflates the string ("\n" -> "\\n"), so converge
+            # on the clip length instead of computing it once.
+            clip = min(total_len, max_size)
+            while clip > 0:
+                s_parent[s_key] = original_str[:clip]
+                parsed["_truncated"] = {
+                    "_truncated": True,
+                    "field": s_key,
+                    "returned": clip,
+                    "total": total_len,
+                }
+                candidate = json.dumps(parsed)
+                if len(candidate) <= max_size:
+                    return candidate
+                clip -= max(len(candidate) - max_size, 32)
+            s_parent[s_key] = original_str
+            parsed.pop("_truncated", None)
+
+    return _clean_text_cut(result_content, max_size)
+
 
 def validate_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Validate tool calls and filter out corrupted ones.
@@ -735,11 +867,14 @@ async def execute_single_tool(
 
             result_content = json.dumps(result) if not isinstance(result, str) else result
 
-            # Truncate oversized results to prevent LLM token overflow
-            max_result_size = 10000  # 10KB max per tool result for LLM context
+            # Truncate oversized results (structure-aware) so a single tool
+            # call can't crowd the LLM context, without emitting broken JSON.
+            max_result_size = TOOL_RESULT_SIZE_OVERRIDES.get(
+                tool_name, settings.tool_result_max_size
+            )
             if len(result_content) > max_result_size:
                 print(f"⚠️ Truncating tool result for {tool_name}: {len(result_content)} -> {max_result_size} bytes", flush=True)
-                result_content = result_content[:max_result_size] + '\n\n[... result truncated]'
+                result_content = truncate_tool_result(result_content, max_result_size)
 
     except Exception as e:
         print(f"❌ Tool execution failed: {tool_name}: {e}", flush=True)

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -870,7 +870,7 @@ async def execute_single_tool(
             # Truncate oversized results (structure-aware) so a single tool
             # call can't crowd the LLM context, without emitting broken JSON.
             max_result_size = TOOL_RESULT_SIZE_OVERRIDES.get(
-                tool_name, settings.tool_result_max_size
+                tool_name, settings.tool_result_context_max_size
             )
             if len(result_content) > max_result_size:
                 print(f"⚠️ Truncating tool result for {tool_name}: {len(result_content)} -> {max_result_size} bytes", flush=True)

--- a/backend/tests/unit/test_delegation_error_handler.py
+++ b/backend/tests/unit/test_delegation_error_handler.py
@@ -1,0 +1,59 @@
+"""The delegation failure handler must report the real error.
+
+execute_agent_tool's except block used to log f"...{tool_name}..." with
+tool_name not in scope, so any failure in the delegation path surfaced as
+{"error": "name 'tool_name' is not defined"} instead of the actual cause.
+These tests pin the fixed behavior: the underlying exception's message is
+what reaches the caller.
+
+Run from the backend directory:
+`python -m pytest tests/unit/test_delegation_error_handler.py`
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import app.services.tool_execution as te
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_delegation_failure_returns_the_real_error(monkeypatch):
+    async def boom(db, user_id, agent_id_str, arguments):
+        raise ValueError("upstream boom")
+
+    monkeypatch.setattr(te, "prepare_agent_delegation", boom)
+    result = _run(
+        te.execute_agent_tool(
+            db=MagicMock(),
+            chat=MagicMock(),
+            user_id="u1",
+            user_token="t1",
+            agent_id_str="ns__agent",
+            arguments={"prompt": "x"},
+            create_chat_with_agent_fn=MagicMock(),
+        )
+    )
+    assert result == {"error": "upstream boom"}
+
+
+def test_delegation_failure_is_not_masked_by_name_error(monkeypatch):
+    async def boom(db, user_id, agent_id_str, arguments):
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr(te, "prepare_agent_delegation", boom)
+    result = _run(
+        te.execute_agent_tool(
+            db=MagicMock(),
+            chat=MagicMock(),
+            user_id="u1",
+            user_token="t1",
+            agent_id_str="ns__agent",
+            arguments={},
+            create_chat_with_agent_fn=MagicMock(),
+        )
+    )
+    assert "tool_name" not in result["error"]
+    assert result["error"] == "redis unavailable"

--- a/backend/tests/unit/test_tool_result_truncation.py
+++ b/backend/tests/unit/test_tool_result_truncation.py
@@ -76,7 +76,7 @@ def test_non_json_falls_back_to_clean_text_cut():
 
 
 def test_default_budget_and_override_registry():
-    assert settings.tool_result_context_max_size == 50000
+    assert settings.tool_result_context_max_size == 102400
     assert TOOL_RESULT_SIZE_OVERRIDES == {}
 
 
@@ -85,6 +85,6 @@ def test_context_cap_is_independent_of_store_cap():
     # what tool_result_store persists per row; the context cap governs what
     # enters the LLM context. They must stay separate fields.
     assert settings.tool_result_max_size == 102400
-    assert settings.tool_result_context_max_size == 50000
+    assert settings.tool_result_context_max_size == 102400
     assert "tool_result_max_size" in type(settings).model_fields
     assert "tool_result_context_max_size" in type(settings).model_fields

--- a/backend/tests/unit/test_tool_result_truncation.py
+++ b/backend/tests/unit/test_tool_result_truncation.py
@@ -1,0 +1,80 @@
+"""Unit tests for structure-aware tool-result truncation.
+
+No network, no DB: `truncate_tool_result` is a pure function. The contract:
+output never exceeds max_size, JSON in means JSON out (with a machine-readable
+{"_truncated": ...} marker when trimmed), and non-JSON falls back to a clean
+text cut with the visible suffix.
+"""
+import json
+
+from app.services.tool_execution import (
+    TOOL_RESULT_SIZE_OVERRIDES,
+    truncate_tool_result,
+)
+from app.core.config import settings
+
+MAX = 2000  # small budget so fixtures stay readable
+
+
+def _rows(n, pad=120):
+    return [{"id": i, "reason": "x" * pad} for i in range(n)]
+
+
+def test_small_result_is_untouched():
+    content = json.dumps(_rows(3))
+    assert truncate_tool_result(content, MAX) == content
+
+
+def test_oversized_list_keeps_whole_elements_and_marks():
+    content = json.dumps(_rows(50))
+    out = truncate_tool_result(content, MAX)
+    assert len(out) <= MAX
+    parsed = json.loads(out)  # valid JSON, not a mid-string cut
+    *items, marker = parsed
+    assert marker["_truncated"] is True
+    assert marker["returned"] == len(items)
+    assert marker["total"] == 50
+    # every surviving element is intact
+    assert all(set(i) == {"id", "reason"} for i in items)
+    assert [i["id"] for i in items] == list(range(len(items)))
+
+
+def test_dict_wrapped_body_list_is_trimmed_in_place():
+    content = json.dumps(
+        {"status_code": 200, "headers": {"server": "x"}, "body": _rows(50)}
+    )
+    out = truncate_tool_result(content, MAX)
+    assert len(out) <= MAX
+    parsed = json.loads(out)
+    assert parsed["status_code"] == 200  # envelope survives
+    assert parsed["_truncated"]["field"] == "body"
+    assert parsed["_truncated"]["returned"] == len(parsed["body"])
+    assert parsed["_truncated"]["total"] == 50
+    assert all(set(i) == {"id", "reason"} for i in parsed["body"])
+
+
+def test_dict_with_dominant_string_is_clipped_not_broken():
+    content = json.dumps(
+        {"status_code": 200, "body": {"version": 1, "content": "line\n" * 1000}}
+    )
+    out = truncate_tool_result(content, MAX)
+    assert len(out) <= MAX
+    parsed = json.loads(out)
+    assert parsed["body"]["version"] == 1
+    assert parsed["_truncated"]["field"] == "content"
+    assert parsed["_truncated"]["returned"] < parsed["_truncated"]["total"]
+    assert len(parsed["body"]["content"]) < 5000
+
+
+def test_non_json_falls_back_to_clean_text_cut():
+    content = "word " * 2000
+    out = truncate_tool_result(content, MAX)
+    assert len(out) <= MAX
+    assert out.endswith("[... result truncated]")
+    # boundary cut: never ends mid-word before the suffix
+    assert not out.removesuffix("\n\n[... result truncated]").endswith("wor")
+
+
+def test_default_budget_and_override_registry():
+    assert settings.tool_result_max_size == 50000
+    assert TOOL_RESULT_SIZE_OVERRIDES == {}

--- a/backend/tests/unit/test_tool_result_truncation.py
+++ b/backend/tests/unit/test_tool_result_truncation.py
@@ -76,5 +76,15 @@ def test_non_json_falls_back_to_clean_text_cut():
 
 
 def test_default_budget_and_override_registry():
-    assert settings.tool_result_max_size == 50000
+    assert settings.tool_result_context_max_size == 50000
     assert TOOL_RESULT_SIZE_OVERRIDES == {}
+
+
+def test_context_cap_is_independent_of_store_cap():
+    # The store cap (tool_result_max_size, env TOOL_RESULT_MAX_SIZE) governs
+    # what tool_result_store persists per row; the context cap governs what
+    # enters the LLM context. They must stay separate fields.
+    assert settings.tool_result_max_size == 102400
+    assert settings.tool_result_context_max_size == 50000
+    assert "tool_result_max_size" in type(settings).model_fields
+    assert "tool_result_context_max_size" in type(settings).model_fields


### PR DESCRIPTION
## Summary

Two long-standing issues in tool execution, plus the config to govern them. Ready for 0.3.0.

---

## 1. Tool results were cut to 10KB with a blind byte-slice

`tool_execution.py` capped every tool result at a hardcoded `max_result_size = 10000` and sliced mid-byte. For JSON results the model receives unparseable output with no way to reach the remainder — so it **retries the same call over and over**.

**Impact in our deployment:** 4,605 truncations since late May — 88% document reads. The cap also silently truncated `get_playbook` on any playbook over 10KB, hiding instructions from every agent.

### On configurability

`TOOL_RESULT_MAX_SIZE` already exists — but it governs the **store** (`tool_result_store.py`, what's persisted per row). The 10KB **context** cap was a separate hardcoded literal that read no setting. This PR keeps the two concerns distinct and makes both explicit:

| Setting | Governs | Default |
|---|---|---|
| `tool_result_max_size` | store (persisted per row) | 100KB *(unchanged)* |
| `tool_result_context_max_size` | what enters the LLM context | **100KB** *(new)* |
| `TOOL_RESULT_SIZE_OVERRIDES` | per-tool registry for known-large safe tools | — |

Default set to 100KB per your note. Deployments wanting a tighter per-turn token budget can set `TOOL_RESULT_CONTEXT_MAX_SIZE=50000` (~12K tokens).

### Structure-aware truncation

Truncation now trims to **whole elements** with a machine-readable marker so the model knows it got part of the result and can page instead of retrying — exactly the *"indicate it's truncated"* point you raised:

```json
{ "_truncated": true, "returned": 12, "total": 47 }
```

- **JSON arrays / the largest list in a dict** → trimmed to whole elements + marker
- **Objects dominated by one big string** (a document body) → string clipped + marker + field name
- **Unparseable content** → whitespace-boundary cut with a visible suffix

Every path returns at most the cap.

---

## 2. Delegation failures reported a `NameError` instead of the real error

The `except` block in `execute_agent_tool` logged `{tool_name}` — not in scope there — so the handler's own `NameError` replaced the original exception. Every `call_agent_*` failure surfaced as: {"error": "name 'tool_name' is not defined"} with the real cause unrecoverable. **In our deployment this masked a plain `ModuleNotFoundError` for two days of debugging.** Fixed to log `agent_id_str` and keep the traceback at debug level.

---

## Tests

- **7 for truncation** — list trim, dict body-list trim, dominant-string clip (with escaping-inflation convergence), text fallback, cap independence
- **2 for delegation** — the underlying error text reaches the caller, never the `NameError`

All green against dev (`dc6df5c`).
