### PR TITLE
feat(webhooks): native agent targets and raw response mode

### DIFF
--- a/backend/alembic/versions/w2a3b4t5g6t7_webhook_agent_targets.py
+++ b/backend/alembic/versions/w2a3b4t5g6t7_webhook_agent_targets.py
@@ -1,0 +1,36 @@
+"""add agent targets and raw response mode to webhooks
+
+Revision ID: w2a3b4t5g6t7
+Revises: c1a2c3h4e5t6
+Create Date: 2026-07-27
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "w2a3b4t5g6t7"
+down_revision = "c1a2c3h4e5t6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "webhooks",
+        sa.Column("target_type", sa.String(10), nullable=False, server_default="function"),
+    )
+    op.add_column("webhooks", sa.Column("agent_namespace", sa.String(255), nullable=True))
+    op.add_column("webhooks", sa.Column("agent_name", sa.String(255), nullable=True))
+    op.add_column("webhooks", sa.Column("message_template", sa.Text, nullable=True))
+    op.add_column("webhooks", sa.Column("session_key_template", sa.String(500), nullable=True))
+    # function_name is no longer required (agent-target webhooks have no function)
+    op.alter_column("webhooks", "function_name", existing_type=sa.String(255), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("webhooks", "function_name", existing_type=sa.String(255), nullable=False)
+    op.drop_column("webhooks", "session_key_template")
+    op.drop_column("webhooks", "message_template")
+    op.drop_column("webhooks", "agent_name")
+    op.drop_column("webhooks", "agent_namespace")
+    op.drop_column("webhooks", "target_type")

--- a/backend/alembic/versions/w2a3b4t5g6t7_webhook_agent_targets.py
+++ b/backend/alembic/versions/w2a3b4t5g6t7_webhook_agent_targets.py
@@ -28,6 +28,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Agent-target rows have function_name NULL by design, so restoring NOT NULL
+    # would abort on them (and, where DDL isn't transactional, leave the schema
+    # half-reverted). They have no meaning without the agent columns being
+    # dropped below, so remove them first.
+    op.execute("DELETE FROM webhooks WHERE target_type = 'agent'")
     op.alter_column("webhooks", "function_name", existing_type=sa.String(255), nullable=False)
     op.drop_column("webhooks", "session_key_template")
     op.drop_column("webhooks", "message_template")

--- a/backend/alembic/versions/w2a3b4t5g6t7_webhook_agent_targets.py
+++ b/backend/alembic/versions/w2a3b4t5g6t7_webhook_agent_targets.py
@@ -1,7 +1,7 @@
 """add agent targets and raw response mode to webhooks
 
 Revision ID: w2a3b4t5g6t7
