### PR TITLE
feat(deploy): toggles to disable code execution and the built-in database

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -191,6 +191,22 @@ class Settings(BaseSettings):
     sandbox_max_executions: int = 100  # Recycle container after this many executions
     sandbox_acquire_timeout: int = 30  # Seconds to wait for a container
 
+    # Optional platform features. Both default to on (no change for existing
+    # deployments); turning them off removes capability rather than hiding it,
+    # so the affected endpoints reject explicitly instead of failing oddly.
+    #
+    # code_execution_enabled=False disables ALL execution of user-supplied code:
+    # Functions and the agent `codeExecution` tool. Pair it with
+    # SANDBOX_EXECUTOR=disabled for the lightest deployment — no sandbox pool,
+    # no per-execution pods, no executor image needed.
+    code_execution_enabled: bool = True
+    # builtin_database_enabled=False skips creating the `sinas_data` database
+    # and its default DatabaseConnection record on startup. This is about not
+    # provisioning a data store the operator never asked for (they bring their
+    # own connections); it does NOT affect the platform's own Postgres, and an
+    # already-created record is left alone.
+    builtin_database_enabled: bool = True
+
     # Package management
     allow_package_installation: bool = True
     allowed_packages: Optional[str] = None  # Comma-separated whitelist, None = all allowed

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -73,7 +73,7 @@ async def lifespan(app: FastAPI):
     # endpoints can report accurate state.  The workers/pool are *created* by
     # the arq worker process or explicit scale calls; here we only discover.
     # Skipped entirely for non-Docker executors (k8s / single-container).
-    if settings.sandbox_executor == "docker_pool":
+    if settings.code_execution_enabled and settings.sandbox_executor == "docker_pool":
         try:
             from app.services.container_pool import container_pool
 
@@ -85,7 +85,7 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             print(f"⚠️  Container pool discovery skipped: {e}")
 
-    if settings.trusted_executor == "docker_shared":
+    if settings.code_execution_enabled and settings.trusted_executor == "docker_shared":
         try:
             from app.services.shared_worker_manager import shared_worker_manager
 

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -229,7 +229,7 @@ async def function_worker_startup(ctx: dict) -> None:
     # Discover shared worker containers (created by scheduler).
     # Retry a few times — the scheduler may still be starting up.
     # Skipped for non-Docker executors (k8s / single-container).
-    if settings.trusted_executor == "docker_shared":
+    if settings.code_execution_enabled and settings.trusted_executor == "docker_shared":
         from app.services.shared_worker_manager import shared_worker_manager
 
         for attempt in range(10):
@@ -244,7 +244,7 @@ async def function_worker_startup(ctx: dict) -> None:
         print(f"✅ Discovered {len(shared_worker_manager.workers)} shared containers")
 
     # Discover existing sandbox containers (created by backend leader)
-    if settings.sandbox_executor == "docker_pool":
+    if settings.code_execution_enabled and settings.sandbox_executor == "docker_pool":
         from app.services.container_pool import container_pool
 
         await container_pool._discover_existing_containers()
@@ -286,7 +286,7 @@ async def agent_worker_startup(ctx: dict) -> None:
     from app.core.database import AsyncSessionLocal  # noqa: F401
 
     # Discover sandbox containers (needed for code execution tool)
-    if settings.sandbox_executor == "docker_pool":
+    if settings.code_execution_enabled and settings.sandbox_executor == "docker_pool":
         from app.services.container_pool import container_pool
 
         await container_pool._discover_existing_containers()

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -52,6 +52,17 @@ async def _maintain_tool_result_partitions() -> None:
 
 async def _initialize_builtin_database() -> None:
     """Ensure the sinas_data database and its Database Connection record exist."""
