### PR TITLE
fix(config): Phase-0 defects — unsafe secret matching, boot crash, lost notifications

### DIFF
--- a/backend/app/api/v1/endpoints/config.py
+++ b/backend/app/api/v1/endpoints/config.py
@@ -109,7 +109,9 @@ async def apply_config(
                 summary={},
                 changes=[],
                 errors=[f"{e.path}: {e.message}" for e in validation.errors],
-                warnings=[f"{w.path}: {w.message}" for w in validation.warnings],
+                # warnings are plain strings; formatting them as objects
+                # turned every warned-about invalid config into a 500.
+                warnings=list(validation.warnings),
             )
 
         # Apply configuration
@@ -117,7 +119,7 @@ async def apply_config(
         result = await apply_service.apply_config(config, dry_run=apply_request.dryRun)
 
         # Add validation warnings to result
-        result.warnings.extend([f"{w.path}: {w.message}" for w in validation.warnings])
+        result.warnings.extend(validation.warnings)
 
         return result
 

--- a/backend/app/api/v1/endpoints/database_triggers.py
+++ b/backend/app/api/v1/endpoints/database_triggers.py
@@ -31,6 +31,26 @@ async def _notify_cdc(action: str, trigger_id: str) -> None:
     await redis.publish(CDC_CHANNEL, json.dumps({"action": action, "trigger_id": trigger_id}))
 
 
+
+async def _resolve_trigger(db: AsyncSession, name: str, user_id, has_all: bool):
+    """Resolve a trigger by name for this caller.
+
+    Trigger names are unique per (user_id, name), NOT globally — so selecting on
+    the name alone raised MultipleResultsFound (a 500) the moment two users
+    picked the same name, e.g. "daily-sync". Scope to the caller unless they
+    hold the :all permission, and prefer their own row when several exist.
+    Scoping also means another user's trigger reads as 404 rather than 403, so
+    the endpoint stops disclosing which names exist.
+    """
+    query = select(DatabaseTrigger).where(DatabaseTrigger.name == name)
+    if not has_all:
+        query = query.where(DatabaseTrigger.user_id == user_id)
+    rows = (await db.execute(query)).scalars().all()
+    if not rows:
+        return None
+    return next((t for t in rows if str(t.user_id) == str(user_id)), rows[0])
+
+
 @router.post("", response_model=DatabaseTriggerResponse, status_code=status.HTTP_201_CREATED)
 async def create_database_trigger(
     request: Request,
@@ -138,8 +158,8 @@ async def get_database_trigger(
     """Get a specific database trigger by name."""
     user_id, permissions = current_user_data
 
-    result = await db.execute(select(DatabaseTrigger).where(DatabaseTrigger.name == name))
-    trigger = result.scalar_one_or_none()
+    has_all = check_permission(permissions, "sinas.database_triggers.read:all")
+    trigger = await _resolve_trigger(db, name, user_id, has_all)
 
     if not trigger:
         raise HTTPException(status_code=404, detail=f"Database trigger '{name}' not found")
@@ -166,8 +186,8 @@ async def update_database_trigger(
     """Update a database trigger."""
     user_id, permissions = current_user_data
 
-    result = await db.execute(select(DatabaseTrigger).where(DatabaseTrigger.name == name))
-    trigger = result.scalar_one_or_none()
+    has_all = check_permission(permissions, "sinas.database_triggers.update:all")
+    trigger = await _resolve_trigger(db, name, user_id, has_all)
 
     if not trigger:
         raise HTTPException(status_code=404, detail=f"Database trigger '{name}' not found")
@@ -217,8 +237,8 @@ async def delete_database_trigger(
     """Delete a database trigger."""
     user_id, permissions = current_user_data
 
-    result = await db.execute(select(DatabaseTrigger).where(DatabaseTrigger.name == name))
-    trigger = result.scalar_one_or_none()
+    has_all = check_permission(permissions, "sinas.database_triggers.delete:all")
+    trigger = await _resolve_trigger(db, name, user_id, has_all)
 
     if not trigger:
         raise HTTPException(status_code=404, detail=f"Database trigger '{name}' not found")

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -211,7 +211,9 @@ async def main() -> None:
                     config_yaml, db=db, strict=False
                 )
 
-                if not validation.valid:
+                # `is_valid`, not `valid`: the wrong name raised AttributeError
+                # here, so AUTO_APPLY_CONFIG=true crashed on every boot.
+                if not validation.is_valid:
                     logger.error("❌ Config validation failed:")
                     for error in validation.errors:
                         logger.error(f"  - {error.path}: {error.message}")
@@ -219,8 +221,10 @@ async def main() -> None:
 
                 if validation.warnings:
                     logger.warning("⚠️  Config validation warnings:")
+                    # warnings are plain strings (errors are the objects with
+                    # .path/.message) — treating them as objects also crashed.
                     for warning in validation.warnings:
-                        logger.warning(f"  - {warning.path}: {warning.message}")
+                        logger.warning(f"  - {warning}")
 
                 apply_service = ConfigApplyService(
                     db, config.metadata.name, owner_user_id=owner_user_id

--- a/backend/app/services/config_apply/integrations.py
+++ b/backend/app/services/config_apply/integrations.py
@@ -237,6 +237,7 @@ async def apply_schedules(
     track_change: Any,
     errors: list[str],
     warnings: list[str],
+    notify_scheduler: Any = None,
 ) -> None:
     """Apply schedule configurations"""
     for schedule_config in schedules:
@@ -288,6 +289,11 @@ async def apply_schedules(
                     existing.input_data = schedule_config.inputData
                     existing.is_active = schedule_config.isActive
                     existing.config_checksum = config_hash
+                    if notify_scheduler:
+                        # Without this the running scheduler never learns about
+                        # config-applied schedules and keeps the old cron (or
+                        # none) until it restarts.
+                        notify_scheduler("update", str(existing.id))
 
                 track_change("update", "schedules", schedule_config.name)
 
@@ -309,6 +315,11 @@ async def apply_schedules(
                         config_checksum=config_hash,
                     )
                     db.add(new_schedule)
+                    if notify_scheduler:
+                        # flush to obtain the generated id; the event itself is
+                        # published only after the transaction commits.
+                        await db.flush()
+                        notify_scheduler("create", str(new_schedule.id))
 
                 track_change("create", "schedules", schedule_config.name)
 

--- a/backend/app/services/config_apply/resources.py
+++ b/backend/app/services/config_apply/resources.py
@@ -150,7 +150,16 @@ async def apply_secrets(
     for secret_config in secrets:
         resource_name = secret_config.name
         try:
-            stmt = select(Secret).where(Secret.name == secret_config.name)
+            # Scope to shared secrets. Config declares platform-level secrets,
+            # while `private` rows are per-user overrides (see
+            # connector_service._resolve_secret_value). Matching on name alone
+            # could select — and then overwrite the value of — another user's
+            # private secret. Shared names are globally unique (partial unique
+            # index on name where visibility='shared'), so this stays a
+            # single-row lookup.
+            stmt = select(Secret).where(
+                Secret.name == secret_config.name, Secret.visibility == "shared"
+            )
             result = await db.execute(stmt)
             existing = result.scalar_one_or_none()
 
@@ -198,6 +207,10 @@ async def apply_secrets(
                     secret = Secret(
                         user_id=owner_user_id,
                         name=secret_config.name,
+                        # Explicit rather than relying on the model default:
+                        # visibility decides who can read this, so it should be
+                        # stated at the point of creation, not inherited.
+                        visibility="shared",
                         encrypted_value=encryption_service.encrypt(secret_config.value),
                         description=secret_config.description,
                         managed_by=managed_by,

--- a/backend/app/services/config_apply/service.py
+++ b/backend/app/services/config_apply/service.py
@@ -64,6 +64,12 @@ class ConfigApplyService:
         self.skip_resource_types = skip_resource_types or set()
         self.summary = ConfigApplySummary()
         self.changes: list[ResourceChange] = []
+        # Post-commit notifications. Collected during apply and published only
+        # after the transaction commits, so a worker can never observe an event
+        # for a row it cannot read yet. When auto_commit is False the caller
+        # owns the commit and must call flush_notifications() itself.
+        self._pending_scheduler: list[tuple[str, str]] = []
+        self._pending_cdc_reload = False
         self.errors: list[str] = []
         self.warnings: list[str] = []
 
@@ -115,6 +121,37 @@ class ConfigApplyService:
         summary_field = action_field_map.get(action, action)
         summary_dict = getattr(self.summary, summary_field)
         summary_dict[resource_type] = summary_dict.get(resource_type, 0) + 1
+
+
+    async def flush_notifications(self) -> None:
+        """Publish queued events to the scheduler and CDC workers.
+
+        Call AFTER the transaction commits. Callers that pass auto_commit=False
+        (package install, for one) own their commit and must call this, or
+        config-applied schedules never reach the running scheduler and CDC
+        triggers are not picked up until a restart. Best-effort throughout: a
+        notification failure must not fail an apply that already committed.
+        """
+        import json
+
+        from app.core.redis import get_redis
+
+        pending_jobs, self._pending_scheduler = self._pending_scheduler, []
+        cdc_reload, self._pending_cdc_reload = self._pending_cdc_reload, False
+        if not pending_jobs and not cdc_reload:
+            return
+        try:
+            redis = await get_redis()
+            for action, job_id in pending_jobs:
+                await redis.publish(
+                    "sinas:scheduler:jobs", json.dumps({"action": action, "job_id": job_id})
+                )
+            if cdc_reload:
+                await redis.publish(
+                    "sinas:cdc:triggers", json.dumps({"action": "reload", "trigger_id": ""})
+                )
+        except Exception as e:
+            logger.warning(f"Failed to publish config-apply notifications: {e}")
 
     async def apply_config(self, config: SinasConfig, dry_run: bool = False) -> ConfigApplyResponse:
         """
@@ -246,6 +283,9 @@ class ConfigApplyService:
                 await apply_schedules(
                     **common_with_owner,
                     schedules=config.spec.schedules,
+                    notify_scheduler=lambda action, job_id: self._pending_scheduler.append(
+                        (action, job_id)
+                    ),
                 )
             if "databaseTriggers" not in self.skip_resource_types:
                 await apply_database_triggers(
@@ -253,26 +293,11 @@ class ConfigApplyService:
                     triggers=config.spec.databaseTriggers,
                 )
 
-            if not dry_run and self.auto_commit:
-                await self.db.commit()
-                # Notify the CDC worker so database triggers created/updated via
-                # config apply (e.g. a Package install) are picked up without a
-                # restart — the REST endpoint notifies per-trigger, this path
-                # did not. One reconcile signal; the worker diffs running poll
-                # tasks against active triggers. Best-effort: never fail the
-                # apply on a notify error.
-                try:
-                    import json
-
-                    from app.core.redis import get_redis
-
-                    redis = await get_redis()
-                    await redis.publish(
-                        "sinas:cdc:triggers",
-                        json.dumps({"action": "reload", "trigger_id": ""}),
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to notify CDC after config apply: {e}")
+            if not dry_run:
+                self._pending_cdc_reload = True
+                if self.auto_commit:
+                    await self.db.commit()
+                    await self.flush_notifications()
 
             return ConfigApplyResponse(
                 success=True,

--- a/backend/app/services/package_service.py
+++ b/backend/app/services/package_service.py
@@ -158,6 +158,10 @@ class PackageService:
 
         # Single commit for everything
         await self.db.commit()
+        # auto_commit=False means the apply service left its notifications
+        # queued for us; without this a package's schedules never reach the
+        # running scheduler and its CDC triggers aren't picked up until restart.
+        await apply_service.flush_notifications()
         await self.db.refresh(package)
 
         return package, result

--- a/backend/tests/unit/test_config_apply_phase0.py
+++ b/backend/tests/unit/test_config_apply_phase0.py
@@ -1,0 +1,191 @@
+"""Phase-0 defects in the config-apply path.
+
+These are pre-existing bugs found while designing the config/CRUD unification;
+each test pins one so the eventual refactor can't silently reintroduce it.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.encryption import encryption_service
+from app.models.secret import Secret
+from app.services.config_parser import ConfigValidation
+
+
+# --------------------------------------------------------------------------
+# 1 + 2. The validation result contract (crashes on boot / on POST)
+# --------------------------------------------------------------------------
+
+def test_validation_exposes_is_valid_not_valid():
+    """scheduler/service.py read `validation.valid`, which does not exist —
+    AUTO_APPLY_CONFIG=true raised AttributeError on every boot."""
+    v = ConfigValidation()
+    assert v.is_valid is True
+    assert not hasattr(v, "valid")
+
+
+def test_validation_warnings_are_plain_strings():
+    """Both the scheduler and POST /config/apply formatted warnings as objects
+    (`w.path`/`w.message`); they are strings, so an invalid config WITH warnings
+    500'd instead of returning its validation errors."""
+    v = ConfigValidation()
+    v.warnings.append("SinasPackage should not define environment-specific resources")
+    assert all(isinstance(w, str) for w in v.warnings)
+    # the formatting the code now uses must work on a str
+    assert f"  - {v.warnings[0]}".endswith("resources")
+
+
+def test_startup_autoapply_formatting_smoke():
+    """Guards the exact expressions the startup path uses."""
+    v = ConfigValidation()
+    v.warnings.append("w1")
+    assert v.is_valid  # not v.valid
+    assert [f"  - {w}" for w in v.warnings] == ["  - w1"]
+
+
+# --------------------------------------------------------------------------
+# 3. Secrets applier could overwrite another user's PRIVATE secret
+# --------------------------------------------------------------------------
+
+class TestSecretsApplierScoping:
+    async def _apply(self, db: AsyncSession, owner_id, name, value):
+        from app.services.config_apply.resources import apply_secrets
+
+        class _Cfg:
+            def __init__(self, name, value):
+                self.name = name
+                self.value = value
+                self.description = None
+
+        changes: list = []
+        await apply_secrets(
+            db=db,
+            secrets=[_Cfg(name, value)],
+            dry_run=False,
+            managed_by="config",
+            config_name="test",
+            owner_user_id=owner_id,
+            calculate_hash=lambda d: "hash-" + str(sorted(d.items())),
+            track_change=lambda *a: changes.append(a),
+            errors=[],
+            warnings=[],
+        )
+        return changes
+
+    async def test_private_secret_of_another_user_is_not_overwritten(
+        self, db: AsyncSession, test_user, admin_user
+    ):
+        """A private secret is a per-user override. Config declares platform
+        (shared) secrets, so applying one must not reach into someone's private
+        row — which the name-only lookup did, replacing its value."""
+        private = Secret(
+            user_id=test_user.id,
+            name=f"API_KEY_{uuid.uuid4().hex[:6]}",
+            encrypted_value=encryption_service.encrypt("user-private-value"),
+            visibility="private",
+        )
+        db.add(private)
+        await db.flush()
+
+        await self._apply(db, str(admin_user.id), private.name, "config-value")
+        await db.flush()
+
+        await db.refresh(private)
+        assert encryption_service.decrypt(private.encrypted_value) == "user-private-value"
+
+    async def test_config_created_secret_is_explicitly_shared(
+        self, db: AsyncSession, admin_user
+    ):
+        name = f"SHARED_{uuid.uuid4().hex[:6]}"
+        await self._apply(db, str(admin_user.id), name, "v")
+        await db.flush()
+
+        row = (
+            await db.execute(select(Secret).where(Secret.name == name))
+        ).scalar_one()
+        assert row.visibility == "shared"
+
+    async def test_existing_shared_secret_is_updated(self, db: AsyncSession, admin_user):
+        """Regression guard: scoping to shared must not break the normal path."""
+        name = f"SHARED_{uuid.uuid4().hex[:6]}"
+        await self._apply(db, str(admin_user.id), name, "first")
+        await db.flush()
+        await self._apply(db, str(admin_user.id), name, "second")
+        await db.flush()
+
+        rows = (await db.execute(select(Secret).where(Secret.name == name))).scalars().all()
+        assert len(rows) == 1
+        assert encryption_service.decrypt(rows[0].encrypted_value) == "second"
+
+
+# --------------------------------------------------------------------------
+# 5 + 4. Post-commit notifications (schedules / CDC)
+# --------------------------------------------------------------------------
+
+class TestApplyNotifications:
+    async def test_flush_publishes_queued_events(self, db: AsyncSession, monkeypatch):
+        """Config-applied schedules never reached the running scheduler, and the
+        CDC reload was skipped entirely for callers using auto_commit=False."""
+        from app.services.config_apply.service import ConfigApplyService
+
+        published: list[tuple[str, str]] = []
+
+        class _FakeRedis:
+            async def publish(self, channel, payload):
+                published.append((channel, payload))
+
+        async def fake_get_redis():
+            return _FakeRedis()
+
+        monkeypatch.setattr("app.core.redis.get_redis", fake_get_redis)
+
+        svc = ConfigApplyService(db, "test-config", owner_user_id=None, auto_commit=False)
+        svc._pending_scheduler.append(("create", "job-1"))
+        svc._pending_cdc_reload = True
+
+        await svc.flush_notifications()
+
+        channels = [c for c, _ in published]
+        assert "sinas:scheduler:jobs" in channels
+        assert "sinas:cdc:triggers" in channels
+
+    async def test_flush_is_idempotent_and_clears_queue(self, db: AsyncSession, monkeypatch):
+        from app.services.config_apply.service import ConfigApplyService
+
+        calls: list = []
+
+        class _FakeRedis:
+            async def publish(self, channel, payload):
+                calls.append(channel)
+
+        async def fake_get_redis():
+            return _FakeRedis()
+
+        monkeypatch.setattr("app.core.redis.get_redis", fake_get_redis)
+
+        svc = ConfigApplyService(db, "c", owner_user_id=None, auto_commit=False)
+        svc._pending_scheduler.append(("create", "j"))
+        await svc.flush_notifications()
+        # assert the first flush really published — otherwise a missed
+        # monkeypatch would make the idempotency check below vacuously true
+        assert calls == ["sinas:scheduler:jobs"]
+
+        await svc.flush_notifications()  # queue drained; must be a no-op
+        assert calls == ["sinas:scheduler:jobs"]
+
+    async def test_notify_failure_does_not_break_apply(self, db: AsyncSession, monkeypatch):
+        """The transaction already committed; a notification problem must not
+        turn a successful apply into an error."""
+        from app.services.config_apply.service import ConfigApplyService
+
+        async def boom():
+            raise RuntimeError("redis down")
+
+        monkeypatch.setattr("app.core.redis.get_redis", boom)
+
+        svc = ConfigApplyService(db, "c", owner_user_id=None, auto_commit=False)
+        svc._pending_cdc_reload = True
+        await svc.flush_notifications()  # must not raise


### PR DESCRIPTION
Pre-existing bugs in the config-apply path, found while designing the config/CRUD unification (§3 of that design doc). Fixed independently of the refactor: several are user-visible, two are security-relevant, and all are small.

| # | Defect | Impact |
|---|---|---|
| 1 | Secrets applier matched on **name alone** | Applying a config could select and overwrite another user's **private** secret; created rows silently inherited `visibility='shared'` |
| 2 | `AUTO_APPLY_CONFIG=true` read `validation.valid` (attribute is `is_valid`) and formatted `str` warnings as objects | **Crashed on every boot** — the feature was 100% broken |
| 3 | `POST /config/apply` formatted `str` warnings as objects | **500** instead of returning validation errors, whenever an invalid config also had warnings |
| 4 | CDC reload only fired for `auto_commit=True` | Package installs never notified CDC → triggers not picked up until restart |
| 5 | Nothing published to `sinas:scheduler:jobs` | Config-applied schedules **never reached the running scheduler** |
| 6 | `database_triggers` GET/PATCH/DELETE selected by name unscoped | Names are unique per `(user_id, name)`, **not globally** → `MultipleResultsFound` **500** as soon as two users used the same name; also disclosed existence of others' triggers (403 vs 404) |

### Notes on the fixes

- **Secrets**: config declares *platform* secrets, while `private` rows are per-user overrides (see `connector_service._resolve_secret_value`). The lookup is now scoped to `visibility='shared'`, which is globally unique by name so it stays a single-row select.
- **Notifications**: both are now queued during apply and published by a new `flush_notifications()` **after the transaction commits** — a worker can never see an event for a row it can't read yet. The service calls it when it owns the commit; `package_service` (which passes `auto_commit=False`) calls it after its own. Best-effort: a notification failure can't fail an apply that already committed.
- **Triggers**: resolution is scoped to the caller unless they hold `:all`, preferring their own row when several exist.

### Tests

`tests/unit/test_config_apply_phase0.py` — 9 tests covering the validation contract, private-secret protection, shared-secret create/update, and the notification flush including idempotency and failure tolerance. **213/213 backend tests pass.**

### Deferred (tracked separately, larger)

Components never compiled; function-version churn on description-only updates; `${ENV_VAR}` interpolation documented but unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)