-Revises: c1a2c3h4e5t6
+Revises: 70ea30af567e
 Create Date: 2026-07-27
 """
 import sqlalchemy as sa
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "w2a3b4t5g6t7"
-down_revision = "c1a2c3h4e5t6"
+down_revision = "70ea30af567e"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/runtime/endpoints/webhooks.py
+++ b/backend/app/api/runtime/endpoints/webhooks.py
@@ -39,7 +39,13 @@ def _build_raw_response(result: Any) -> tuple[Response, dict[str, Any]]:
 
     if isinstance(result, dict) and any(k in result for k in RAW_CONTROL_KEYS):
         raw_status = result.get("_status", 200)
-        status = raw_status if isinstance(raw_status, int) else 200
+        # `isinstance(True, int)` is True in Python, so a bool would slip through
+        # and become status 1. Range-check as well — an out-of-range code raises
+        # inside Starlette, after the handler has returned.
+        if isinstance(raw_status, int) and not isinstance(raw_status, bool) and 100 <= raw_status <= 599:
+            status = raw_status
+        else:
+            status = 200
         raw_headers = result.get("_headers")
         if isinstance(raw_headers, dict):
             headers = {str(k): str(v) for k, v in raw_headers.items()}
@@ -47,9 +53,21 @@ def _build_raw_response(result: Any) -> tuple[Response, dict[str, Any]]:
 
     cache_entry = {"__raw__": {"status": status, "headers": headers, "body": body}}
 
+    return _raw_response(status, headers, body), cache_entry
+
+
+def _raw_response(status: int, headers: dict[str, str], body: Any) -> Response:
+    """Build the response, honouring status codes that must not carry a body.
+
+    204/304 (and 1xx) are body-less per RFC 9110; emitting one makes h11 raise a
+    protocol error *after* the handler returns, so the client sees a truncated
+    response instead of the status the function asked for.
+    """
+    if status in (204, 304) or 100 <= status < 200:
+        return Response(status_code=status, headers=headers)
     if isinstance(body, str):
-        return PlainTextResponse(body, status_code=status, headers=headers), cache_entry
-    return JSONResponse(body, status_code=status, headers=headers), cache_entry
+        return PlainTextResponse(body, status_code=status, headers=headers)
+    return JSONResponse(body, status_code=status, headers=headers)
 
 
 def _replay_cached(cached: str) -> Response:
@@ -57,12 +75,7 @@ def _replay_cached(cached: str) -> Response:
     parsed = json.loads(cached)
     if isinstance(parsed, dict) and "__raw__" in parsed:
         raw = parsed["__raw__"]
-        body = raw.get("body")
-        status = raw.get("status", 200)
-        headers = raw.get("headers") or {}
-        if isinstance(body, str):
-            return PlainTextResponse(body, status_code=status, headers=headers)
-        return JSONResponse(body, status_code=status, headers=headers)
+        return _raw_response(raw.get("status", 200), raw.get("headers") or {}, raw.get("body"))
     return JSONResponse(parsed, status_code=200)
 
 
@@ -81,8 +94,11 @@ async def _execute_agent_webhook(
     from app.models.chat import Chat
     from app.models.user import User
     from app.services.message_service import MessageService
-    from app.services.template_renderer import render_webhook_template
+    from app.services.template_renderer import render_webhook_template_checked
 
+    # Not scoped by user_id: agents are shared by design (`chat:all` and
+    # `read:all` are default grants), unlike functions. Reachability is enforced
+    # by the permission check below, not by an ownership filter.
     agent_namespace = webhook.agent_namespace or "default"
     agent = await Agent.get_by_name(db, agent_namespace, webhook.agent_name)
     if not agent:
@@ -93,23 +109,65 @@ async def _execute_agent_webhook(
 
     # Render templates against the request payload (defaults merged in)
     context = final_input if isinstance(final_input, dict) else {"input": final_input}
-    message = render_webhook_template(webhook.message_template or "", context).strip()
-    if not message:
+    message, msg_had_undefined = render_webhook_template_checked(
+        webhook.message_template or "", context
+    )
+    message = message.strip()
+    # Fall back on a PARTIAL render too, not just an empty one: 'New issue {{a}}:
+    # {{b}}' against an unexpected payload renders 'New issue :' — non-empty, but
+    # it would invoke (and bill) the agent with no information about the event.
+    if not message or msg_had_undefined:
         logger.warning(
-            "Webhook %s: message template rendered empty, falling back to raw payload",
+            "Webhook %s: message template did not fully render (empty=%s, undefined=%s); "
+            "falling back to raw payload",
             webhook.path,
+            not message,
+            msg_had_undefined,
         )
         message = json.dumps(context)
 
     session_key: Optional[str] = None
     if webhook.session_key_template:
-        session_key = render_webhook_template(webhook.session_key_template, context).strip() or None
+        rendered_key, key_had_undefined = render_webhook_template_checked(
+            webhook.session_key_template, context
+        )
+        # A partially-rendered key ('jira-') would be shared by every malformed
+        # delivery, merging unrelated events into one conversation. Treat it as
+        # no key at all so each such request gets a fresh chat.
+        if key_had_undefined:
+            logger.warning(
+                "Webhook %s: session key template had undefined variables; "
+                "using a fresh session for this request",
+                webhook.path,
+            )
+            session_key = None
+        else:
+            session_key = rendered_key.strip() or None
 
-    # Look up user (needed for the JWT the agent runs with)
+    # Look up user (needed for the JWT the agent runs with).
+    # `is_active` matters as much as existence: a soft-deleted user still has a
+    # row, and every other auth path rejects them (core/auth.py). Without this a
+    # deactivated user's public webhook would keep firing and keep minting tokens
+    # for them, re-opening the access that deleting them was supposed to revoke.
     result = await db.execute(select(User).where(User.id == uuid.UUID(user_id)))
     user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(status_code=500, detail="Webhook user not found")
+    if not user or not user.is_active:
+        raise HTTPException(status_code=403, detail="Webhook owner is no longer active")
+
+    # Re-check the owner's access to the target on every request. Permissions
+    # granted at creation can be narrowed later, and an unauthenticated webhook
+    # performs no caller-side permission check at all — so without this, a
+    # long-lived public endpoint would keep running on revoked authority.
+    from app.core.auth import get_user_permissions
+
+    owner_permissions = await get_user_permissions(db, user_id)
+    chat_perm = f"sinas.agents/{agent_namespace}/{webhook.agent_name}.chat:all"
+    if not check_permission(owner_permissions, chat_perm):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Webhook owner is no longer authorized to chat with agent '{agent_namespace}/{webhook.agent_name}'",
+        )
+
     token = create_access_token(user_id=user_id, email=user.email)
 
     # Resolve or create the chat (session-key continuity, like agent invoke)
@@ -252,30 +310,40 @@ async def execute_webhook(
                 db=db,
             )
 
-            # Check permission on the target resource
+            # Triggering a webhook runs as the webhook's OWNER (their token, their
+            # tools, their secrets), so the question is "may this caller trigger
+            # this webhook?" — not "may this caller use the target resource?".
+            # Answering the latter is unsafe: `sinas.agents/*/*.chat:all` is a
+            # default grant for every user, so a target-permission check would
+            # let any authenticated user drive someone else's webhook as them.
+            # Ownership is therefore required unconditionally.
+            if str(webhook.user_id) != user_id:
+                set_permission_used(request, f"webhook.execute:own:{webhook.path}", has_perm=False)
+                raise HTTPException(
+                    status_code=403, detail=f"Not authorized to execute webhook '{path}'"
+                )
+
+            # Defence in depth: the caller is the owner, but their access to the
+            # target may have been narrowed since the webhook was created, so the
+            # target permission is re-checked on every request rather than trusted
+            # from creation time.
             if is_agent_target:
                 target_perm = (
-                    f"sinas.agents/{webhook.agent_namespace}/{webhook.agent_name}.chat:own"
-                )
-                target_perm_all = (
                     f"sinas.agents/{webhook.agent_namespace}/{webhook.agent_name}.chat:all"
                 )
             else:
                 target_perm = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:own"
                 target_perm_all = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:all"
+                if check_permission(permissions, target_perm_all):
+                    target_perm = target_perm_all
 
-            has_permission = check_permission(permissions, target_perm_all) or (
-                check_permission(permissions, target_perm) and str(webhook.user_id) == user_id
-            )
-
-            if not has_permission:
+            if not check_permission(permissions, target_perm):
                 set_permission_used(request, target_perm, has_perm=False)
-                raise HTTPException(status_code=403, detail=f"Not authorized to execute webhook '{path}'")
+                raise HTTPException(
+                    status_code=403, detail=f"Not authorized to execute webhook '{path}'"
+                )
 
-            set_permission_used(
-                request,
-                target_perm_all if check_permission(permissions, target_perm_all) else target_perm,
-            )
+            set_permission_used(request, target_perm)
         except HTTPException:
             raise
         except Exception as e:
@@ -316,6 +384,17 @@ async def execute_webhook(
             if is_dup:
                 if cached:
                     return _replay_cached(cached)
+                # Duplicate arrived before the original finished (or the mode
+                # never caches: the async agent path stores no result). A JSON
+                # envelope would be wrong for the two modes that exist to
+                # control their own response — raw mode owes the provider a
+                # verbatim body (Slack's url_verification handshake fails
+                # otherwise), and async owes a 202. Answer in the shape the
+                # mode promises.
+                if webhook.response_mode == "raw":
+                    return Response(status_code=204)
+                if is_agent_target and webhook.response_mode == "async":
+                    return JSONResponse({"deduplicated": True}, status_code=202)
                 return JSONResponse({"deduplicated": True}, status_code=200)
 
         # Agent target

--- a/backend/app/api/runtime/endpoints/webhooks.py
+++ b/backend/app/api/runtime/endpoints/webhooks.py
@@ -152,7 +152,9 @@ async def _execute_agent_webhook(
             content=message,
             channel_id=str(uuid.uuid4()),
             agent=f"{agent.namespace}/{agent.name}",
-            trigger_type=TriggerType.WEBHOOK.value,
+            # Agent-message jobs use lowercase trigger labels (cf. scheduler's
+            # "schedule"), unlike TriggerType enum values used for functions
+            trigger_type="webhook",
             job_timeout=agent.default_job_timeout,
         )
         return JSONResponse({"chat_id": chat_id, "job_id": job_id}, status_code=202)

--- a/backend/app/api/runtime/endpoints/webhooks.py
+++ b/backend/app/api/runtime/endpoints/webhooks.py
@@ -1,10 +1,12 @@
-"""Runtime webhook endpoints - execute functions via HTTP."""
+"""Runtime webhook endpoints - execute functions or agents via HTTP."""
+import asyncio
 import json
+import logging
 import uuid
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,9 +18,181 @@ from app.models.webhook import Webhook
 from app.services.dedup_service import check_and_mark, store_result
 from app.services.queue_service import queue_service
 
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Reserved keys for the raw response-control convention:
+# a function may return {"_status": 200, "_headers": {...}, "_body": ...}
+RAW_CONTROL_KEYS = ("_status", "_headers", "_body")
+
+
+def _build_raw_response(result: Any) -> tuple[Response, dict[str, Any]]:
+    """Build the HTTP response for a raw-mode webhook from a function result.
+
+    Returns (response, cache_entry) where cache_entry is the JSON-serializable
+    form used for dedup replay.
+    """
+    status = 200
+    headers: dict[str, str] = {}
+    body = result
+
+    if isinstance(result, dict) and any(k in result for k in RAW_CONTROL_KEYS):
+        raw_status = result.get("_status", 200)
+        status = raw_status if isinstance(raw_status, int) else 200
+        raw_headers = result.get("_headers")
+        if isinstance(raw_headers, dict):
+            headers = {str(k): str(v) for k, v in raw_headers.items()}
+        body = result.get("_body")
+
+    cache_entry = {"__raw__": {"status": status, "headers": headers, "body": body}}
+
+    if isinstance(body, str):
+        return PlainTextResponse(body, status_code=status, headers=headers), cache_entry
+    return JSONResponse(body, status_code=status, headers=headers), cache_entry
+
+
+def _replay_cached(cached: str) -> Response:
+    """Rebuild the HTTP response for a deduplicated request from the cache."""
+    parsed = json.loads(cached)
+    if isinstance(parsed, dict) and "__raw__" in parsed:
+        raw = parsed["__raw__"]
+        body = raw.get("body")
+        status = raw.get("status", 200)
+        headers = raw.get("headers") or {}
+        if isinstance(body, str):
+            return PlainTextResponse(body, status_code=status, headers=headers)
+        return JSONResponse(body, status_code=status, headers=headers)
+    return JSONResponse(parsed, status_code=200)
+
+
+async def _execute_agent_webhook(
+    webhook: Webhook,
+    db: AsyncSession,
+    user_id: str,
+    final_input: Any,
+    req_headers: dict[str, str],
+):
+    """Execute an agent-target webhook: render templates, resolve the chat by
+    session key, and either enqueue (async) or wait for the reply (sync)."""
+    from app.core.auth import create_access_token
+    from app.core.config import settings
+    from app.models.agent import Agent
+    from app.models.chat import Chat
+    from app.models.user import User
+    from app.services.message_service import MessageService
+    from app.services.template_renderer import render_webhook_template
+
+    agent_namespace = webhook.agent_namespace or "default"
+    agent = await Agent.get_by_name(db, agent_namespace, webhook.agent_name)
+    if not agent:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Webhook target agent '{agent_namespace}/{webhook.agent_name}' not found",
+        )
+
+    # Render templates against the request payload (defaults merged in)
+    context = final_input if isinstance(final_input, dict) else {"input": final_input}
+    message = render_webhook_template(webhook.message_template or "", context).strip()
+    if not message:
+        logger.warning(
+            "Webhook %s: message template rendered empty, falling back to raw payload",
+            webhook.path,
+        )
+        message = json.dumps(context)
+
+    session_key: Optional[str] = None
+    if webhook.session_key_template:
+        session_key = render_webhook_template(webhook.session_key_template, context).strip() or None
+
+    # Look up user (needed for the JWT the agent runs with)
+    result = await db.execute(select(User).where(User.id == uuid.UUID(user_id)))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=500, detail="Webhook user not found")
+    token = create_access_token(user_id=user_id, email=user.email)
+
+    # Resolve or create the chat (session-key continuity, like agent invoke)
+    chat = None
+    if session_key:
+        result = await db.execute(
+            select(Chat).where(
+                Chat.agent_id == agent.id,
+                Chat.session_key == session_key,
+                Chat.archived == False,
+            )
+        )
+        chat = result.scalar_one_or_none()
+        if chat and str(chat.user_id) != user_id:
+            raise HTTPException(status_code=403, detail="Not authorized to use this session")
+
+    if not chat:
+        chat = Chat(
+            user_id=user_id,
+            agent_id=agent.id,
+            agent_namespace=agent.namespace,
+            agent_name=agent.name,
+            title=f"webhook:{webhook.path}",
+            session_key=session_key,
+            job_timeout=agent.default_job_timeout,
+        )
+        db.add(chat)
+        await db.flush()
+        await db.refresh(chat)
+
+    chat_id = str(chat.id)
+
+    # Async mode: commit the chat so the queue worker can see it, then enqueue
+    if webhook.response_mode == "async":
+        await db.commit()
+        job_id = await queue_service.enqueue_agent_message(
+            chat_id=chat_id,
+            user_id=user_id,
+            user_token=token,
+            content=message,
+            channel_id=str(uuid.uuid4()),
+            agent=f"{agent.namespace}/{agent.name}",
+            trigger_type=TriggerType.WEBHOOK.value,
+            job_timeout=agent.default_job_timeout,
+        )
+        return JSONResponse({"chat_id": chat_id, "job_id": job_id}, status_code=202)
+
+    # Sync mode: run inline and wait for the reply (same as agent invoke)
+    message_service = MessageService(db)
+    timeout = agent.default_job_timeout or settings.function_timeout or 300
+    try:
+        response_message = await asyncio.wait_for(
+            message_service.send_message(
+                chat_id=chat_id,
+                user_id=user_id,
+                user_token=token,
+                content=message,
+            ),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="Agent execution timed out")
+
+    response = {
+        "success": True,
+        "chat_id": chat_id,
+        "reply": response_message.content or "",
+    }
+
+    # Cache result for dedup
+    if webhook.dedup:
+        try:
+            await store_result(
+                webhook_id=str(webhook.id),
+                body=final_input if isinstance(final_input, dict) else {},
+                headers=req_headers,
+                dedup_config=webhook.dedup,
+                result=json.dumps(response),
+            )
+        except Exception:
+            pass  # Non-critical
+
+    return response
 
 
 @router.api_route(
@@ -30,7 +204,7 @@ async def execute_webhook(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
-    """Execute webhook by triggering associated function."""
+    """Execute webhook by triggering the associated function or agent."""
     # Look up webhook configuration
     result = await db.execute(
         select(Webhook).where(
@@ -48,6 +222,8 @@ async def execute_webhook(
             status_code=404,
             detail=f"No active webhook found for path '{path}' and method '{request.method}'",
         )
+
+    is_agent_target = webhook.target_type == "agent"
 
     # Authenticate if required
     user_id: Optional[str] = None
@@ -74,21 +250,29 @@ async def execute_webhook(
                 db=db,
             )
 
-            # Check function execute permission
-            function_perm = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:own"
-            function_perm_all = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:all"
+            # Check permission on the target resource
+            if is_agent_target:
+                target_perm = (
+                    f"sinas.agents/{webhook.agent_namespace}/{webhook.agent_name}.chat:own"
+                )
+                target_perm_all = (
+                    f"sinas.agents/{webhook.agent_namespace}/{webhook.agent_name}.chat:all"
+                )
+            else:
+                target_perm = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:own"
+                target_perm_all = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:all"
 
-            has_permission = check_permission(permissions, function_perm_all) or (
-                check_permission(permissions, function_perm) and str(webhook.user_id) == user_id
+            has_permission = check_permission(permissions, target_perm_all) or (
+                check_permission(permissions, target_perm) and str(webhook.user_id) == user_id
             )
 
             if not has_permission:
-                set_permission_used(request, function_perm, has_perm=False)
+                set_permission_used(request, target_perm, has_perm=False)
                 raise HTTPException(status_code=403, detail=f"Not authorized to execute webhook '{path}'")
 
             set_permission_used(
                 request,
-                function_perm_all if check_permission(permissions, function_perm_all) else function_perm,
+                target_perm_all if check_permission(permissions, target_perm_all) else target_perm,
             )
         except HTTPException:
             raise
@@ -100,7 +284,7 @@ async def execute_webhook(
         set_permission_used(request, f"webhook.public:{webhook.path}")
 
     try:
-        # Extract the request body as function input
+        # Extract the request body as input
         content_type = request.headers.get("content-type", "")
         if "application/json" in content_type:
             try:
@@ -118,9 +302,9 @@ async def execute_webhook(
         else:
             final_input = input_data
 
-        # Deduplication check
+        # Deduplication check (identical for function and agent targets)
+        req_headers = dict(request.headers)
         if webhook.dedup:
-            req_headers = dict(request.headers)
             is_dup, cached = await check_and_mark(
                 webhook_id=str(webhook.id),
                 body=final_input if isinstance(final_input, dict) else {},
@@ -129,9 +313,20 @@ async def execute_webhook(
             )
             if is_dup:
                 if cached:
-                    return JSONResponse(json.loads(cached), status_code=200)
+                    return _replay_cached(cached)
                 return JSONResponse({"deduplicated": True}, status_code=200)
 
+        # Agent target
+        if is_agent_target:
+            return await _execute_agent_webhook(
+                webhook=webhook,
+                db=db,
+                user_id=user_id,
+                final_input=final_input,
+                req_headers=req_headers,
+            )
+
+        # Function target
         execution_id = str(uuid.uuid4())
         chat_id = request.headers.get("x-chat-id")
 
@@ -149,7 +344,7 @@ async def execute_webhook(
             )
             return JSONResponse({"execution_id": execution_id}, status_code=202)
 
-        # Sync mode (default): wait for result
+        # Sync and raw modes: wait for result
         result = await queue_service.enqueue_and_wait(
             function_namespace=webhook.function_namespace,
             function_name=webhook.function_name,
@@ -161,12 +356,28 @@ async def execute_webhook(
             chat_id=chat_id,
         )
 
+        # Raw mode: the function's return value IS the response body
+        if webhook.response_mode == "raw":
+            raw_response, cache_entry = _build_raw_response(result)
+            if webhook.dedup:
+                try:
+                    await store_result(
+                        webhook_id=str(webhook.id),
+                        body=final_input if isinstance(final_input, dict) else {},
+                        headers=req_headers,
+                        dedup_config=webhook.dedup,
+                        result=json.dumps(cache_entry),
+                    )
+                except Exception:
+                    pass  # Non-critical
+            return raw_response
+
+        # Sync mode (default): wrap in the standard envelope
         response = {"success": True, "execution_id": execution_id, "result": result}
 
         # Cache result for dedup
         if webhook.dedup:
             try:
-                req_headers = dict(request.headers)
                 await store_result(
                     webhook_id=str(webhook.id),
                     body=final_input if isinstance(final_input, dict) else {},
@@ -179,5 +390,7 @@ async def execute_webhook(
 
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Function execution failed: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Webhook execution failed: {str(e)}")

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
 from app.core.permissions import check_permission
+from app.models.agent import Agent
 from app.models.function import Function
 from app.models.webhook import Webhook
 from app.schemas import WebhookCreate, WebhookResponse, WebhookUpdate
@@ -41,21 +42,34 @@ async def create_webhook(
             status_code=400, detail=f"Webhook path '{webhook_data.path}' already exists"
         )
 
-    # Verify function exists
-    function = await Function.get_by_name(
-        db, webhook_data.function_namespace, webhook_data.function_name, user_id
-    )
-    if not function:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Function '{webhook_data.function_namespace}.{webhook_data.function_name}' not found",
+    # Verify the target resource exists
+    if webhook_data.target_type == "function":
+        function = await Function.get_by_name(
+            db, webhook_data.function_namespace, webhook_data.function_name, user_id
         )
+        if not function:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Function '{webhook_data.function_namespace}.{webhook_data.function_name}' not found",
+            )
+    else:
+        agent = await Agent.get_by_name(db, webhook_data.agent_namespace, webhook_data.agent_name)
+        if not agent:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Agent '{webhook_data.agent_namespace}/{webhook_data.agent_name}' not found",
+            )
     # Create webhook
     webhook = Webhook(
         user_id=user_id,
         path=webhook_data.path,
+        target_type=webhook_data.target_type,
         function_namespace=webhook_data.function_namespace,
         function_name=webhook_data.function_name,
+        agent_namespace=webhook_data.agent_namespace if webhook_data.target_type == "agent" else None,
+        agent_name=webhook_data.agent_name,
+        message_template=webhook_data.message_template,
+        session_key_template=webhook_data.session_key_template,
         http_method=webhook_data.http_method,
         description=webhook_data.description,
         default_values=webhook_data.default_values or {},
@@ -156,6 +170,9 @@ async def update_webhook(
     detach_if_package_managed(webhook)
 
     # Update fields
+    if webhook_data.target_type is not None:
+        webhook.target_type = webhook_data.target_type
+
     if webhook_data.function_namespace is not None or webhook_data.function_name is not None:
         # Use updated namespace or keep existing
         new_namespace = (
@@ -187,6 +204,32 @@ async def update_webhook(
         webhook.function_namespace = new_namespace
         webhook.function_name = new_function_name
 
+    if webhook_data.agent_namespace is not None or webhook_data.agent_name is not None:
+        new_agent_namespace = (
+            webhook_data.agent_namespace
+            if webhook_data.agent_namespace is not None
+            else (webhook.agent_namespace or "default")
+        )
+        new_agent_name = (
+            webhook_data.agent_name if webhook_data.agent_name is not None else webhook.agent_name
+        )
+
+        # Verify new agent exists
+        agent = await Agent.get_by_name(db, new_agent_namespace, new_agent_name)
+        if not agent:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Agent '{new_agent_namespace}/{new_agent_name}' not found",
+            )
+
+        webhook.agent_namespace = new_agent_namespace
+        webhook.agent_name = new_agent_name
+
+    if webhook_data.message_template is not None:
+        webhook.message_template = webhook_data.message_template
+    if webhook_data.session_key_template is not None:
+        webhook.session_key_template = webhook_data.session_key_template
+
     if webhook_data.http_method is not None:
         webhook.http_method = webhook_data.http_method
     if webhook_data.description is not None:
@@ -201,6 +244,27 @@ async def update_webhook(
         webhook.response_mode = webhook_data.response_mode
     if webhook_data.dedup is not None:
         webhook.dedup = webhook_data.dedup.model_dump()
+
+    # Validate resulting target configuration
+    if webhook.target_type == "function":
+        if not webhook.function_name:
+            raise HTTPException(
+                status_code=400, detail="function_name is required for function-target webhooks"
+            )
+        if webhook.response_mode not in ("sync", "async", "raw"):
+            raise HTTPException(status_code=400, detail="Invalid response_mode")
+    else:
+        if not webhook.agent_name or not webhook.message_template:
+            raise HTTPException(
+                status_code=400,
+                detail="agent_name and message_template are required for agent-target webhooks",
+            )
+        if webhook.response_mode == "raw":
+            raise HTTPException(
+                status_code=400,
+                detail="response_mode 'raw' is only supported for function-target webhooks",
+            )
+
     await db.flush()
     await db.refresh(webhook)
 

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -53,11 +53,29 @@ async def create_webhook(
                 detail=f"Function '{webhook_data.function_namespace}.{webhook_data.function_name}' not found",
             )
     else:
-        agent = await Agent.get_by_name(db, webhook_data.agent_namespace, webhook_data.agent_name)
+        # Agents are shared by design (chat:all/read:all are default grants), so
+        # the lookup is intentionally not ownership-scoped — the permission check
+        # below is what authorizes the target.
+        agent = await Agent.get_by_name(
+            db, webhook_data.agent_namespace, webhook_data.agent_name
+        )
         if not agent:
             raise HTTPException(
                 status_code=404,
                 detail=f"Agent '{webhook_data.agent_namespace}/{webhook_data.agent_name}' not found",
+            )
+        # Fail fast if the creator can't chat with the target: a webhook they
+        # could never legitimately trigger shouldn't be creatable. This mirrors
+        # POST /agents/{ns}/{name}/invoke. The authoritative check is at
+        # execution time (permissions can be narrowed after creation).
+        _chat_perm = (
+            f"sinas.agents/{webhook_data.agent_namespace}/{webhook_data.agent_name}.chat:all"
+        )
+        if not check_permission(permissions, _chat_perm):
+            set_permission_used(request, _chat_perm, has_perm=False)
+            raise HTTPException(
+                status_code=403,
+                detail=f"Not authorized to chat with agent '{webhook_data.agent_namespace}/{webhook_data.agent_name}'",
             )
     # Create webhook
     webhook = Webhook(
@@ -214,21 +232,36 @@ async def update_webhook(
             webhook_data.agent_name if webhook_data.agent_name is not None else webhook.agent_name
         )
 
-        # Verify new agent exists
+        # Verify the new agent exists; reachability is enforced by the permission
+        # check below rather than an ownership filter (agents are shared by design).
         agent = await Agent.get_by_name(db, new_agent_namespace, new_agent_name)
         if not agent:
             raise HTTPException(
                 status_code=404,
                 detail=f"Agent '{new_agent_namespace}/{new_agent_name}' not found",
             )
+        _chat_perm = f"sinas.agents/{new_agent_namespace}/{new_agent_name}.chat:all"
+        if not check_permission(permissions, _chat_perm):
+            set_permission_used(request, _chat_perm, has_perm=False)
+            raise HTTPException(
+                status_code=403,
+                detail=f"Not authorized to chat with agent '{new_agent_namespace}/{new_agent_name}'",
+            )
 
         webhook.agent_namespace = new_agent_namespace
         webhook.agent_name = new_agent_name
 
+    # `is not None` can't express "clear this field" — for optional fields that
+    # a user can legitimately unset, distinguish "absent from the request" from
+    # "explicitly sent as null" via the fields actually provided. Without this,
+    # clearing a session key or turning dedup off was a silent no-op that still
+    # reported success.
+    provided = webhook_data.model_fields_set
+
     if webhook_data.message_template is not None:
         webhook.message_template = webhook_data.message_template
-    if webhook_data.session_key_template is not None:
-        webhook.session_key_template = webhook_data.session_key_template
+    if "session_key_template" in provided:
+        webhook.session_key_template = webhook_data.session_key_template or None
 
     if webhook_data.http_method is not None:
         webhook.http_method = webhook_data.http_method
@@ -242,8 +275,8 @@ async def update_webhook(
         webhook.requires_auth = webhook_data.requires_auth
     if webhook_data.response_mode is not None:
         webhook.response_mode = webhook_data.response_mode
-    if webhook_data.dedup is not None:
-        webhook.dedup = webhook_data.dedup.model_dump()
+    if "dedup" in provided:
+        webhook.dedup = webhook_data.dedup.model_dump() if webhook_data.dedup else None
 
     # Validate resulting target configuration
     if webhook.target_type == "function":

--- a/backend/app/models/webhook.py
+++ b/backend/app/models/webhook.py
@@ -24,8 +24,17 @@ class Webhook(Base):
     id: Mapped[uuid_pk]
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     path: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    # Target: "function" (default) or "agent"
+    target_type: Mapped[str] = mapped_column(
+        String(10), default="function", server_default="function", nullable=False
+    )
     function_namespace: Mapped[str] = mapped_column(String(255), nullable=False, default="default")
-    function_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    function_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Agent target fields (target_type == "agent")
+    agent_namespace: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    agent_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    message_template: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    session_key_template: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     http_method: Mapped[HTTPMethod] = mapped_column(
         Enum(HTTPMethod), default=HTTPMethod.POST, nullable=False
     )

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -227,13 +227,36 @@ class WebhookConfig(BaseModel):
     """Webhook configuration"""
 
     path: str
-    functionName: str
+    targetType: str = "function"  # "function" or "agent"
+    functionName: Optional[str] = None  # for function targets ("namespace/name" or "name")
+    agentName: Optional[str] = None  # for agent targets (namespace/name)
+    messageTemplate: Optional[str] = None  # Jinja2, rendered against the request payload
+    sessionKeyTemplate: Optional[str] = None  # Jinja2, optional conversation continuity key
     httpMethod: str = "POST"
     description: Optional[str] = None
     requiresAuth: bool = True
     defaultValues: dict[str, Any] = Field(default_factory=dict)
-    responseMode: str = "sync"
+    responseMode: str = "sync"  # "sync", "async", or "raw" (raw: function targets only)
     dedup: Optional[WebhookDedupConfig] = None
+
+    @validator("dedup", always=True)
+    def validate_target(cls, v, values):
+        target_type = values.get("targetType", "function")
+        if target_type not in ("function", "agent"):
+            raise ValueError("targetType must be 'function' or 'agent'")
+        if values.get("responseMode") not in ("sync", "async", "raw"):
+            raise ValueError("responseMode must be 'sync', 'async', or 'raw'")
+        if target_type == "function":
+            if not values.get("functionName"):
+                raise ValueError("functionName is required for function-target webhooks")
+        else:
+            if not values.get("agentName"):
+                raise ValueError("agentName is required for agent-target webhooks")
+            if not values.get("messageTemplate"):
+                raise ValueError("messageTemplate is required for agent-target webhooks")
+            if values.get("responseMode") == "raw":
+                raise ValueError("responseMode 'raw' is only supported for function-target webhooks")
+        return v
 
 
 class ScheduleConfig(BaseModel):

--- a/backend/app/schemas/webhook.py
+++ b/backend/app/schemas/webhook.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.models.webhook import HTTPMethod
 
@@ -15,35 +15,66 @@ class DedupConfig(BaseModel):
 
 class WebhookCreate(BaseModel):
     path: str = Field(..., min_length=1, max_length=255, pattern=r"^[a-zA-Z0-9_/-]+$")
+    target_type: Literal["function", "agent"] = "function"
     function_namespace: str = Field(
         default="default", min_length=1, max_length=255, pattern=r"^[a-zA-Z_][a-zA-Z0-9_]*$"
     )
-    function_name: str = Field(..., min_length=1, max_length=255)
+    function_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    agent_namespace: str = Field(
+        default="default", min_length=1, max_length=255, pattern=r"^[a-zA-Z_][a-zA-Z0-9_]*$"
+    )
+    agent_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    message_template: Optional[str] = None
+    session_key_template: Optional[str] = Field(default=None, max_length=500)
     http_method: HTTPMethod = HTTPMethod.POST
     description: Optional[str] = None
     default_values: Optional[dict[str, Any]] = None
     requires_auth: bool = True
-    response_mode: Literal["sync", "async"] = "sync"
+    response_mode: Literal["sync", "async", "raw"] = "sync"
     dedup: Optional[DedupConfig] = None
+
+    @model_validator(mode="after")
+    def validate_target(self):
+        if self.target_type == "function":
+            if not self.function_name:
+                raise ValueError("function_name is required for function-target webhooks")
+        else:  # agent
+            if not self.agent_name:
+                raise ValueError("agent_name is required for agent-target webhooks")
+            if not self.message_template:
+                raise ValueError("message_template is required for agent-target webhooks")
+            if self.response_mode == "raw":
+                raise ValueError("response_mode 'raw' is only supported for function-target webhooks")
+        return self
 
 
 class WebhookUpdate(BaseModel):
+    target_type: Optional[Literal["function", "agent"]] = None
     function_namespace: Optional[str] = None
     function_name: Optional[str] = None
+    agent_namespace: Optional[str] = None
+    agent_name: Optional[str] = None
+    message_template: Optional[str] = None
+    session_key_template: Optional[str] = None
     http_method: Optional[HTTPMethod] = None
     description: Optional[str] = None
     default_values: Optional[dict[str, Any]] = None
     is_active: Optional[bool] = None
     requires_auth: Optional[bool] = None
-    response_mode: Optional[Literal["sync", "async"]] = None
+    response_mode: Optional[Literal["sync", "async", "raw"]] = None
     dedup: Optional[DedupConfig] = None
 
 
 class WebhookResponse(BaseModel):
     id: uuid.UUID
     path: str
+    target_type: str
     function_namespace: str
-    function_name: str
+    function_name: Optional[str]
+    agent_namespace: Optional[str]
+    agent_name: Optional[str]
+    message_template: Optional[str]
+    session_key_template: Optional[str]
     http_method: HTTPMethod
     description: Optional[str]
     default_values: Optional[dict[str, Any]]

--- a/backend/app/services/config_apply/integrations.py
+++ b/backend/app/services/config_apply/integrations.py
@@ -3,7 +3,7 @@ Integration appliers: webhooks, templates, schedules, database triggers
 """
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +17,21 @@ from app.models.webhook import Webhook
 from app.services.config_apply.normalizers import should_skip_existing
 
 logger = logging.getLogger(__name__)
