### PR TITLE
feat(chart): clickhouse.enabled toggle, compact deployment profile, helm CI

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,48 @@
+name: Helm Chart Checks
+
+# Phase-0 gate from the footprint plan: every chart change must lint and
+# render. Templates both profiles so a values regression in either the
+# default or the compact (clickhouse-less) shape fails CI.
+on:
+  push:
+    branches: [main, dev]
+    paths: ['charts/**']
+  pull_request:
+    paths: ['charts/**']
+
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: helm lint
+        run: |
+          helm lint charts/sinas \
+            --set domain=ci.example.com \
+            --set secrets.secretKey=ci --set secrets.encryptionKey=ci \
+            --set postgres.password=ci --set clickhouse.password=ci
+
+      - name: helm template (default profile)
+        run: |
+          helm template ci charts/sinas \
+            --set domain=ci.example.com \
+            --set secrets.secretKey=ci --set secrets.encryptionKey=ci \
+            --set postgres.password=ci --set clickhouse.password=ci \
+            > /tmp/default.yaml
+          grep -q "kind: StatefulSet" /tmp/default.yaml
+          grep -q "name: clickhouse" /tmp/default.yaml
+
+      - name: helm template (compact profile, clickhouse disabled)
+        run: |
+          helm template ci charts/sinas \
+            --set domain=ci.example.com \
+            --set secrets.secretKey=ci --set secrets.encryptionKey=ci \
+            --set postgres.password=ci \
+            --set clickhouse.enabled=false \
+            > /tmp/compact.yaml
+          ! grep -q "name: clickhouse" /tmp/compact.yaml
+          # backend must get the explicit-disable signal
+          grep -q 'CLICKHOUSE_HOST' /tmp/compact.yaml

--- a/backend/app/services/clickhouse_logger.py
+++ b/backend/app/services/clickhouse_logger.py
@@ -21,7 +21,20 @@ class ClickHouseLogger:
         self._initialize_client()
 
     def _initialize_client(self):
-        """Initialize ClickHouse client connection."""
+        """Initialize ClickHouse client connection.
+
+        An empty CLICKHOUSE_HOST means ClickHouse is deliberately disabled
+        (e.g. the compact deployment profile): skip connecting entirely so
+        the per-request `_ensure_client` retry doesn't attempt a connection
+        and log an error on every request. Logging methods no-op and log
+        queries return empty, as with any unavailable ClickHouse.
+        """
+        if not settings.clickhouse_host:
+            if not getattr(self, "_disabled", False):
+                logger.info("ClickHouse disabled (CLICKHOUSE_HOST empty) — request/execution logging off")
+            self._disabled = True
+            self.client = None
+            return
         try:
             self.client = clickhouse_connect.get_client(
                 host=settings.clickhouse_host,
@@ -36,6 +49,8 @@ class ClickHouseLogger:
 
     def _ensure_client(self) -> bool:
         """Ensure client is connected, retry if needed."""
+        if getattr(self, "_disabled", False):
+            return False
         if self.client:
             return True
         self._initialize_client()

--- a/backend/tests/unit/test_clickhouse_disabled.py
+++ b/backend/tests/unit/test_clickhouse_disabled.py
@@ -1,0 +1,43 @@
+"""ClickHouse-disabled mode (compact profile): empty CLICKHOUSE_HOST.
+
+The chart's `clickhouse.enabled: false` sets CLICKHOUSE_HOST="" — the logger
+must treat that as a deliberate disable: no connection attempts (not even
+retries from `_ensure_client`), logging no-ops, queries return empty.
+"""
+
+from unittest.mock import patch
+
+from app.services.clickhouse_logger import ClickHouseLogger
+
+
+def _disabled_logger():
+    with patch("app.services.clickhouse_logger.settings") as s:
+        s.clickhouse_host = ""
+        return ClickHouseLogger()
+
+
+def test_empty_host_disables_without_connecting():
+    with patch("app.services.clickhouse_logger.clickhouse_connect") as cc:
+        logger = _disabled_logger()
+        cc.get_client.assert_not_called()
+    assert logger.client is None
+
+
+def test_ensure_client_does_not_retry_when_disabled():
+    logger = _disabled_logger()
+    with patch("app.services.clickhouse_logger.clickhouse_connect") as cc:
+        with patch("app.services.clickhouse_logger.settings") as s:
+            s.clickhouse_host = ""
+            assert logger._ensure_client() is False
+            assert logger._ensure_client() is False
+        cc.get_client.assert_not_called()
+
+
+def test_query_logs_returns_empty_when_disabled():
+    import asyncio
+
+    logger = _disabled_logger()
+    with patch("app.services.clickhouse_logger.settings") as s:
+        s.clickhouse_host = ""
+        rows = asyncio.run(logger.query_logs())
+    assert rows == []

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -63,6 +63,7 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
   value: "postgresql://{{ .Values.postgres.user }}:$(DATABASE_PASSWORD)@pgbouncer:5432/{{ .Values.postgres.database }}"
 - name: DATABASE_DIRECT_HOST
   value: postgres
+{{- if .Values.clickhouse.enabled }}
 - name: CLICKHOUSE_HOST
   value: clickhouse
 - name: CLICKHOUSE_PORT
@@ -71,6 +72,12 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
   value: {{ .Values.clickhouse.user | quote }}
 - name: CLICKHOUSE_DATABASE
   value: {{ .Values.clickhouse.database | quote }}
+{{- else }}
+## Empty host = explicit disable: the backend skips ClickHouse entirely
+## (no connection retries, logging methods no-op, log queries return empty).
+- name: CLICKHOUSE_HOST
+  value: ""
+{{- end }}
 - name: REDIS_URL
   value: "redis://redis:6379/0"
 - name: BUILDER_URL
@@ -105,11 +112,13 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
     secretKeyRef:
       name: {{ .Release.Name }}-secrets
       key: encryption-key
+{{- if .Values.clickhouse.enabled }}
 - name: CLICKHOUSE_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .Release.Name }}-secrets
       key: clickhouse-password
