### PR TITLE
fix(chart): leaner default resources for shared components + quota sizing docs

### DIFF
--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -98,22 +98,22 @@ networkPolicy:
 builder:
   resources:
     requests:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: "50m"
+      memory: "96Mi"
     limits:
       cpu: "500m"
-      memory: "512Mi"
+      memory: "384Mi"
 
 ## Backend (FastAPI)
 backend:
   replicas: 1
   resources:
     requests:
-      cpu: "500m"
-      memory: "512Mi"
+      cpu: "300m"
+      memory: "384Mi"
     limits:
-      cpu: "2"
-      memory: "2Gi"
+      cpu: "1500m"
+      memory: "1536Mi"
 
 ## Queue worker
 queueWorker:
@@ -124,11 +124,11 @@ queueWorker:
   concurrency: 10
   resources:
     requests:
-      cpu: "200m"
-      memory: "256Mi"
+      cpu: "150m"
+      memory: "192Mi"
     limits:
       cpu: "1"
-      memory: "1Gi"
+      memory: "768Mi"
 
 ## Queue agent worker
 queueAgent:
@@ -137,38 +137,38 @@ queueAgent:
   concurrency: 5
   resources:
     requests:
-      cpu: "200m"
-      memory: "256Mi"
+      cpu: "150m"
+      memory: "192Mi"
     limits:
       cpu: "1"
-      memory: "1Gi"
+      memory: "768Mi"
 
 ## Scheduler
 scheduler:
   resources:
     requests:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: "50m"
+      memory: "96Mi"
     limits:
       cpu: "500m"
-      memory: "512Mi"
+      memory: "384Mi"
 
 ## CDC worker
 cdcWorker:
   resources:
     requests:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: "50m"
+      memory: "96Mi"
     limits:
       cpu: "500m"
-      memory: "512Mi"
+      memory: "384Mi"
 
 ## Console (React SPA)
 console:
   resources:
     requests:
-      cpu: "50m"
-      memory: "64Mi"
+      cpu: "25m"
+      memory: "32Mi"
     limits:
       cpu: "200m"
       memory: "128Mi"

--- a/docs-mint/getting-started/kubernetes.mdx
+++ b/docs-mint/getting-started/kubernetes.mdx
@@ -119,6 +119,10 @@ namespace — so they compete with the platform's own pods for any namespace
   the execution fails with a quota error — reduce sandbox size, raise the
   quota, or lower worker concurrency (`queueWorker`/`queueAgent` values) to
   bound simultaneous executions.
+- **Trusted (`inprocess`) code has no per-function memory cap** — it runs
+  inside the queue-worker process, so the worker's `resources.limits.memory`
+  *is* the tenant's burst envelope for `shared_pool` functions
+  (worker baseline + concurrency × per-call allocation). Size it accordingly.
 - **Datastores** (postgres, redis, pgbouncer) set no container resources in
   the chart; on clusters with a `LimitRange` they inherit its defaults, which
   count against the quota too. Give them explicit values in your own manifest

--- a/docs-mint/getting-started/kubernetes.mdx
+++ b/docs-mint/getting-started/kubernetes.mdx
@@ -98,6 +98,35 @@ shared ones — that choice lives entirely in your own tooling, not here.
 All four are no-ops by default, matching the behavior described above with
 no scheduling constraint at all.
 
+## Sizing under namespace quotas
+
+Sandbox pods are created **on demand, per execution**, in the release
+namespace — so they compete with the platform's own pods for any namespace
+`ResourceQuota`. Plan the quota headroom explicitly:
+
+- **Sandbox pod size** is set by the executor, with `requests == limits`:
+  `MAX_FUNCTION_MEMORY` (MiB, default `512`) and `MAX_FUNCTION_CPU` (cores,
+  default `1.0`), plus an ephemeral-storage limit from `MAX_FUNCTION_STORAGE`.
+  Pass them via the chart's `extraEnv` to shrink each execution's footprint,
+  e.g. `MAX_FUNCTION_MEMORY=192`, `MAX_FUNCTION_CPU=0.5`.
+- **Concurrency ceiling** ≈ what's left of the quota after the platform pods,
+  divided by one sandbox pod's request. Example: with a
+  `requests.memory: 3Gi` quota and the default chart components requesting
+  ~1.4Gi, a 192Mi sandbox pod allows ~8 concurrent executions; a 512Mi one
+  allows ~3. Check `requests.cpu` and the `pods:` count the same way — the
+  binding constraint is whichever runs out first.
+- **Failure mode:** when the quota is exhausted, pod creation is rejected and
+  the execution fails with a quota error — reduce sandbox size, raise the
+  quota, or lower worker concurrency (`queueWorker`/`queueAgent` values) to
+  bound simultaneous executions.
+- **Datastores** (postgres, redis, pgbouncer) set no container resources in
+  the chart; on clusters with a `LimitRange` they inherit its defaults, which
+  count against the quota too. Give them explicit values in your own manifest
+  patches if you need deterministic accounting.
+
+The chart's per-component `resources` are values — override any of them
+per deployment.
+
 ## Key values
 
 | Value | Default | Description |


### PR DESCRIPTION
Fleet feedback from Ihor: under a namespace `ResourceQuota` (3Gi memory requests) the chart defaults left too little headroom for on-demand sandbox pods — executions failed with quota errors.

- Lower shared-component resource defaults (backend 384Mi req / 1.5Gi lim, workers 192Mi/768Mi, scheduler/cdc/builder/console proportionally). All overridable per deployment as before.
- New **Sizing under namespace quotas** docs section: sandbox pod footprint knobs (`MAX_FUNCTION_MEMORY`/`MAX_FUNCTION_CPU` via `extraEnv`), the concurrency-ceiling math, the quota-exhaustion failure mode, and the LimitRange caveat for datastores.

helm lint + template verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)