+
+
+
+def _dedup_storage(dedup) -> Optional[dict]:
+    """Canonical storage shape for a webhook dedup block.
+
+    The config schema field is `ttlSeconds`, but the stored blob is read by
+    dedup_service (and written by the REST schema) as `ttl_seconds`. Dumping the
+    config model verbatim stored the camelCase key, which the consumer never
+    read — every config-managed webhook silently ran on the default TTL. Emit
+    the snake_case shape so both write paths agree.
+    """
+    if not dedup:
+        return None
+    return {"key": dedup.key, "ttl_seconds": dedup.ttlSeconds}
 
 
 async def apply_webhooks(
@@ -69,7 +84,7 @@ async def apply_webhooks(
                     "requires_auth": webhook_config.requiresAuth,
                     "default_values": webhook_config.defaultValues,
                     "response_mode": webhook_config.responseMode,
-                    "dedup": webhook_config.dedup.model_dump() if webhook_config.dedup else None,
+                    "dedup": _dedup_storage(webhook_config.dedup),
                 }
             )
 
@@ -90,8 +105,14 @@ async def apply_webhooks(
                     existing.requires_auth = webhook_config.requiresAuth
                     existing.default_values = webhook_config.defaultValues
                     existing.response_mode = webhook_config.responseMode
-                    existing.dedup = webhook_config.dedup.model_dump() if webhook_config.dedup else None
-                    existing.is_active = True
+                    existing.dedup = _dedup_storage(webhook_config.dedup)
+                    # Deliberately NOT re-enabling: is_active is operator state,
+                    # not config state (WebhookConfig has no isActive field), so
+                    # a re-apply must not silently re-arm a webhook someone
+                    # disabled. This matters because adding fields to the
+                    # config_hash input changes every existing webhook's
+                    # checksum, so the first apply after such a change updates
+                    # them all even when the YAML is byte-identical.
                     existing.config_checksum = config_hash
                     existing.updated_at = datetime.utcnow()
 
@@ -114,7 +135,7 @@ async def apply_webhooks(
                         requires_auth=webhook_config.requiresAuth,
                         default_values=webhook_config.defaultValues,
                         response_mode=webhook_config.responseMode,
-                        dedup=webhook_config.dedup.model_dump() if webhook_config.dedup else None,
+                        dedup=_dedup_storage(webhook_config.dedup),
                         is_active=True,
                         managed_by=managed_by,
                         config_name=config_name,

--- a/backend/app/services/config_apply/integrations.py
+++ b/backend/app/services/config_apply/integrations.py
@@ -38,10 +38,32 @@ async def apply_webhooks(
             result = await db.execute(stmt)
             existing = result.scalar_one_or_none()
 
+            target_type = getattr(webhook_config, "targetType", "function")
+
+            # Parse target references (may be "namespace/name" or just "name")
+            func_ns, func_name = "default", None
+            agent_ns, agent_name = None, None
+            if target_type == "agent":
+                agent_ref = webhook_config.agentName or ""
+                if "/" in agent_ref:
+                    agent_ns, agent_name = agent_ref.split("/", 1)
+                else:
+                    agent_ns, agent_name = "default", agent_ref
+            else:
+                func_ref = webhook_config.functionName or ""
+                if "/" in func_ref:
+                    func_ns, func_name = func_ref.split("/", 1)
+                else:
+                    func_ns, func_name = "default", func_ref
+
             config_hash = calculate_hash(
                 {
                     "path": webhook_config.path,
+                    "target_type": target_type,
                     "function_name": webhook_config.functionName,
+                    "agent_name": webhook_config.agentName,
+                    "message_template": webhook_config.messageTemplate,
+                    "session_key_template": webhook_config.sessionKeyTemplate,
                     "http_method": webhook_config.httpMethod,
                     "description": webhook_config.description,
                     "requires_auth": webhook_config.requiresAuth,
@@ -56,15 +78,13 @@ async def apply_webhooks(
                     continue
 
                 if not dry_run:
-                    # Parse function reference (may be "namespace/name" or just "name")
-                    func_ref = webhook_config.functionName
-                    if "/" in func_ref:
-                        func_ns, func_name = func_ref.split("/", 1)
-                    else:
-                        func_ns, func_name = "default", func_ref
-
+                    existing.target_type = target_type
                     existing.function_namespace = func_ns
                     existing.function_name = func_name
+                    existing.agent_namespace = agent_ns
+                    existing.agent_name = agent_name
+                    existing.message_template = webhook_config.messageTemplate
+                    existing.session_key_template = webhook_config.sessionKeyTemplate
                     existing.http_method = webhook_config.httpMethod
                     existing.description = webhook_config.description
                     existing.requires_auth = webhook_config.requiresAuth
@@ -79,17 +99,15 @@ async def apply_webhooks(
 
             else:
                 if not dry_run:
-                    # Parse function reference (may be "namespace/name" or just "name")
-                    func_ref = webhook_config.functionName
-                    if "/" in func_ref:
-                        func_ns, func_name = func_ref.split("/", 1)
-                    else:
-                        func_ns, func_name = "default", func_ref
-
                     new_webhook = Webhook(
                         path=webhook_config.path,
+                        target_type=target_type,
                         function_namespace=func_ns,
                         function_name=func_name,
+                        agent_namespace=agent_ns,
+                        agent_name=agent_name,
+                        message_template=webhook_config.messageTemplate,
+                        session_key_template=webhook_config.sessionKeyTemplate,
                         user_id=owner_user_id,
                         http_method=webhook_config.httpMethod,
                         description=webhook_config.description,

--- a/backend/app/services/config_parser.py
+++ b/backend/app/services/config_parser.py
@@ -434,29 +434,53 @@ class ConfigParser:
 
         # Validate webhook references
         for i, webhook in enumerate(spec.get("webhooks", [])):
-            # Build function reference as namespace/name
-            func_namespace = webhook.get("functionNamespace", "default")
-            func_name = webhook["functionName"]
-            func_ref = f"{func_namespace}/{func_name}"
-            if not _ref_matches_any(func_ref, all_function_names):
-                errors.append(
-                    ConfigValidationError(
-                        path=f"spec.webhooks[{i}].functionName",
-                        message=f"Referenced function '{func_ref}' not defined",
+            if webhook.get("targetType", "function") == "agent":
+                agent_ref = webhook.get("agentName") or ""
+                if "/" not in agent_ref:
+                    agent_ref = f"default/{agent_ref}"
+                if not _ref_matches_any(agent_ref, all_agent_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.webhooks[{i}].agentName",
+                            message=f"Referenced agent '{agent_ref}' not defined",
+                        )
                     )
-                )
+            else:
+                # functionName may be "namespace/name" or a bare name
+                func_ref = webhook.get("functionName") or ""
+                if "/" not in func_ref:
+                    func_ref = f"{webhook.get('functionNamespace', 'default')}/{func_ref}"
+                if not _ref_matches_any(func_ref, all_function_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.webhooks[{i}].functionName",
+                            message=f"Referenced function '{func_ref}' not defined",
+                        )
+                    )
 
         # Validate schedule references
         for i, schedule in enumerate(spec.get("schedules", [])):
-            # Build function reference as namespace/name
-            func_namespace = schedule.get("functionNamespace", "default")
-            func_name = schedule["functionName"]
-            func_ref = f"{func_namespace}/{func_name}"
-            if not _ref_matches_any(func_ref, all_function_names):
-                errors.append(
-                    ConfigValidationError(
-                        path=f"spec.schedules[{i}].functionName",
-                        message=f"Referenced function '{func_ref}' not defined",
+            if schedule.get("scheduleType", "function") == "agent":
+                agent_ref = schedule.get("agentName") or ""
+                if "/" not in agent_ref:
+                    agent_ref = f"default/{agent_ref}"
+                if not _ref_matches_any(agent_ref, all_agent_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.schedules[{i}].agentName",
+                            message=f"Referenced agent '{agent_ref}' not defined",
+                        )
                     )
-                )
+            else:
+                # functionName may be "namespace/name" or a bare name
+                func_ref = schedule.get("functionName") or ""
+                if "/" not in func_ref:
+                    func_ref = f"{schedule.get('functionNamespace', 'default')}/{func_ref}"
+                if not _ref_matches_any(func_ref, all_function_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.schedules[{i}].functionName",
+                            message=f"Referenced function '{func_ref}' not defined",
+                        )
+                    )
 

--- a/backend/app/services/dedup_service.py
+++ b/backend/app/services/dedup_service.py
@@ -36,6 +36,22 @@ def _extract_key_value(
     return None
 
 
+
+def _dedup_ttl(dedup_config: dict) -> int:
+    """TTL from a stored dedup blob.
+
+    Accepts both key spellings: the REST schema stores `ttl_seconds` while the
+    config schema's model_dump() produced `ttlSeconds`, so rows written by
+    config apply carry the camelCase key. Reading both means existing rows keep
+    their configured TTL instead of silently falling back to the default.
+    """
+    for key in ("ttl_seconds", "ttlSeconds"):
+        value = dedup_config.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return 300
+
+
 async def check_and_mark(
     webhook_id: str,
     body: dict[str, Any],
@@ -49,7 +65,7 @@ async def check_and_mark(
         previous result if available (sync mode only).
     """
     key_expr = dedup_config.get("key", "")
-    ttl = dedup_config.get("ttl_seconds", 300)
+    ttl = _dedup_ttl(dedup_config)
 
     key_value = _extract_key_value(key_expr, body, headers)
     if not key_value:
@@ -80,7 +96,7 @@ async def store_result(
 ) -> None:
     """Cache the result of a sync webhook for dedup responses."""
     key_expr = dedup_config.get("key", "")
-    ttl = dedup_config.get("ttl_seconds", 300)
+    ttl = _dedup_ttl(dedup_config)
 
     key_value = _extract_key_value(key_expr, body, headers)
     if not key_value:

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -136,8 +136,28 @@ def serialize_webhook(webhook) -> dict:
         "description": webhook.description,
         "defaultValues": webhook.default_values or None,
         "responseMode": getattr(webhook, "response_mode", None),
-        "dedup": getattr(webhook, "dedup", None) or None,
+        "dedup": _serialize_dedup(getattr(webhook, "dedup", None)),
     })
+
+
+def _serialize_dedup(dedup: Optional[dict]) -> Optional[dict]:
+    """Export a stored dedup blob in the config schema's camelCase shape.
+
+    Storage is snake_case (`ttl_seconds`); the config schema expects
+    `ttlSeconds`. Exporting the raw blob emitted the snake_case key, which
+    WebhookDedupConfig then ignored on re-apply — silently resetting the TTL to
+    its default on a no-op round-trip. Older rows may still hold `ttlSeconds`,
+    so accept either on the way out.
+    """
+    if not dedup:
+        return None
+    ttl = dedup.get("ttl_seconds")
+    if not isinstance(ttl, int) or isinstance(ttl, bool):
+        ttl = dedup.get("ttlSeconds")
+    out: dict[str, Any] = {"key": dedup.get("key")}
+    if isinstance(ttl, int) and not isinstance(ttl, bool):
+        out["ttlSeconds"] = ttl
+    return out
 
 
 def serialize_schedule(schedule) -> dict:

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -118,9 +118,19 @@ def serialize_template(template) -> dict:
 
 
 def serialize_webhook(webhook) -> dict:
+    target_type = getattr(webhook, "target_type", "function") or "function"
     return _remove_none_values({
         "path": webhook.path,
-        "functionName": f"{webhook.function_namespace}/{webhook.function_name}",
+        # Omitted for function targets so legacy exports stay unchanged
+        "targetType": target_type if target_type != "function" else None,
+        "functionName": f"{webhook.function_namespace}/{webhook.function_name}"
+        if target_type == "function"
+        else None,
+        "agentName": f"{webhook.agent_namespace}/{webhook.agent_name}"
+        if target_type == "agent"
+        else None,
+        "messageTemplate": webhook.message_template if target_type == "agent" else None,
+        "sessionKeyTemplate": webhook.session_key_template if target_type == "agent" else None,
         "httpMethod": webhook.http_method,
         "requiresAuth": webhook.requires_auth,
         "description": webhook.description,

--- a/backend/app/services/template_renderer.py
+++ b/backend/app/services/template_renderer.py
@@ -6,9 +6,12 @@ Used for:
 
 Security: Uses sandboxed Jinja2 environment with autoescape enabled.
 """
+import logging
 from typing import Any, Optional
 
-from jinja2 import Environment, StrictUndefined, select_autoescape
+from jinja2 import ChainableUndefined, Environment, StrictUndefined, select_autoescape
+
+logger = logging.getLogger(__name__)
 
 # Sandboxed Jinja2 environment for security
 _jinja_env = Environment(
@@ -17,6 +20,38 @@ _jinja_env = Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
+
+
+class _LoggingUndefined(ChainableUndefined):
+    """Undefined that renders as empty string but logs, so a missing payload
+    field never crashes a webhook."""
+
+    def __str__(self) -> str:
+        logger.warning(
+            "Webhook template referenced undefined variable: %s", self._undefined_name
+        )
+        return ""
+
+
+# Environment for webhook message/session-key templates: payloads are untrusted
+# and providers change their schemas, so undefined variables render empty
+# instead of failing. No autoescape — output is plain text, not HTML.
+_webhook_jinja_env = Environment(
+    undefined=_LoggingUndefined,
+    autoescape=False,
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+def render_webhook_template(template_str: str, context: dict[str, Any]) -> str:
+    """Render a webhook message/session-key template against a request payload.
+
+    Undefined variables render as empty strings (and are logged) so that
+    unexpected payload shapes never fail the webhook.
+    """
+    template = _webhook_jinja_env.from_string(template_str)
+    return template.render(**context)
 
 
 def render_template(template_str: str, context: dict[str, Any]) -> str:

--- a/backend/app/services/template_renderer.py
+++ b/backend/app/services/template_renderer.py
@@ -4,17 +4,25 @@ Used for:
 1. Agent system prompt templating (with agent input context)
 2. Function parameter templating (with agent input context)
 
-Security: Uses sandboxed Jinja2 environment with autoescape enabled.
+Security: Uses jinja2 SandboxedEnvironment (blocks attribute traversal such as
+__class__/__globals__, which would otherwise be RCE in the API process, since
+templates are user-authored). Autoescape is on for the general environment.
 """
 import logging
 from typing import Any, Optional
 
-from jinja2 import ChainableUndefined, Environment, StrictUndefined, select_autoescape
+from jinja2 import ChainableUndefined, StrictUndefined, select_autoescape
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 
 logger = logging.getLogger(__name__)
 
-# Sandboxed Jinja2 environment for security
-_jinja_env = Environment(
+# SandboxedEnvironment, not Environment: these templates are authored by users
+# (agent prompts, function params, webhook messages) but rendered IN-PROCESS in
+# the API worker, which holds SECRET_KEY, ENCRYPTION_KEY and DB credentials. A
+# plain Environment allows attribute traversal (__class__/__globals__) — i.e.
+# code execution — from any template author. autoescape does not prevent this.
+_jinja_env = SandboxedEnvironment(
     undefined=StrictUndefined,  # Fail on undefined variables
     autoescape=select_autoescape(default_for_string=True, default=True),  # XSS protection
     trim_blocks=True,
@@ -24,9 +32,17 @@ _jinja_env = Environment(
 
 class _LoggingUndefined(ChainableUndefined):
     """Undefined that renders as empty string but logs, so a missing payload
-    field never crashes a webhook."""
+    field never crashes a webhook.
+
+    Exception: a sandbox violation must still fail loudly. SandboxedEnvironment
+    signals blocked attribute access by returning an Undefined carrying
+    SecurityError; swallowing that here would make an attempted escape look
+    identical to a provider renaming a field.
+    """
 
     def __str__(self) -> str:
+        if self._undefined_exception is SecurityError:
+            self._fail_with_undefined_error()
         logger.warning(
             "Webhook template referenced undefined variable: %s", self._undefined_name
         )
@@ -36,7 +52,7 @@ class _LoggingUndefined(ChainableUndefined):
 # Environment for webhook message/session-key templates: payloads are untrusted
 # and providers change their schemas, so undefined variables render empty
 # instead of failing. No autoescape — output is plain text, not HTML.
-_webhook_jinja_env = Environment(
+_webhook_jinja_env = SandboxedEnvironment(
     undefined=_LoggingUndefined,
     autoescape=False,
     trim_blocks=True,
@@ -50,8 +66,31 @@ def render_webhook_template(template_str: str, context: dict[str, Any]) -> str:
     Undefined variables render as empty strings (and are logged) so that
     unexpected payload shapes never fail the webhook.
     """
-    template = _webhook_jinja_env.from_string(template_str)
-    return template.render(**context)
+    rendered, _ = render_webhook_template_checked(template_str, context)
+    return rendered
+
+
+def render_webhook_template_checked(
+    template_str: str, context: dict[str, Any]
+) -> tuple[str, bool]:
+    """Render a webhook template, reporting whether any variable was undefined.
+
+    Returns (rendered, had_undefined). Callers need the flag because a *partial*
+    render is the dangerous case: 'jira-{{ issue.key }}' against a payload with
+    no `issue` yields 'jira-', which is non-empty and truthy, so a bare
+    emptiness check accepts it — collapsing unrelated events into one session,
+    or handing an agent a message with no information in it.
+    """
+    seen: list[str] = []
+
+    class _Tracking(_LoggingUndefined):
+        def __str__(self) -> str:  # noqa: D105 - see _LoggingUndefined
+            seen.append(self._undefined_name or "?")
+            return super().__str__()
+
+    env = _webhook_jinja_env.overlay(undefined=_Tracking)
+    rendered = env.from_string(template_str).render(**context)
+    return rendered, bool(seen)
 
 
 def render_template(template_str: str, context: dict[str, Any]) -> str:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -105,6 +105,10 @@ async def test_role(db: AsyncSession) -> Role:
         "sinas.agents/*/*.read:all",
         "sinas.agents/*/*.update:own",
         "sinas.agents/*/*.delete:own",
+        # Matches DEFAULT_ROLE_PERMISSIONS: every real user can chat with any
+        # agent. Without it this fixture models a user who cannot use agents at
+        # all, which silently hides permission regressions on agent paths.
+        "sinas.agents/*/*.chat:all",
         "sinas.functions.create:own",
         "sinas.functions/*/*.read:all",
         "sinas.functions/*/*.update:own",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,13 +39,18 @@ async def db() -> AsyncGenerator[AsyncSession, None]:
 async def app(db: AsyncSession):
     """Create a FastAPI app with the test DB session injected."""
     from app.main import app as _app
+    from app.main import management_app
 
     async def _override_get_db():
         yield db
 
+    # Override on the mounted management sub-app too — FastAPI dependency
+    # overrides do not propagate into mounted sub-applications.
     _app.dependency_overrides[get_db] = _override_get_db
+    management_app.dependency_overrides[get_db] = _override_get_db
     yield _app
     _app.dependency_overrides.clear()
+    management_app.dependency_overrides.clear()
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/unit/test_webhook_security.py
+++ b/backend/tests/unit/test_webhook_security.py
@@ -1,0 +1,152 @@
+"""Security and correctness regressions for webhook agent targets (PR #111 review).
+
+Each test pins a specific defect found in review:
+  - template sandbox escape (RCE in the API process)
+  - partial template renders being accepted as if fully rendered
+  - raw-mode `_status` accepting bools / body-less codes
+  - dedup TTL key-casing mismatch between the REST and config write paths
+
+The authorization fixes (ownership enforcement, is_active revalidation) are
+covered in test_webhook_targets.py where the request fixtures live.
+"""
+
+import pytest
+from jinja2.exceptions import SecurityError
+
+from app.services.dedup_service import _dedup_ttl
+from app.services.resource_serializers import _serialize_dedup
+from app.services.template_renderer import (
+    render_template,
+    render_webhook_template,
+    render_webhook_template_checked,
+)
+
+
+# --------------------------------------------------------------------------
+# Template sandbox — templates are user-authored but rendered in-process
+# --------------------------------------------------------------------------
+
+ESCAPES = [
+    "{{ cycler.__init__.__globals__ }}",
+    "{{ ''.__class__.__mro__ }}",
+    "{{ joiner.__init__.__globals__['os'] }}",
+    "{{ namespace.__init__.__globals__ }}",
+]
+
+
+@pytest.mark.parametrize("template", ESCAPES)
+def test_webhook_env_blocks_sandbox_escape(template):
+    """A webhook template must not reach Python internals: rendering happens in
+    the API worker, which holds SECRET_KEY/ENCRYPTION_KEY."""
+    with pytest.raises(SecurityError):
+        render_webhook_template(template, {})
+
+
+@pytest.mark.parametrize("template", ESCAPES)
+def test_general_env_blocks_sandbox_escape(template):
+    """Same for agent prompts / function params (pre-existing path)."""
+    with pytest.raises(SecurityError):
+        render_template(template, {})
+
+
+def test_escape_is_not_silently_swallowed_as_a_missing_variable():
+    """_LoggingUndefined renders unknown payload fields as '' — it must not do
+    that for a sandbox violation, or an attempted escape is indistinguishable
+    from a provider renaming a field."""
+    with pytest.raises(SecurityError):
+        render_webhook_template("{{ cycler.__init__ }}", {})
+
+
+def test_missing_payload_field_stays_tolerant():
+    """The tolerance that motivated the custom Undefined must survive the fix."""
+    out = render_webhook_template("New issue {{ issue.key }}", {})
+    assert out == "New issue "
+
+
+# --------------------------------------------------------------------------
+# Partial renders — the dangerous case is non-empty-but-incomplete
+# --------------------------------------------------------------------------
+
+def test_checked_render_reports_undefined_on_partial_render():
+    rendered, had_undefined = render_webhook_template_checked(
+        "New issue {{ issue.key }}: {{ issue.fields.summary }}", {}
+    )
+    assert rendered == "New issue : "  # non-empty, so an emptiness check accepts it
+    assert had_undefined is True
+
+
+def test_checked_render_reports_clean_on_full_render():
+    rendered, had_undefined = render_webhook_template_checked(
+        "New issue {{ key }}", {"key": "AB-1"}
+    )
+    assert rendered == "New issue AB-1"
+    assert had_undefined is False
+
+
+def test_partial_session_key_is_detected():
+    """'jira-{{ issue.key }}' with no issue renders 'jira-' — truthy, and would
+    collapse every malformed delivery into one shared chat."""
+    rendered, had_undefined = render_webhook_template_checked("jira-{{ issue.key }}", {})
+    assert rendered == "jira-"
+    assert had_undefined is True
+
+
+# --------------------------------------------------------------------------
+# Dedup TTL — three-way key mismatch (REST snake / config camel / consumer snake)
+# --------------------------------------------------------------------------
+
+def test_dedup_ttl_reads_rest_shape():
+    assert _dedup_ttl({"key": "$.id", "ttl_seconds": 3600}) == 3600
+
+
+def test_dedup_ttl_reads_legacy_config_shape():
+    """Rows written by config apply before the fix carry camelCase; they must
+    keep their configured TTL rather than silently falling back to 300."""
+    assert _dedup_ttl({"key": "$.id", "ttlSeconds": 3600}) == 3600
+
+
+def test_dedup_ttl_defaults_when_absent_or_invalid():
+    assert _dedup_ttl({"key": "$.id"}) == 300
+    assert _dedup_ttl({"key": "$.id", "ttl_seconds": "soon"}) == 300
+    # bool is an int subclass in Python — must not be accepted as a TTL
+    assert _dedup_ttl({"key": "$.id", "ttl_seconds": True}) == 300
+
+
+def test_dedup_export_emits_config_casing():
+    """Export must produce the shape WebhookDedupConfig actually parses, or an
+    export -> re-apply round-trip silently resets the TTL to the default."""
+    assert _serialize_dedup({"key": "$.id", "ttl_seconds": 3600}) == {
+        "key": "$.id",
+        "ttlSeconds": 3600,
+    }
+
+
+def test_dedup_export_round_trips_through_config_schema():
+    from app.schemas.config import WebhookDedupConfig
+
+    exported = _serialize_dedup({"key": "$.id", "ttl_seconds": 3600})
+    parsed = WebhookDedupConfig(**exported)
+    assert parsed.ttlSeconds == 3600  # not the 300 default
+
+
+def test_dedup_export_none_stays_none():
+    assert _serialize_dedup(None) is None
+    assert _serialize_dedup({}) is None
+
+
+# --------------------------------------------------------------------------
+# PATCH semantics — "absent" vs "explicitly cleared"
+# --------------------------------------------------------------------------
+
+def test_update_schema_distinguishes_absent_from_null():
+    """`is not None` cannot express 'clear this field', so clearing a session
+    key or disabling dedup silently did nothing while reporting success."""
+    from app.schemas.webhook import WebhookUpdate
+
+    absent = WebhookUpdate(description="x")
+    assert "session_key_template" not in absent.model_fields_set
+    assert "dedup" not in absent.model_fields_set
+
+    cleared = WebhookUpdate(session_key_template=None, dedup=None)
+    assert "session_key_template" in cleared.model_fields_set
+    assert "dedup" in cleared.model_fields_set

--- a/backend/tests/unit/test_webhook_targets.py
+++ b/backend/tests/unit/test_webhook_targets.py
@@ -447,6 +447,8 @@ async def _create_function(db: AsyncSession, user) -> Function:
         namespace="slack",
         name=f"handler-{uuid.uuid4().hex[:8]}",
         code="def main(input): return input",
+        input_schema={},
+        output_schema={},
         is_active=True,
     )
     db.add(fn)
@@ -656,8 +658,38 @@ class TestRuntimeAgentTarget:
 
         monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
 
-        # Payload missing everything the template references
+        # Payload missing everything the template references: undefined
+        # variables render empty, the webhook still succeeds
         resp = await client.post(f"/webhooks/{path}", json={"unrelated": True})
         assert resp.status_code == 202, resp.text
-        # Rendered empty -> falls back to the JSON payload
+        assert captured["content"] == "New issue :"
+
+    async def test_fully_empty_render_falls_back_to_payload(
+        self, client, db, test_user, monkeypatch
+    ):
+        agent, path = await self._setup(db, test_user)
+
+        # Make the whole template render empty
+        from sqlalchemy import select as sa_select
+
+        result = await db.execute(sa_select(Webhook).where(Webhook.path == path))
+        webhook = result.scalar_one()
+        webhook.message_template = "{{ missing }}"
+        await db.flush()
+
+        monkeypatch.setattr(db, "commit", db.flush)
+
+        from app.services.queue_service import queue_service
+
+        captured = {}
+
+        async def fake_enqueue_agent_message(**kwargs):
+            captured.update(kwargs)
+            return "job-z"
+
+        monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
+
+        resp = await client.post(f"/webhooks/{path}", json={"unrelated": True})
+        assert resp.status_code == 202, resp.text
+        # Empty render falls back to the JSON payload so the agent gets context
         assert "unrelated" in captured["content"]

--- a/backend/tests/unit/test_webhook_targets.py
+++ b/backend/tests/unit/test_webhook_targets.py
@@ -1,0 +1,663 @@
+"""Tests for webhook agent targets and raw response mode."""
+import json
+import uuid
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent import Agent
+from app.models.function import Function
+from app.models.webhook import Webhook
+from tests.conftest import auth_headers
+
+
+# =========================================================================
+# API schema validation
+# =========================================================================
+
+
+class TestWebhookCreateSchema:
+    def test_legacy_function_webhook_defaults(self):
+        from app.schemas.webhook import WebhookCreate
+
+        w = WebhookCreate(path="stripe/payment", function_name="process")
+        assert w.target_type == "function"
+        assert w.response_mode == "sync"
+
+    def test_agent_webhook(self):
+        from app.schemas.webhook import WebhookCreate
+
+        w = WebhookCreate(
+            path="jira/issue-created",
+            target_type="agent",
+            agent_namespace="jira",
+            agent_name="triage",
+            message_template="New issue {{ issue.key }}",
+            session_key_template="jira-{{ issue.key }}",
+            response_mode="async",
+        )
+        assert w.agent_name == "triage"
+
+    def test_function_webhook_requires_function_name(self):
+        from app.schemas.webhook import WebhookCreate
+
+        with pytest.raises(ValidationError, match="function_name"):
+            WebhookCreate(path="p")
+
+    def test_agent_webhook_requires_agent_name(self):
+        from app.schemas.webhook import WebhookCreate
+
+        with pytest.raises(ValidationError, match="agent_name"):
+            WebhookCreate(path="p", target_type="agent", message_template="m")
+
+    def test_agent_webhook_requires_message_template(self):
+        from app.schemas.webhook import WebhookCreate
+
+        with pytest.raises(ValidationError, match="message_template"):
+            WebhookCreate(path="p", target_type="agent", agent_name="a")
+
+    def test_raw_mode_rejected_for_agent_targets(self):
+        from app.schemas.webhook import WebhookCreate
+
+        with pytest.raises(ValidationError, match="raw"):
+            WebhookCreate(
+                path="p",
+                target_type="agent",
+                agent_name="a",
+                message_template="m",
+                response_mode="raw",
+            )
+
+    def test_raw_mode_allowed_for_function_targets(self):
+        from app.schemas.webhook import WebhookCreate
+
+        w = WebhookCreate(path="slack/events", function_name="handler", response_mode="raw")
+        assert w.response_mode == "raw"
+
+
+# =========================================================================
+# Config YAML schema validation
+# =========================================================================
+
+
+class TestWebhookConfigYaml:
+    def test_function_webhook(self):
+        from app.schemas.config import WebhookConfig
+
+        c = WebhookConfig(path="slack/events", functionName="slack/handler", responseMode="raw")
+        assert c.targetType == "function"
+
+    def test_agent_webhook(self):
+        from app.schemas.config import WebhookConfig
+
+        c = WebhookConfig(
+            path="jira/issue-created",
+            targetType="agent",
+            agentName="jira/triage",
+            messageTemplate="New issue {{ issue.key }}",
+            sessionKeyTemplate="jira-{{ issue.key }}",
+            responseMode="async",
+        )
+        assert c.agentName == "jira/triage"
+
+    def test_function_name_required_for_function_targets(self):
+        from app.schemas.config import WebhookConfig
+
+        with pytest.raises(ValidationError, match="functionName"):
+            WebhookConfig(path="p")
+
+    def test_agent_fields_required_for_agent_targets(self):
+        from app.schemas.config import WebhookConfig
+
+        with pytest.raises(ValidationError, match="agentName"):
+            WebhookConfig(path="p", targetType="agent")
+        with pytest.raises(ValidationError, match="messageTemplate"):
+            WebhookConfig(path="p", targetType="agent", agentName="a/b")
+
+    def test_raw_mode_rejected_for_agent_targets(self):
+        from app.schemas.config import WebhookConfig
+
+        with pytest.raises(ValidationError, match="raw"):
+            WebhookConfig(
+                path="p",
+                targetType="agent",
+                agentName="a/b",
+                messageTemplate="m",
+                responseMode="raw",
+            )
+
+    def test_invalid_response_mode_rejected(self):
+        from app.schemas.config import WebhookConfig
+
+        with pytest.raises(ValidationError, match="responseMode"):
+            WebhookConfig(path="p", functionName="f", responseMode="banana")
+
+
+# =========================================================================
+# Webhook template rendering
+# =========================================================================
+
+
+class TestWebhookTemplateRendering:
+    def test_renders_nested_payload(self):
+        from app.services.template_renderer import render_webhook_template
+
+        out = render_webhook_template(
+            "New issue {{ issue.key }}: {{ issue.fields.summary }}",
+            {"issue": {"key": "AB-1", "fields": {"summary": "Boom"}}},
+        )
+        assert out == "New issue AB-1: Boom"
+
+    def test_undefined_variables_render_empty(self):
+        from app.services.template_renderer import render_webhook_template
+
+        assert render_webhook_template("x{{ missing }}y", {}) == "xy"
+
+    def test_undefined_chains_render_empty(self):
+        from app.services.template_renderer import render_webhook_template
+
+        assert render_webhook_template("x{{ a.b.c.d }}y", {}) == "xy"
+
+    def test_no_html_escaping(self):
+        from app.services.template_renderer import render_webhook_template
+
+        assert render_webhook_template("{{ v }}", {"v": "<b>&</b>"}) == "<b>&</b>"
+
+
+# =========================================================================
+# Raw response building and dedup replay
+# =========================================================================
+
+
+class TestRawResponse:
+    def test_dict_result_is_json_body(self):
+        from app.api.runtime.endpoints.webhooks import _build_raw_response
+
+        resp, cache = _build_raw_response({"challenge": "abc"})
+        assert resp.status_code == 200
+        assert json.loads(resp.body) == {"challenge": "abc"}
+        assert resp.media_type == "application/json"
+
+    def test_string_result_is_text_plain(self):
+        from app.api.runtime.endpoints.webhooks import _build_raw_response
+
+        resp, _ = _build_raw_response("hello")
+        assert resp.body == b"hello"
+        assert resp.media_type == "text/plain"
+
+    def test_control_keys_set_status_headers_body(self):
+        from app.api.runtime.endpoints.webhooks import _build_raw_response
+
+        resp, cache = _build_raw_response(
+            {"_status": 201, "_headers": {"X-A": "1"}, "_body": {"ok": True}}
+        )
+        assert resp.status_code == 201
+        assert resp.headers["x-a"] == "1"
+        assert json.loads(resp.body) == {"ok": True}
+
+    def test_cache_entry_replays_identically(self):
+        from app.api.runtime.endpoints.webhooks import _build_raw_response, _replay_cached
+
+        resp, cache = _build_raw_response({"_status": 201, "_headers": {"X-A": "1"}, "_body": "ok"})
+        replayed = _replay_cached(json.dumps(cache))
+        assert replayed.status_code == 201
+        assert replayed.headers["x-a"] == "1"
+        assert replayed.body == b"ok"
+        assert replayed.media_type == "text/plain"
+
+    def test_legacy_envelope_cache_replays_as_json(self):
+        from app.api.runtime.endpoints.webhooks import _replay_cached
+
+        cached = json.dumps({"success": True, "execution_id": "e", "result": 1})
+        replayed = _replay_cached(cached)
+        assert replayed.status_code == 200
+        assert json.loads(replayed.body)["success"] is True
+
+
+# =========================================================================
+# Serializer / config round-trip
+# =========================================================================
+
+
+class TestSerializeWebhook:
+    def _webhook(self, **kw):
+        defaults = dict(
+            path="p",
+            target_type="function",
+            function_namespace="default",
+            function_name="fn",
+            agent_namespace=None,
+            agent_name=None,
+            message_template=None,
+            session_key_template=None,
+            http_method="POST",
+            requires_auth=True,
+            description=None,
+            default_values=None,
+            response_mode="sync",
+            dedup=None,
+        )
+        defaults.update(kw)
+        return type("W", (), defaults)()
+
+    def test_function_webhook_export_has_no_target_type(self):
+        from app.schemas.config import WebhookConfig
+        from app.services.resource_serializers import serialize_webhook
+
+        s = serialize_webhook(self._webhook())
+        assert "targetType" not in s
+        assert s["functionName"] == "default/fn"
+        WebhookConfig(**s)  # round-trips
+
+    def test_agent_webhook_round_trip(self):
+        from app.schemas.config import WebhookConfig
+        from app.services.resource_serializers import serialize_webhook
+
+        s = serialize_webhook(
+            self._webhook(
+                target_type="agent",
+                function_name=None,
+                agent_namespace="jira",
+                agent_name="triage",
+                message_template="m {{x}}",
+                session_key_template="k-{{y}}",
+                response_mode="async",
+            )
+        )
+        assert s["targetType"] == "agent"
+        assert s["agentName"] == "jira/triage"
+        assert "functionName" not in s
+        cfg = WebhookConfig(**s)
+        assert cfg.messageTemplate == "m {{x}}"
+        assert cfg.sessionKeyTemplate == "k-{{y}}"
+
+
+# =========================================================================
+# Config parser reference validation
+# =========================================================================
+
+
+CONFIG_HEADER = """
+apiVersion: sinas.co/v1
+kind: SinasConfig
+metadata:
+  name: test
+spec:
+"""
+
+
+class TestConfigParserWebhookRefs:
+    async def test_agent_webhook_ref_valid(self):
+        from app.services.config_parser import ConfigParser
+
+        yaml_str = CONFIG_HEADER + """
+  agents:
+    - namespace: jira
+      name: triage
+  webhooks:
+    - path: jira/issue-created
+      targetType: agent
+      agentName: jira/triage
+      messageTemplate: "New {{ issue.key }}"
+"""
+        config, validation = await ConfigParser.parse_and_validate(yaml_str)
+        assert validation.errors == [], [str(e) for e in validation.errors]
+        assert config is not None
+
+    async def test_agent_webhook_ref_undefined(self):
+        from app.services.config_parser import ConfigParser
+
+        yaml_str = CONFIG_HEADER + """
+  webhooks:
+    - path: jira/issue-created
+      targetType: agent
+      agentName: jira/missing
+      messageTemplate: "m"
+"""
+        _, validation = await ConfigParser.parse_and_validate(yaml_str)
+        assert any("jira/missing" in str(e) for e in validation.errors)
+
+    async def test_function_webhook_ref_with_namespace(self):
+        from app.services.config_parser import ConfigParser
+
+        yaml_str = CONFIG_HEADER + """
+  functions:
+    - namespace: slack
+      name: handler
+      code: "def main(input): return input"
+  webhooks:
+    - path: slack/events
+      functionName: slack/handler
+      responseMode: raw
+"""
+        config, validation = await ConfigParser.parse_and_validate(yaml_str)
+        assert validation.errors == [], [str(e) for e in validation.errors]
+
+    async def test_agent_schedule_ref_validated(self):
+        """scheduleType: agent schedules must validate agentName (regression:
+        this used to KeyError on the missing functionName)."""
+        from app.services.config_parser import ConfigParser
+
+        yaml_str = CONFIG_HEADER + """
+  agents:
+    - namespace: ops
+      name: reporter
+  schedules:
+    - name: daily-report
+      scheduleType: agent
+      agentName: ops/reporter
+      content: "Write the daily report"
+      cronExpression: "0 9 * * *"
+"""
+        config, validation = await ConfigParser.parse_and_validate(yaml_str)
+        assert validation.errors == [], [str(e) for e in validation.errors]
+
+    async def test_agent_schedule_ref_undefined(self):
+        from app.services.config_parser import ConfigParser
+
+        yaml_str = CONFIG_HEADER + """
+  schedules:
+    - name: daily-report
+      scheduleType: agent
+      agentName: ops/missing
+      content: "hi"
+      cronExpression: "0 9 * * *"
+"""
+        _, validation = await ConfigParser.parse_and_validate(yaml_str)
+        assert any("ops/missing" in str(e) for e in validation.errors)
+
+
+# =========================================================================
+# CRUD API
+# =========================================================================
+
+
+class TestWebhookCrudApi:
+    async def _create_agent(self, db: AsyncSession, user) -> Agent:
+        agent = Agent(
+            user_id=user.id,
+            namespace="jira",
+            name=f"triage-{uuid.uuid4().hex[:8]}",
+            is_active=True,
+        )
+        db.add(agent)
+        await db.flush()
+        await db.refresh(agent)
+        return agent
+
+    async def test_create_agent_webhook(self, client, db, admin_user):
+        agent = await self._create_agent(db, admin_user)
+        resp = await client.post(
+            "/api/v1/webhooks",
+            json={
+                "path": f"jira/created-{uuid.uuid4().hex[:8]}",
+                "target_type": "agent",
+                "agent_namespace": "jira",
+                "agent_name": agent.name,
+                "message_template": "New issue {{ issue.key }}",
+                "session_key_template": "jira-{{ issue.key }}",
+                "response_mode": "async",
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["target_type"] == "agent"
+        assert data["agent_namespace"] == "jira"
+        assert data["agent_name"] == agent.name
+        assert data["function_name"] is None
+
+    async def test_create_agent_webhook_unknown_agent_404(self, client, admin_user):
+        resp = await client.post(
+            "/api/v1/webhooks",
+            json={
+                "path": f"x-{uuid.uuid4().hex[:8]}",
+                "target_type": "agent",
+                "agent_name": "does-not-exist",
+                "message_template": "m",
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 404
+
+    async def test_create_agent_webhook_raw_mode_422(self, client, admin_user):
+        resp = await client.post(
+            "/api/v1/webhooks",
+            json={
+                "path": "p",
+                "target_type": "agent",
+                "agent_name": "a",
+                "message_template": "m",
+                "response_mode": "raw",
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 422
+
+
+# =========================================================================
+# Runtime execution
+# =========================================================================
+
+
+async def _create_function(db: AsyncSession, user) -> Function:
+    fn = Function(
+        user_id=user.id,
+        namespace="slack",
+        name=f"handler-{uuid.uuid4().hex[:8]}",
+        code="def main(input): return input",
+        is_active=True,
+    )
+    db.add(fn)
+    await db.flush()
+    await db.refresh(fn)
+    return fn
+
+
+class TestRuntimeRawMode:
+    async def test_raw_mode_returns_unwrapped_body(self, client, db, test_user, monkeypatch):
+        fn = await _create_function(db, test_user)
+        path = f"slack/events-{uuid.uuid4().hex[:8]}"
+        db.add(
+            Webhook(
+                user_id=test_user.id,
+                path=path,
+                function_namespace=fn.namespace,
+                function_name=fn.name,
+                http_method="POST",
+                requires_auth=False,
+                response_mode="raw",
+            )
+        )
+        await db.flush()
+
+        from app.services.queue_service import queue_service
+
+        async def fake_enqueue_and_wait(**kwargs):
+            return {"challenge": kwargs["input_data"]["challenge"]}
+
+        monkeypatch.setattr(queue_service, "enqueue_and_wait", fake_enqueue_and_wait)
+
+        resp = await client.post(
+            f"/webhooks/{path}",
+            json={"type": "url_verification", "challenge": "3eZbrw1a"},
+        )
+        assert resp.status_code == 200
+        # The body IS the function result — no envelope
+        assert resp.json() == {"challenge": "3eZbrw1a"}
+
+    async def test_raw_mode_string_result_is_text_plain(self, client, db, test_user, monkeypatch):
+        fn = await _create_function(db, test_user)
+        path = f"slack/plain-{uuid.uuid4().hex[:8]}"
+        db.add(
+            Webhook(
+                user_id=test_user.id,
+                path=path,
+                function_namespace=fn.namespace,
+                function_name=fn.name,
+                http_method="POST",
+                requires_auth=False,
+                response_mode="raw",
+            )
+        )
+        await db.flush()
+
+        from app.services.queue_service import queue_service
+
+        async def fake_enqueue_and_wait(**kwargs):
+            return "3eZbrw1a"
+
+        monkeypatch.setattr(queue_service, "enqueue_and_wait", fake_enqueue_and_wait)
+
+        resp = await client.post(f"/webhooks/{path}", json={})
+        assert resp.status_code == 200
+        assert resp.text == "3eZbrw1a"
+        assert resp.headers["content-type"].startswith("text/plain")
+
+    async def test_sync_mode_envelope_unchanged(self, client, db, test_user, monkeypatch):
+        fn = await _create_function(db, test_user)
+        path = f"slack/sync-{uuid.uuid4().hex[:8]}"
+        db.add(
+            Webhook(
+                user_id=test_user.id,
+                path=path,
+                function_namespace=fn.namespace,
+                function_name=fn.name,
+                http_method="POST",
+                requires_auth=False,
+                response_mode="sync",
+            )
+        )
+        await db.flush()
+
+        from app.services.queue_service import queue_service
+
+        async def fake_enqueue_and_wait(**kwargs):
+            return {"anything": 1}
+
+        monkeypatch.setattr(queue_service, "enqueue_and_wait", fake_enqueue_and_wait)
+
+        resp = await client.post(f"/webhooks/{path}", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["result"] == {"anything": 1}
+        assert "execution_id" in data
+
+
+class TestRuntimeAgentTarget:
+    async def _setup(self, db: AsyncSession, user, **webhook_kw):
+        agent = Agent(
+            user_id=user.id,
+            namespace="jira",
+            name=f"triage-{uuid.uuid4().hex[:8]}",
+            is_active=True,
+        )
+        db.add(agent)
+        await db.flush()
+        await db.refresh(agent)
+
+        path = f"jira/created-{uuid.uuid4().hex[:8]}"
+        webhook = Webhook(
+            user_id=user.id,
+            path=path,
+            target_type="agent",
+            function_namespace="default",
+            function_name=None,
+            agent_namespace=agent.namespace,
+            agent_name=agent.name,
+            message_template="New issue {{ issue.key }}: {{ issue.fields.summary }}",
+            session_key_template="jira-{{ issue.key }}",
+            http_method="POST",
+            requires_auth=False,
+            response_mode="async",
+            **webhook_kw,
+        )
+        db.add(webhook)
+        await db.flush()
+        return agent, path
+
+    async def test_async_agent_webhook_enqueues_message(
+        self, client, db, test_user, monkeypatch
+    ):
+        agent, path = await self._setup(db, test_user)
+
+        # Keep the handler's commit inside the test transaction
+        monkeypatch.setattr(db, "commit", db.flush)
+
+        from app.services.queue_service import queue_service
+
+        captured = {}
+
+        async def fake_enqueue_agent_message(**kwargs):
+            captured.update(kwargs)
+            return "job-123"
+
+        monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
+
+        payload = {"issue": {"key": "AB-1", "fields": {"summary": "It broke"}}}
+        resp = await client.post(f"/webhooks/{path}", json=payload)
+        assert resp.status_code == 202, resp.text
+        data = resp.json()
+        assert data["job_id"] == "job-123"
+        assert data["chat_id"]
+
+        # Message rendered from the payload
+        assert captured["content"] == "New issue AB-1: It broke"
+        assert captured["agent"] == f"{agent.namespace}/{agent.name}"
+        assert captured["trigger_type"] == "webhook"
+
+        # Chat carries the rendered session key
+        from app.models.chat import Chat
+
+        chat = await db.get(Chat, uuid.UUID(data["chat_id"]))
+        assert chat is not None
+        assert chat.session_key == "jira-AB-1"
+        assert chat.agent_id == agent.id
+
+    async def test_session_key_reuses_chat(self, client, db, test_user, monkeypatch):
+        agent, path = await self._setup(db, test_user)
+        monkeypatch.setattr(db, "commit", db.flush)
+
+        from app.services.queue_service import queue_service
+
+        async def fake_enqueue_agent_message(**kwargs):
+            return "job-x"
+
+        monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
+
+        payload = {"issue": {"key": "AB-2", "fields": {"summary": "first"}}}
+        resp1 = await client.post(f"/webhooks/{path}", json=payload)
+        resp2 = await client.post(f"/webhooks/{path}", json=payload)
+        assert resp1.status_code == 202 and resp2.status_code == 202
+        assert resp1.json()["chat_id"] == resp2.json()["chat_id"]
+
+        # A different issue key starts a fresh conversation
+        other = await client.post(
+            f"/webhooks/{path}",
+            json={"issue": {"key": "AB-3", "fields": {"summary": "other"}}},
+        )
+        assert other.json()["chat_id"] != resp1.json()["chat_id"]
+
+    async def test_undefined_template_variables_do_not_fail(
+        self, client, db, test_user, monkeypatch
+    ):
+        agent, path = await self._setup(db, test_user)
+        monkeypatch.setattr(db, "commit", db.flush)
+
+        from app.services.queue_service import queue_service
+
+        captured = {}
+
+        async def fake_enqueue_agent_message(**kwargs):
+            captured.update(kwargs)
+            return "job-y"
+
+        monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
+
+        # Payload missing everything the template references
+        resp = await client.post(f"/webhooks/{path}", json={"unrelated": True})
+        assert resp.status_code == 202, resp.text
+        # Rendered empty -> falls back to the JSON payload
+        assert "unrelated" in captured["content"]

--- a/backend/tests/unit/test_webhook_targets.py
+++ b/backend/tests/unit/test_webhook_targets.py
@@ -658,11 +658,15 @@ class TestRuntimeAgentTarget:
 
         monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
 
-        # Payload missing everything the template references: undefined
-        # variables render empty, the webhook still succeeds
+        # Payload missing everything the template references: the webhook must
+        # still succeed (undefined variables never raise), but a PARTIAL render
+        # must not be sent as-is. 'New issue :' is non-empty yet carries no
+        # information about the event, so the agent would be invoked — and
+        # billed — with nothing to act on. Fall back to the raw payload instead.
         resp = await client.post(f"/webhooks/{path}", json={"unrelated": True})
         assert resp.status_code == 202, resp.text
-        assert captured["content"] == "New issue :"
+        assert captured["content"] != "New issue :"
+        assert "unrelated" in captured["content"]
 
     async def test_fully_empty_render_falls_back_to_payload(
         self, client, db, test_user, monkeypatch
@@ -693,3 +697,119 @@ class TestRuntimeAgentTarget:
         assert resp.status_code == 202, resp.text
         # Empty render falls back to the JSON payload so the agent gets context
         assert "unrelated" in captured["content"]
+
+
+# =========================================================================
+# Authorization (PR #111 review): triggering a webhook runs AS THE OWNER, so
+# ownership — not the caller's access to the target — is what authorizes it.
+# =========================================================================
+
+
+async def _user_with_perms(db: AsyncSession, perms: list[str]):
+    """A user whose role grants exactly `perms`."""
+    from app.models.user import Role, RolePermission, User, UserRole
+
+    role = Role(name=f"role-{uuid.uuid4().hex[:8]}", description="perm fixture")
+    db.add(role)
+    await db.flush()
+    await db.refresh(role)
+    for key in perms:
+        db.add(RolePermission(role_id=role.id, permission_key=key, permission_value=True))
+
+    user = User(email=f"u-{uuid.uuid4().hex[:8]}@example.com")
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    db.add(UserRole(role_id=role.id, user_id=user.id, active=True))
+    await db.flush()
+    return user
+
+
+async def _agent_webhook(db: AsyncSession, owner, *, requires_auth: bool):
+    agent = Agent(
+        user_id=owner.id,
+        namespace="jira",
+        name=f"triage-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    db.add(agent)
+    await db.flush()
+    await db.refresh(agent)
+
+    path = f"jira/auth-{uuid.uuid4().hex[:8]}"
+    db.add(
+        Webhook(
+            user_id=owner.id,
+            path=path,
+            target_type="agent",
+            function_namespace="default",
+            function_name=None,
+            agent_namespace=agent.namespace,
+            agent_name=agent.name,
+            message_template="Issue {{ key }}",
+            http_method="POST",
+            requires_auth=requires_auth,
+            response_mode="async",
+        )
+    )
+    await db.flush()
+    return agent, path
+
+
+class TestWebhookOwnershipAuthorization:
+    async def test_non_owner_with_chat_all_is_rejected(self, db: AsyncSession, client):
+        """`sinas.agents/*/*.chat:all` is a DEFAULT grant for every user, so a
+        target-permission check would let any authenticated user drive someone
+        else's webhook — and it runs as the owner, with the owner's secrets."""
+        owner = await _user_with_perms(db, ["sinas.agents/*/*.chat:all"])
+        other = await _user_with_perms(db, ["sinas.agents/*/*.chat:all"])
+        _agent, path = await _agent_webhook(db, owner, requires_auth=True)
+
+        resp = await client.post(
+            f"/webhooks/{path}", json={"key": "AB-1"}, headers=auth_headers(other)
+        )
+        assert resp.status_code == 403, resp.text
+
+    async def test_owner_is_allowed(self, db: AsyncSession, client, monkeypatch):
+        """Regression guard: the ownership rule must not lock out the owner."""
+        owner = await _user_with_perms(db, ["sinas.agents/*/*.chat:all"])
+        _agent, path = await _agent_webhook(db, owner, requires_auth=True)
+
+        monkeypatch.setattr(db, "commit", db.flush)
+        from app.services.queue_service import queue_service
+
+        async def fake_enqueue_agent_message(**kwargs):
+            return "job-owner"
+
+        monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
+
+        resp = await client.post(
+            f"/webhooks/{path}", json={"key": "AB-1"}, headers=auth_headers(owner)
+        )
+        assert resp.status_code == 202, resp.text
+
+    async def test_owner_without_chat_permission_is_rejected(
+        self, db: AsyncSession, client
+    ):
+        """Permissions can be narrowed after the webhook is created; the target
+        check must be re-evaluated per request, not trusted from creation."""
+        owner = await _user_with_perms(db, [])  # no chat permission at all
+        _agent, path = await _agent_webhook(db, owner, requires_auth=False)
+
+        resp = await client.post(f"/webhooks/{path}", json={"key": "AB-1"})
+        assert resp.status_code == 403, resp.text
+
+    async def test_deactivated_owner_cannot_fire_public_webhook(
+        self, db: AsyncSession, client
+    ):
+        """Soft-deleting a user revokes their API keys and tokens (#102). A
+        public webhook that keeps minting tokens for them would re-open exactly
+        the access that deletion was supposed to close."""
+        owner = await _user_with_perms(db, ["sinas.agents/*/*.chat:all"])
+        _agent, path = await _agent_webhook(db, owner, requires_auth=False)
+
+        owner.is_active = False
+        await db.flush()
+
+        resp = await client.post(f"/webhooks/{path}", json={"key": "AB-1"})
+        assert resp.status_code == 403, resp.text

--- a/console/src/pages/WebhookEditor.tsx
+++ b/console/src/pages/WebhookEditor.tsx
@@ -13,7 +13,11 @@ export function WebhookEditor() {
 
   const [formData, setFormData] = useState({
     path: '',
+    target_type: 'function' as 'function' | 'agent',
     function_name: '',
+    agent_name: '',
+    message_template: '',
+    session_key_template: '',
     http_method: 'POST',
     description: '',
     default_values: {} as Record<string, any>,
@@ -38,9 +42,15 @@ export function WebhookEditor() {
     if (webhook && !isNew) {
       setFormData({
         path: webhook.path || '',
+        target_type: webhook.target_type || 'function',
         function_name: webhook.function_namespace && webhook.function_name
           ? `${webhook.function_namespace}/${webhook.function_name}`
           : '',
+        agent_name: webhook.agent_namespace && webhook.agent_name
+          ? `${webhook.agent_namespace}/${webhook.agent_name}`
+          : '',
+        message_template: webhook.message_template || '',
+        session_key_template: webhook.session_key_template || '',
         http_method: webhook.http_method || 'POST',
         description: webhook.description || '',
         default_values: webhook.default_values || {},
@@ -53,27 +63,42 @@ export function WebhookEditor() {
     }
   }, [webhook, isNew]);
 
-  // Fetch available functions for dropdown
+  // Fetch available functions and agents for dropdowns
   const { data: functions } = useQuery({
     queryKey: ['functions'],
     queryFn: () => apiClient.listFunctions(),
     retry: false,
   });
 
+  const { data: agents } = useQuery({
+    queryKey: ['agents'],
+    queryFn: () => apiClient.listAgents(),
+    retry: false,
+  });
+
   const saveMutation = useMutation({
     mutationFn: (data: any) => {
-      // Split function_name into namespace and name
-      const [namespace, name] = data.function_name.split('/');
       const payload: any = {
-        ...data,
-        function_namespace: namespace,
-        function_name: name,
+        path: data.path,
+        target_type: data.target_type,
+        http_method: data.http_method,
+        description: data.description,
+        default_values: data.default_values,
+        requires_auth: data.requires_auth,
         response_mode: data.response_mode,
         dedup: data.dedup_enabled ? { key: data.dedup_key, ttl_seconds: data.dedup_ttl } : null,
       };
-      delete payload.dedup_enabled;
-      delete payload.dedup_key;
-      delete payload.dedup_ttl;
+      if (data.target_type === 'agent') {
+        const [agentNamespace, agentName] = data.agent_name.split('/');
+        payload.agent_namespace = agentNamespace;
+        payload.agent_name = agentName;
+        payload.message_template = data.message_template;
+        payload.session_key_template = data.session_key_template || null;
+      } else {
+        const [namespace, name] = data.function_name.split('/');
+        payload.function_namespace = namespace;
+        payload.function_name = name;
+      }
       return isNew
         ? apiClient.createWebhook(payload)
         : apiClient.updateWebhook(webhookPath!, payload);
@@ -148,7 +173,7 @@ export function WebhookEditor() {
               {isNew ? 'New Webhook' : formData.path || 'Edit Webhook'}
             </h1>
             <p className="text-gray-400 mt-1">
-              {isNew ? 'Create a web-accessible endpoint to trigger a function' : 'Edit webhook endpoint configuration'}
+              {isNew ? 'Create a web-accessible endpoint to trigger a function or agent' : 'Edit webhook endpoint configuration'}
             </p>
           </div>
         </div>
@@ -214,35 +239,140 @@ print(result["execution_id"], result["result"])`,
         <div className="card">
           <h2 className="text-lg font-semibold text-gray-100 mb-4">Webhook Configuration</h2>
           <div className="space-y-4">
+            {/* Target Type Toggle */}
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">
-                Function to Execute *
-              </label>
-              <select
-                value={formData.function_name}
-                onChange={(e) => {
-                  const selectedFunc = functions?.find((f: any) => `${f.namespace}/${f.name}` === e.target.value);
-                  setFormData({
+              <label className="block text-sm font-medium text-gray-300 mb-2">Target</label>
+              <div className="flex rounded-lg border border-white/10 overflow-hidden w-fit">
+                <button type="button"
+                  onClick={() => setFormData({
                     ...formData,
-                    function_name: e.target.value,
-                    path: formData.path || (selectedFunc ? selectedFunc.name : ''),
-                    description: formData.description || selectedFunc?.description || '',
-                  });
-                }}
-                required
-                className="input"
-              >
-                <option value="">Select a function...</option>
-                {functions?.map((func: any) => (
-                  <option key={func.id} value={`${func.namespace}/${func.name}`}>
-                    {func.namespace}/{func.name} {func.description ? `- ${func.description}` : ''}
-                  </option>
-                ))}
-              </select>
+                    target_type: 'function',
+                    agent_name: '',
+                    message_template: '',
+                    session_key_template: '',
+                  })}
+                  className={`px-4 py-2 text-sm font-medium ${
+                    formData.target_type === 'function'
+                      ? 'bg-[#2563eb] text-white'
+                      : 'bg-[#161616] text-gray-300 hover:bg-white/5'}`}>
+                  Function
+                </button>
+                <button type="button"
+                  onClick={() => setFormData({
+                    ...formData,
+                    target_type: 'agent',
+                    function_name: '',
+                    // raw is function-only
+                    response_mode: formData.response_mode === 'raw' ? 'sync' : formData.response_mode,
+                  })}
+                  className={`px-4 py-2 text-sm font-medium border-l border-white/10 ${
+                    formData.target_type === 'agent'
+                      ? 'bg-[#2563eb] text-white'
+                      : 'bg-[#161616] text-gray-300 hover:bg-white/5'}`}>
+                  Agent
+                </button>
+              </div>
               <p className="text-xs text-gray-500 mt-1">
-                The function that will be called when this webhook is triggered
+                Execute a function, or send a message to an agent
               </p>
             </div>
+
+            {formData.target_type === 'function' ? (
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">
+                  Function to Execute *
+                </label>
+                <select
+                  value={formData.function_name}
+                  onChange={(e) => {
+                    const selectedFunc = functions?.find((f: any) => `${f.namespace}/${f.name}` === e.target.value);
+                    setFormData({
+                      ...formData,
+                      function_name: e.target.value,
+                      path: formData.path || (selectedFunc ? selectedFunc.name : ''),
+                      description: formData.description || selectedFunc?.description || '',
+                    });
+                  }}
+                  required
+                  className="input"
+                >
+                  <option value="">Select a function...</option>
+                  {functions?.map((func: any) => (
+                    <option key={func.id} value={`${func.namespace}/${func.name}`}>
+                      {func.namespace}/{func.name} {func.description ? `- ${func.description}` : ''}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 mt-1">
+                  The function that will be called when this webhook is triggered
+                </p>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    Agent to Trigger *
+                  </label>
+                  <select
+                    value={formData.agent_name}
+                    onChange={(e) => {
+                      const selectedAgent = agents?.find((a: any) => `${a.namespace}/${a.name}` === e.target.value);
+                      setFormData({
+                        ...formData,
+                        agent_name: e.target.value,
+                        path: formData.path || (selectedAgent ? selectedAgent.name : ''),
+                        description: formData.description || selectedAgent?.description || '',
+                      });
+                    }}
+                    required
+                    className="input"
+                  >
+                    <option value="">Select an agent...</option>
+                    {agents?.map((agent: any) => (
+                      <option key={agent.id} value={`${agent.namespace}/${agent.name}`}>
+                        {agent.namespace}/{agent.name} {agent.description ? `- ${agent.description}` : ''}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    The agent that will receive a message when this webhook is triggered
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    Message Template *
+                  </label>
+                  <textarea
+                    value={formData.message_template}
+                    onChange={(e) => setFormData({ ...formData, message_template: e.target.value })}
+                    placeholder={'New issue {{ issue.key }}: {{ issue.fields.summary }}'}
+                    rows={4}
+                    required
+                    className="input font-mono text-sm"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    Jinja2 template rendered against the request payload — the result is sent to the agent as the user message
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    Session Key Template
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.session_key_template}
+                    onChange={(e) => setFormData({ ...formData, session_key_template: e.target.value })}
+                    placeholder={'jira-{{ issue.key }}'}
+                    className="input font-mono text-sm"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    Optional Jinja2 template — events rendering the same key continue the same conversation
+                  </p>
+                </div>
+              </>
+            )}
 
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">
@@ -334,6 +464,18 @@ print(result["execution_id"], result["result"])`,
                     <p className="text-xs text-gray-500">Return 202 immediately, run in background</p>
                   </div>
                 </label>
+                {formData.target_type === 'function' && (
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="response_mode" value="raw"
+                      checked={formData.response_mode === 'raw'}
+                      onChange={() => setFormData({ ...formData, response_mode: 'raw' })}
+                      className="text-primary-600" />
+                    <div>
+                      <span className="text-sm text-gray-200">Raw</span>
+                      <p className="text-xs text-gray-500">Function return value becomes the response body</p>
+                    </div>
+                  </label>
+                )}
               </div>
             </div>
 

--- a/console/src/pages/WebhookEditor.tsx
+++ b/console/src/pages/WebhookEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient, API_BASE_URL } from '../lib/api';
+import { apiClient, API_BASE_URL, getApiErrorMessage } from '../lib/api';
 import { ArrowLeft, Save, Trash2 } from 'lucide-react';
 import { ApiUsage } from '../components/ApiUsage';
 
@@ -93,7 +93,9 @@ export function WebhookEditor() {
         payload.agent_namespace = agentNamespace;
         payload.agent_name = agentName;
         payload.message_template = data.message_template;
-        payload.session_key_template = data.session_key_template || null;
+        // '' rather than null: the API treats null as 'leave unchanged',
+        // so sending null made clearing the field a silent no-op.
+        payload.session_key_template = data.session_key_template || '';
       } else {
         const [namespace, name] = data.function_name.split('/');
         payload.function_namespace = namespace;
@@ -570,7 +572,7 @@ print(result["execution_id"], result["result"])`,
 
         {saveMutation.isError && (
           <div className="p-4 bg-red-900/20 border border-red-800/30 rounded-lg text-sm text-red-400">
-            Failed to save webhook. Please check your configuration.
+            {getApiErrorMessage(saveMutation.error, 'Failed to save webhook. Please check your configuration.')}
           </div>
         )}
 

--- a/console/src/pages/Webhooks.tsx
+++ b/console/src/pages/Webhooks.tsx
@@ -52,9 +52,15 @@ export function Webhooks() {
                     </div>
                     <p className="text-sm text-gray-400 mt-1">{webhook.description || 'No description'}</p>
                     <div className="flex items-center gap-4 mt-1">
-                      <p className="text-xs text-gray-500">
-                        Function: <span className="font-mono">{webhook.function_namespace}/{webhook.function_name}</span>
-                      </p>
+                      {webhook.target_type === 'agent' ? (
+                        <p className="text-xs text-gray-500">
+                          Agent: <span className="font-mono">{webhook.agent_namespace}/{webhook.agent_name}</span>
+                        </p>
+                      ) : (
+                        <p className="text-xs text-gray-500">
+                          Function: <span className="font-mono">{webhook.function_namespace}/{webhook.function_name}</span>
+                        </p>
+                      )}
                       {webhook.requires_auth && (
                         <span className="text-xs text-green-600 font-medium">🔒 Auth Required</span>
                       )}

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -495,8 +495,13 @@ export interface EnabledConnectorConfig {
 export interface Webhook {
   id: string;
   path: string;
+  target_type: 'function' | 'agent';
   function_namespace: string;
-  function_name: string;
+  function_name: string | null;
+  agent_namespace: string | null;
+  agent_name: string | null;
+  message_template: string | null;
+  session_key_template: string | null;
   http_method: string;
   description: string | null;
   default_values: Record<string, any> | null;
@@ -510,8 +515,13 @@ export interface Webhook {
 
 export interface WebhookCreate {
   path: string;
+  target_type?: 'function' | 'agent';
   function_namespace?: string;
-  function_name: string;
+  function_name?: string;
+  agent_namespace?: string;
+  agent_name?: string;
+  message_template?: string;
+  session_key_template?: string;
   http_method?: string;
   description?: string;
   default_values?: Record<string, any>;
@@ -521,8 +531,13 @@ export interface WebhookCreate {
 }
 
 export interface WebhookUpdate {
+  target_type?: 'function' | 'agent';
   function_namespace?: string;
   function_name?: string;
+  agent_namespace?: string;
+  agent_name?: string;
+  message_template?: string;
+  session_key_template?: string;
   http_method?: string;
   description?: string;
   default_values?: Record<string, any>;

--- a/docs-mint/triggers/webhooks.mdx
+++ b/docs-mint/triggers/webhooks.mdx
@@ -4,7 +4,7 @@ description: "Inbound HTTP webhook handlers"
 ---
 
 
-Webhooks expose functions as HTTP endpoints. When a request arrives at a webhook path, Sinas executes the linked function with the request data.
+Webhooks expose functions and agents as HTTP endpoints. When a request arrives at a webhook path, Sinas either executes the linked function with the request data, or renders a message from the request payload and sends it to the linked agent.
 
 **Key properties:**
 
@@ -12,9 +12,15 @@ Webhooks expose functions as HTTP endpoints. When a request arrives at a webhook
 |---|---|
 | `path` | URL path (e.g., `stripe/payment-webhook`) |
 | `http_method` | GET, POST, PUT, DELETE, or PATCH |
-| `function_namespace` / `function_name` | Target function |
-| `requires_auth` | Whether the caller must provide a Bearer token |
+| `target_type` | `function` (default) or `agent` |
+| `function_namespace` / `function_name` | Target function (function targets) |
+| `agent_namespace` / `agent_name` | Target agent (agent targets) |
+| `message_template` | Jinja2 template rendered against the request payload; the result is sent to the agent as the user message (agent targets) |
+| `session_key_template` | Optional Jinja2 template; events rendering the same key continue the same conversation (agent targets) |
+| `requires_auth` | Whether the caller must provide a Bearer token or API key |
 | `default_values` | Default parameters merged with request data (request takes priority) |
+| `response_mode` | `sync` (default), `async`, or `raw` (function targets only) |
+| `dedup` | Optional deduplication: `{key, ttl_seconds}` where key is a JSONPath (`$.event.id`) or `header:X-Header-Name` |
 
 **How input is extracted:**
 
@@ -22,7 +28,63 @@ Webhooks expose functions as HTTP endpoints. When a request arrives at a webhook
 - `GET` → query parameters become the input
 - Default values are merged underneath (request data overrides)
 
-**Example:**
+## Response modes
+
+| Mode | Behavior |
+|---|---|
+| `sync` | Wait for the result and return it wrapped in an envelope: `{"success": true, "execution_id": ..., "result": ...}` (function targets) or `{"success": true, "chat_id": ..., "reply": ...}` (agent targets) |
+| `async` | Return `202` immediately with an identifier; execution continues in the background. Recommended for provider webhooks with delivery timeouts. |
+| `raw` | Function targets only. Wait for the result and return the function's return value as the **literal HTTP response body** — no envelope. |
+
+### Raw mode
+
+In raw mode the function's return value becomes the response body: a dict or list is returned as JSON, a string as `text/plain`. This is required for providers that expect a specific response body, e.g. Slack's Events API `url_verification` handshake:
+
+```python
+def handler(input):
+    if input.get("type") == "url_verification":
+        return {"challenge": input["challenge"]}
+    # ... handle other events
+    return {"ok": True}
+```
+
+For full control over status code and headers, return a dict using the reserved keys `_status`, `_headers`, and `_body`:
+
+```python
+return {"_status": 201, "_headers": {"X-Request-Id": "abc"}, "_body": {"ok": True}}
+```
+
+## Agent targets
+
+A webhook can trigger an agent directly, without a bridge function. The request payload is rendered through `message_template` (Jinja2) and sent to the agent as a user message. Undefined template variables render as empty strings — an unexpected payload shape never fails the webhook.
+
+With a `session_key_template`, repeated events that render the same key continue the same conversation (like the `session_key` on `POST /agents/{ns}/{name}/invoke`) — e.g. all events for one Jira issue or one Slack thread share a chat. Without it, each delivery starts a fresh chat.
+
+- `sync` waits for the agent's reply and returns `{"success": true, "chat_id": ..., "reply": "..."}`
+- `async` returns `202` with `{"chat_id": ..., "job_id": ...}` — use this for provider webhooks
+- For authenticated webhooks the caller needs chat permission on the target agent (`sinas.agents/{ns}/{name}.chat`); unauthenticated webhooks run as the webhook owner
+- Deduplication works identically for both target types
+
+**Declarative config (YAML):**
+
+```yaml
+webhooks:
+  - path: jira/issue-created
+    targetType: agent
+    agentName: jira/triage
+    messageTemplate: |
+      New issue {{ issue.key }}: {{ issue.fields.summary }}
+    sessionKeyTemplate: "jira-{{ issue.key }}"
+    responseMode: async
+    requiresAuth: false
+    dedup:
+      key: "header:X-Atlassian-Webhook-Identifier"
+      ttlSeconds: 3600
+```
+
+Function-target webhooks in YAML are unchanged (`functionName: namespace/name`); `responseMode: raw` is available for them as well.
+
+**Example (function target):**
 
 ```bash
 # Create a webhook
@@ -44,6 +106,24 @@ curl -X POST https://yourdomain.com/webhooks/stripe/payment \
   -d '{"event": "charge.succeeded", "amount": 1000}'
 
 # Function receives: {"source": "stripe", "event": "charge.succeeded", "amount": 1000}
+```
+
+**Example (agent target):**
+
+```bash
+curl -X POST https://yourdomain.com/api/v1/webhooks \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "jira/issue-created",
+    "target_type": "agent",
+    "agent_namespace": "jira",
+    "agent_name": "triage",
+    "message_template": "New issue {{ issue.key }}: {{ issue.fields.summary }}",
+    "session_key_template": "jira-{{ issue.key }}",
+    "response_mode": "async",
+    "requires_auth": false
+  }'
 ```
 
 **Endpoints:**


### PR DESCRIPTION
## Summary

Two webhook features that close the gap with schedules and unblock provider integrations:

### 1. Native agent targets (`targetType: agent`)
Webhooks can now trigger an agent directly — no bridge function needed. Mirrors the schedule design (`scheduleType: function | agent`):

```yaml
webhooks:
  - path: jira/issue-created
    targetType: agent
    agentName: jira/triage
    messageTemplate: |
      New issue {{ issue.key }}: {{ issue.fields.summary }}
    sessionKeyTemplate: "jira-{{ issue.key }}"
    responseMode: async
    dedup: { key: "header:X-Atlassian-Webhook-Identifier", ttlSeconds: 3600 }
```

- `messageTemplate` / `sessionKeyTemplate` are Jinja2, rendered against the request payload (defaults merged). Undefined variables render empty and are logged — a payload shape change never fails the webhook; a fully-empty render falls back to the JSON payload.
- Session-key chat reuse works like `POST /agents/{ns}/{name}/invoke` — repeated events for the same issue/thread continue one conversation; without a key each delivery gets a fresh chat.
- `sync` waits for the agent reply (`{success, chat_id, reply}`), `async` returns 202 with `{chat_id, job_id}` (chat committed before enqueue so the worker sees it).
- Authenticated webhooks check `sinas.agents/{ns}/{name}.chat` (all, or own + webhook owner) — analogous to the function execute check; `requires_auth: false` runs as the webhook owner, unchanged.
- Dedup behaves identically for both target types.

### 2. Raw response mode (`responseMode: raw`, function targets only)
The function's return value becomes the literal HTTP response body — no `{"success": ..., "result": ...}` envelope. dict/list → JSON, str → text/plain. Optional `{"_status", "_headers", "_body"}` convention for full control. This is what Slack's `url_verification` handshake and Telegram's reply-in-response pattern need. Dedup replay caches and replays the raw body (status, headers, content type), not the envelope.

### Scope
- Model + Alembic migration (`w2a3b4t5g6t7`, revises `70ea30af567e`): `target_type`, `agent_namespace`, `agent_name`, `message_template`, `session_key_template`; `function_name` now nullable.
- API schemas with cross-field validation (agent fields required for agent targets, `raw` rejected for agent targets); CRUD endpoints verify the target agent exists.
- Config YAML round-trip: `WebhookConfig` validation, parser reference validation (agent refs against config+DB), apply, export (function-target exports unchanged byte-for-byte).
- Console: target-type toggle (function/agent) in the webhook editor like the schedule editor, agent picker, template fields, `raw` radio (function-only), list page shows agent targets.
- Docs: `docs-mint/triggers/webhooks.mdx`.
- Also fixes a latent parser bug: `scheduleType: agent` schedules KeyError'd on the missing `functionName` during reference validation.

### Backward compatibility
Existing webhooks (no `targetType`) behave exactly as before; sync envelope, async 202 body, and dedup cache format for existing modes are unchanged.

### Tests
`tests/unit/test_webhook_targets.py` — 39 tests: schema/config validation, template rendering, raw response building + dedup replay, serializer round-trip, parser reference validation (incl. the schedule regression), CRUD API, and runtime paths (raw body, sync envelope, agent async enqueue, session-key chat reuse, undefined-template resilience). Full suite: 175 passed.

Out of scope (kept compatible, not implemented): platform-level HMAC signature verification, declarative event filters, header passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)