+{{- end }}
 - name: BACKEND_PORT
   value: "8000"
 {{- with .Values.extraEnv }}

--- a/charts/sinas/templates/clickhouse.yaml
+++ b/charts/sinas/templates/clickhouse.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clickhouse.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -234,3 +235,4 @@ spec:
     - name: native
       port: 9000
       targetPort: 9000
+{{- end }}

--- a/charts/sinas/templates/secret.yaml
+++ b/charts/sinas/templates/secret.yaml
@@ -9,7 +9,9 @@ stringData:
   secret-key: {{ .Values.secrets.secretKey | quote }}
   encryption-key: {{ .Values.secrets.encryptionKey | quote }}
   database-password: {{ .Values.postgres.password | quote }}
+  {{- if .Values.clickhouse.enabled }}
   clickhouse-password: {{ .Values.clickhouse.password | quote }}
+  {{- end }}
   smtp-password: {{ .Values.smtp.password | quote }}
 {{- if and .Values.registry .Values.registry.username }}
 ---

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -66,6 +66,9 @@ redis:
 
 ## ClickHouse
 clickhouse:
+  ## Set false for the compact profile: no ClickHouse pod, request/execution
+  ## logging off, log UI empty. Everything else works normally.
+  enabled: true
   user: default
   password: ""
   database: sinas

--- a/docs-mint/getting-started/kubernetes.mdx
+++ b/docs-mint/getting-started/kubernetes.mdx
@@ -131,6 +131,51 @@ namespace — so they compete with the platform's own pods for any namespace
 The chart's per-component `resources` are values — override any of them
 per deployment.
 
+## Compact profile (density deployments)
+
+For packing several small instances onto one box (e.g. **3 instances on a
+4GB node**), drop ClickHouse and size requests near measured idle usage
+(backend idles ~175MB, workers ~90–120MB):
+
+```yaml
+# compact-values.yaml — ≈650–750MB per instance at idle
+clickhouse:
+  enabled: false          # no ClickHouse pod; request/execution log UI stays empty
+
+backend:
+  resources:
+    requests: { cpu: "200m", memory: "224Mi" }
+    limits:   { cpu: "1",    memory: "768Mi" }
+queueWorker:
+  replicas: 1
+  concurrency: 4          # bounds simultaneous executions (and sandbox pods)
+  resources:
+    requests: { cpu: "100m", memory: "128Mi" }
+    limits:   { cpu: "500m", memory: "512Mi" }   # = shared_pool burst envelope
+queueAgent:
+  replicas: 1
+  concurrency: 2
+  resources:
+    requests: { cpu: "100m", memory: "160Mi" }
+    limits:   { cpu: "500m", memory: "512Mi" }
+
+extraEnv:
+  - name: MAX_FUNCTION_MEMORY   # sandbox pod request=limit, MiB
+    value: "192"
+  - name: MAX_FUNCTION_CPU
+    value: "0.5"
+```
+
+The math for 3 × on a 4GB node: 3 instances × ~700MB ≈ 2.1GB, k3s host
+overhead ~0.7GB → ~2.8GB idle, leaving ~700MB shared burst headroom — enough
+for a few concurrent 192Mi sandbox pods across tenants. Keep
+`queueWorker.concurrency` low so tenants can't burst past it, or set
+`SANDBOX_EXECUTOR=disabled` for trusted-only tiers.
+
+With `clickhouse.enabled: false` the backend detects the empty
+`CLICKHOUSE_HOST` and disables logging cleanly (no reconnect attempts); the
+Logs pages return empty results.
+
 ## Key values
 
 | Value | Default | Description |


### PR DESCRIPTION
Enables the density story from the footprint plan — 3 small instances on a 4GB node:

- **`clickhouse.enabled` toggle** (default `true`, zero change for existing deployments). Disabled: no ClickHouse objects render, and the backend gets `CLICKHOUSE_HOST=""` as an explicit disable — the logger now skips connection retries entirely (no per-request error spam), logging no-ops, log queries return empty. 3 unit tests.
- **Compact profile docs**: values example sized from the measured idle numbers, with the 3×4GB math and the inprocess burst-envelope caveat.
- **Helm CI**: lint + template of both profiles on chart changes — closes the last Phase-0 gate item.

Verified: helm lint clean; default profile renders ClickHouse, compact renders none and carries the empty-host signal; disabled-logger tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)