+    if not settings.builtin_database_enabled:
+        # Operators who bring their own connections shouldn't have a data store
+        # provisioned for them. Only creation is skipped — an already-created
+        # sinas_data database and its record are left untouched, so toggling
+        # this off is not destructive and can be reversed.
+        logger.info(
+            "Built-in database disabled (BUILTIN_DATABASE_ENABLED=false) — "
+            "not creating sinas_data or its Database Connection"
+        )
+        return
+
     direct_host = settings.database_direct_host or settings.database_host
     try:
         conn = await asyncpg.connect(
@@ -241,25 +252,34 @@ async def main() -> None:
     await _initialize_builtin_database()
 
     # --- Sandbox containers ---
-    async with AsyncSessionLocal() as db:
-        if settings.sandbox_executor == "docker_pool":
-            await container_pool.initialize(db)
-        elif settings.sandbox_executor == "docker_ephemeral":
-            # No warm pool — untrusted code runs in a fresh container per
-            # execution. Pre-build the baked sandbox image so the first
-            # execution doesn't pay the build (it self-corrects otherwise).
-            from app.services.sandbox_image import build_sandbox_image
+    # Skipped entirely when code execution is off: no warm pool, no baked image
+    # build, no shared workers. This is where the footprint saving actually
+    # comes from — the executors are the heavy part, not the API process.
+    if not settings.code_execution_enabled:
+        logger.info(
+            "Code execution disabled (CODE_EXECUTION_ENABLED=false) — "
+            "skipping sandbox and shared-worker initialization"
+        )
+    else:
+        async with AsyncSessionLocal() as db:
+            if settings.sandbox_executor == "docker_pool":
+                await container_pool.initialize(db)
+            elif settings.sandbox_executor == "docker_ephemeral":
+                # No warm pool — untrusted code runs in a fresh container per
+                # execution. Pre-build the baked sandbox image so the first
+                # execution doesn't pay the build (it self-corrects otherwise).
+                from app.services.sandbox_image import build_sandbox_image
 
-            try:
-                await build_sandbox_image(db)
-            except Exception as e:
-                logger.warning(
-                    "Sandbox image pre-build failed (will build on demand): %s", e
-                )
+                try:
+                    await build_sandbox_image(db)
+                except Exception as e:
+                    logger.warning(
+                        "Sandbox image pre-build failed (will build on demand): %s", e
+                    )
 
-    # --- Shared containers ---
-    if settings.trusted_executor == "docker_shared":
-        await shared_worker_manager.initialize()
+        # --- Shared containers ---
+        if settings.trusted_executor == "docker_shared":
+            await shared_worker_manager.initialize()
 
     # --- APScheduler ---
     await scheduler.start()

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -98,6 +98,17 @@ async def execute(
     """
     effective_timeout = timeout or settings.code_execution_timeout
     execution_id = str(uuid.uuid4())
+
+    if not settings.code_execution_enabled:
+        # Belt and braces: the tool isn't advertised when disabled, but a model
+        # can still emit a call for a tool it saw earlier in the conversation.
+        return {
+            "stdout": "",
+            "stderr": "Code execution is disabled on this deployment.",
+            "result": None,
+            "duration_ms": 0,
+            "error": "Code execution is disabled on this deployment.",
+        }
     start_time = time.time()
 
     # Wrap the user code so we capture stdout and the last expression result.

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -248,6 +248,14 @@ class FunctionExecutor:
         embedded in the per-execution access token so a nested call can
         compute its own depth and be bounded by settings.max_execution_depth.
         """
+        # Single choke point for every trigger type (API, webhook, schedule,
+        # agent tool, CDC), so one guard disables user-code execution platform
+        # wide rather than each entry point remembering to check.
+        if not settings.code_execution_enabled:
+            raise FunctionExecutionError(
+                "Function execution is disabled on this deployment "
+                "(CODE_EXECUTION_ENABLED=false)."
+            )
         async with AsyncSessionLocal() as db:
             # Get user info for context
             from app.core.auth import create_access_token

--- a/backend/app/services/tool_discovery.py
+++ b/backend/app/services/tool_discovery.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_user_permissions
+from app.core.config import settings
 from app.core.permissions import check_permission
 from app.models import Agent, Chat
 from app.models.execution import Execution, ExecutionStatus
@@ -322,7 +323,9 @@ async def get_available_tools(
     # Bind Sinas system tools (opt-in platform capabilities)
     from app.services.system_tool_helpers import has_system_tool
     system_tools = agent.system_tools or []
-    if has_system_tool(system_tools, "codeExecution"):
+    # Not advertised when disabled: offering a tool the platform will refuse
+    # wastes context and invites retry loops when the model keeps trying it.
+    if has_system_tool(system_tools, "codeExecution") and settings.code_execution_enabled:
         tools.append(await get_code_exec_tool_definition(db))
     if has_system_tool(system_tools, "packageManagement"):
         from app.services.package_tools import get_package_tool_definitions

--- a/backend/tests/unit/test_feature_toggles.py
+++ b/backend/tests/unit/test_feature_toggles.py
@@ -1,0 +1,70 @@
+"""Deployment feature toggles: code execution and the built-in database.
+
+Both default on. Off means the capability is *removed* — the tool is not
+advertised to the model, execution is refused explicitly, and the heavy
+executor startup is skipped — rather than left half-present to fail oddly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services.code_execution import execute as execute_code
+
+
+class TestCodeExecutionToggle:
+    def test_enabled_by_default(self):
+        from app.core.config import Settings
+
+        assert Settings().code_execution_enabled is True
+
+    async def test_disabled_refuses_with_a_clear_error(self):
+        """A model can still emit a call for a tool it saw earlier in the
+        conversation, so the executor itself must refuse rather than rely on
+        the tool simply being absent."""
+        with patch("app.services.code_execution.settings") as s:
+            s.code_execution_enabled = False
+            s.code_execution_timeout = 120
+            result = await execute_code("print('hi')")
+
+        assert result["result"] is None
+        assert "disabled" in result["error"].lower()
+        # Shaped like a normal result so the agent loop handles it uniformly
+        assert set(result) >= {"stdout", "stderr", "result", "duration_ms", "error"}
+
+    async def test_function_execution_is_refused(self):
+        """execute_function is the single choke point for every trigger type
+        (API, webhook, schedule, agent tool, CDC)."""
+        from app.services.execution_engine import FunctionExecutionError, executor
+
+        with patch("app.services.execution_engine.settings") as s:
+            s.code_execution_enabled = False
+            with pytest.raises(FunctionExecutionError, match="disabled"):
+                await executor.execute_function(
+                    function_namespace="default",
+                    function_name="whatever",
+                    input_data={},
+                    execution_id="e1",
+                    trigger_type="api",
+                    trigger_id="t1",
+                    user_id="u1",
+                )
+
+
+class TestBuiltinDatabaseToggle:
+    def test_enabled_by_default(self):
+        from app.core.config import Settings
+
+        assert Settings().builtin_database_enabled is True
+
+    async def test_disabled_skips_creation_without_touching_anything(self):
+        """Only creation is skipped: no connection is opened, so an existing
+        sinas_data database and its record are left intact and the toggle is
+        reversible."""
+        from app.scheduler import service as scheduler_service
+
+        with patch.object(scheduler_service, "settings") as s:
+            s.builtin_database_enabled = False
+            with patch.object(scheduler_service, "asyncpg") as pg:
+                await scheduler_service._initialize_builtin_database()
+                pg.connect.assert_not_called()

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -119,6 +119,10 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
       name: {{ .Release.Name }}-secrets
       key: clickhouse-password
 {{- end }}
+- name: CODE_EXECUTION_ENABLED
+  value: {{ .Values.features.codeExecution | quote }}
+- name: BUILTIN_DATABASE_ENABLED
+  value: {{ .Values.features.builtinDatabase | quote }}
 - name: BACKEND_PORT
   value: "8000"
 {{- with .Values.extraEnv }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -186,6 +186,20 @@ smtp:
   domain: ""
   ipv4: ""
 
+## Optional platform features. Both default on — turning one off removes the
+## capability (endpoints reject explicitly rather than failing oddly).
+features:
+  ## false disables ALL user-code execution: Functions and the agent
+  ## codeExecution tool. Also skips sandbox/shared-worker startup entirely, so
+  ## no pool, no per-execution pods, and no executor image is needed — the
+  ## biggest single footprint saving available.
+  codeExecution: true
+  ## false skips creating the `sinas_data` database and its default Database
+  ## Connection on startup, for operators who only use their own connections.
+  ## Does NOT affect the platform's own Postgres, and leaves an already-created
+  ## record untouched.
+  builtinDatabase: true
+
 ## Extra environment variables appended to every sinas service (backend,
 ## queue workers, scheduler, cdc-worker). Any backend Settings knob
 ## (app/core/config.py) can be set here without a chart change, e.g.:

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -69,6 +69,16 @@ Required when `AUTH_MODE` is `otp` or `password+otp`. Skip entirely for `passwor
 | `MAX_EXECUTION_DEPTH` | _(= workers)_ | Max nesting depth for execution chains (a function/agent invoking another execution). A deeper call is rejected fast instead of deadlocking the shared pool. Defaults to `DEFAULT_WORKER_COUNT`; `0` disables. |
 | `SHARED_POOL_RESERVE` | `0` | Shared-worker slots reserved for nested calls so a parent waiting on a child can't starve the pool. `0` = off. For full single-chain safety set to `MAX_EXECUTION_DEPTH - 1`. |
 
+## Optional Features
+
+Both default on. Turning one off removes the capability — affected endpoints
+reject explicitly rather than half-working.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CODE_EXECUTION_ENABLED` | `true` | `false` disables **all** execution of user-supplied code: Functions and the agent `codeExecution` tool. The tool is not advertised to the model, function execution is refused at every trigger (API, webhook, schedule, agent, CDC), and sandbox/shared-worker startup is skipped entirely — no pool, no per-execution pods, no executor image. The single biggest footprint reduction available. |
+| `BUILTIN_DATABASE_ENABLED` | `true` | `false` skips creating the `sinas_data` database and its default Database Connection at startup, for deployments that only use their own connections. Does **not** affect the platform's own PostgreSQL, and an already-created database and record are left untouched (so the toggle is reversible and non-destructive). |
+
 ## Executors
 
 How Sinas runs user code. `SANDBOX_EXECUTOR` handles untrusted code


### PR DESCRIPTION
Two opt-out features for lighter / narrower deployments. **Both default on**, so nothing changes for existing installs.

## `CODE_EXECUTION_ENABLED=false`

Removes user-code execution entirely — Functions *and* the agent `codeExecution` tool:

- the tool is **not advertised** to the model (offering a tool the platform will refuse wastes context and invites retry loops)
- `code_execution.execute()` refuses anyway — a model can still call a tool it saw earlier in the conversation
- `execution_engine.execute_function()` refuses; it's the **single choke point** for every trigger (API, webhook, schedule, agent tool, CDC), so one guard covers them all
- sandbox pool / baked-image build / shared-worker init, and the workers' pool discovery, are all **skipped**

That last point is the actual footprint win — the executors are the heavy part, not the API process. Pairs naturally with the compact profile.

## `BUILTIN_DATABASE_ENABLED=false`

Skips creating `sinas_data` and its default Database Connection at startup, for operators who only use their own connections.

To be precise about scope: this is **not** about disabling PostgreSQL. It does not touch the platform's own database, and only *creation* is skipped — an existing `sinas_data` and its record are left intact, so the toggle is reversible and non-destructive.

## Helm

Exposed as `features.codeExecution` / `features.builtinDatabase`; rendered into every service's env. `helm lint` + template verified for both values.

## Tests

5 new tests: defaults on; disabled code execution returns a normal-shaped result carrying a clear error; `execute_function` raises; the built-in DB path opens **no connection at all** when disabled (proving nothing existing is touched). Full suite 204/204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)