### PR TITLE
Pipelines: unified triggers + linear typed steps

### DIFF
--- a/backend/alembic/versions/p1i2p3l4n5s6_add_pipelines.py
+++ b/backend/alembic/versions/p1i2p3l4n5s6_add_pipelines.py
@@ -2,7 +2,7 @@
 agents.enabled_pipelines; database_triggers pipeline targets
 
 Revision ID: p1i2p3l4n5s6
-Revises: c1a2c3h4e5t6
+Revises: 70ea30af567e
 Create Date: 2026-07-28
 """
 import sqlalchemy as sa
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "p1i2p3l4n5s6"
-down_revision = "c1a2c3h4e5t6"
+down_revision = "70ea30af567e"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/p1i2p3l4n5s6_add_pipelines.py
+++ b/backend/alembic/versions/p1i2p3l4n5s6_add_pipelines.py
@@ -1,0 +1,141 @@
+"""add pipelines, pipeline_runs, pipeline_cursors; PIPELINE trigger type;
+agents.enabled_pipelines; database_triggers pipeline targets
+
+Revision ID: p1i2p3l4n5s6
+Revises: c1a2c3h4e5t6
+Create Date: 2026-07-28
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "p1i2p3l4n5s6"
+down_revision = "c1a2c3h4e5t6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # New TriggerType value for child executions of pipeline runs
+    op.execute("ALTER TYPE triggertype ADD VALUE IF NOT EXISTS 'PIPELINE'")
+
+    op.create_table(
+        "pipelines",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("namespace", sa.String(255), nullable=False, server_default="default", index=True),
+        sa.Column("name", sa.String(255), nullable=False, index=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("input_schema", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("steps", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("per_user", sa.JSON(), nullable=True),
+        sa.Column("as_tool", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("tool_description", sa.Text(), nullable=True),
+        sa.Column("sync_timeout_seconds", sa.Integer(), nullable=False, server_default="120"),
+        sa.Column("concurrency", sa.String(10), nullable=True),
+        sa.Column("disable_after_failures", sa.Integer(), nullable=True),
+        sa.Column("output_mapping", sa.JSON(), nullable=True),
+        sa.Column("cursor_value", sa.Text(), nullable=True),
+        sa.Column("consecutive_failures", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("managed_by", sa.Text(), nullable=True),
+        sa.Column("config_name", sa.Text(), nullable=True),
+        sa.Column("config_checksum", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("namespace", "name", name="uq_pipeline_namespace_name"),
+    )
+
+    op.create_table(
+        "pipeline_runs",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "pipeline_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("pipelines.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("run_id", sa.String(255), nullable=False, unique=True, index=True),
+        sa.Column(
+            "user_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "trigger_type",
+            sa.dialects.postgresql.ENUM(name="triggertype", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("trigger_id", sa.String(255), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default="running", index=True),
+        sa.Column("input", sa.JSON(), nullable=True),
+        sa.Column("steps", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("cursor_before", sa.Text(), nullable=True),
+        sa.Column("cursor_after", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+    )
+
+    op.create_table(
+        "pipeline_cursors",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "pipeline_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("pipelines.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("cursor_value", sa.Text(), nullable=True),
+        sa.Column("consecutive_failures", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("pipeline_id", "user_id", name="uq_pipeline_cursor_pipeline_user"),
+    )
+
+    # Agents can expose asTool pipelines
+    op.add_column(
+        "agents",
+        sa.Column("enabled_pipelines", sa.JSON(), nullable=False, server_default="[]"),
+    )
+
+    # Database triggers (CDC) gain a pipeline target
+    op.add_column(
+        "database_triggers",
+        sa.Column("target_type", sa.String(10), nullable=False, server_default="function"),
+    )
+    op.add_column("database_triggers", sa.Column("pipeline_namespace", sa.String(255), nullable=True))
+    op.add_column("database_triggers", sa.Column("pipeline_name", sa.String(255), nullable=True))
+    # function_name is no longer required (pipeline-target triggers have no function)
+    op.alter_column("database_triggers", "function_name", existing_type=sa.String(255), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("database_triggers", "function_name", existing_type=sa.String(255), nullable=False)
+    op.drop_column("database_triggers", "pipeline_name")
+    op.drop_column("database_triggers", "pipeline_namespace")
+    op.drop_column("database_triggers", "target_type")
+    op.drop_column("agents", "enabled_pipelines")
+    op.drop_table("pipeline_cursors")
+    op.drop_table("pipeline_runs")
+    op.drop_table("pipelines")
+    # Note: Cannot remove enum values in PostgreSQL

--- a/backend/alembic/versions/p1i2p3l4n5s6_add_pipelines.py
+++ b/backend/alembic/versions/p1i2p3l4n5s6_add_pipelines.py
@@ -2,7 +2,7 @@
 agents.enabled_pipelines; database_triggers pipeline targets
 
 Revision ID: p1i2p3l4n5s6
-Revises: 70ea30af567e
+Revises: w2a3b4t5g6t7
 Create Date: 2026-07-28
 """
 import sqlalchemy as sa
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "p1i2p3l4n5s6"
-down_revision = "70ea30af567e"
+down_revision = "w2a3b4t5g6t7"
 branch_labels = None
 depends_on = None
 
@@ -118,6 +118,10 @@ def upgrade() -> None:
         sa.Column("enabled_pipelines", sa.JSON(), nullable=False, server_default="[]"),
     )
 
+    # Webhooks gain a pipeline target (third target_type value, after #111's "agent")
+    op.add_column("webhooks", sa.Column("pipeline_namespace", sa.String(255), nullable=True))
+    op.add_column("webhooks", sa.Column("pipeline_name", sa.String(255), nullable=True))
+
     # Database triggers (CDC) gain a pipeline target
     op.add_column(
         "database_triggers",
@@ -130,6 +134,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.drop_column("webhooks", "pipeline_name")
+    op.drop_column("webhooks", "pipeline_namespace")
     op.alter_column("database_triggers", "function_name", existing_type=sa.String(255), nullable=False)
     op.drop_column("database_triggers", "pipeline_name")
     op.drop_column("database_triggers", "pipeline_namespace")

--- a/backend/app/api/runtime/__init__.py
+++ b/backend/app/api/runtime/__init__.py
@@ -1,7 +1,7 @@
 """Runtime API - Data Plane for execution, authentication, and runtime state."""
 from fastapi import APIRouter
 
-from app.api.runtime.endpoints import batches, manifests, authentication, chats, components, discovery, executions, files, functions, info, queries, stores, templates, webhooks
+from app.api.runtime.endpoints import batches, manifests, authentication, chats, components, discovery, executions, files, functions, info, pipelines, queries, stores, templates, webhooks
 
 runtime_router = APIRouter()
 
@@ -23,6 +23,9 @@ runtime_router.include_router(webhooks.router, prefix="/webhooks", tags=["runtim
 
 # Queries - query execution
 runtime_router.include_router(queries.router, tags=["runtime-queries"])
+
+# Pipelines - manual runs, run history, replay
+runtime_router.include_router(pipelines.router, tags=["runtime-pipelines"])
 
 # Executions - function execution history and status
 runtime_router.include_router(executions.router, tags=["runtime-executions"])

--- a/backend/app/api/runtime/endpoints/authentication.py
+++ b/backend/app/api/runtime/endpoints/authentication.py
@@ -456,6 +456,12 @@ async def connector_oauth_callback(
     ok = await connector_service.exchange_authorization_code(
         db=db, connector=connector, user_id=ctx["user_id"], code=code, code_verifier=ctx["code_verifier"],
     )
+    if ok:
+        # Re-credentialing is the recovery point for perUser pipelines that
+        # skip-listed this user after consecutive failures.
+        from app.services.pipeline_runner import reset_user_failure_state
+
+        await reset_user_failure_state(db, ctx["user_id"], connector_id=connector.id)
     result = _oauth_result_page(
         ok,
         f"Connected {connector.namespace}/{connector.name}." if ok

--- a/backend/app/api/runtime/endpoints/pipelines.py
+++ b/backend/app/api/runtime/endpoints/pipelines.py
@@ -1,0 +1,241 @@
+"""Runtime pipeline endpoints — manual runs, run history, replay."""
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user_with_permissions, set_permission_used
+from app.core.database import get_db
+from app.core.permissions import check_permission
+from app.models.execution import TriggerType
+from app.models.pipeline import Pipeline, PipelineRun
+from app.schemas.pipeline import (
+    PipelineFanOutResponse,
+    PipelineRunEnqueuedResponse,
+    PipelineRunRecord,
+    PipelineRunRequest,
+    PipelineRunResponse,
+)
+# Shared depth resolution with the runtime function endpoints (PR #81 semantics).
+from app.api.runtime.endpoints.functions import _resolve_child_depth
+from app.services import pipeline_runner
+from app.services.pipeline_runner import PipelineBusyError
+from app.services.queue_service import queue_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _check_run_permission(permissions: dict, namespace: str, name: str) -> tuple[bool, str]:
+    perm_own = f"sinas.pipelines/{namespace}/{name}.run:own"
+    return check_permission(permissions, perm_own), perm_own
+
+
+async def _load_pipeline(db: AsyncSession, namespace: str, name: str) -> Pipeline:
+    pipeline = await Pipeline.get_by_name(db, namespace, name)
+    if not pipeline:
+        raise HTTPException(status_code=404, detail=f"Pipeline '{namespace}/{name}' not found")
+    return pipeline
+
+
+# NOTE: literal-prefix routes (/pipelines/runs/...) are declared before the
+# parameterized ones so "runs" is never captured as a namespace.
+
+
+@router.get("/pipelines/runs/{run_id}", response_model=PipelineRunRecord)
+async def get_pipeline_run(
+    run_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """Fetch one run record (input, per-step summaries, error, cursor movement)."""
+    user_id, permissions = current_user_data
+
+    run = (
+        await db.execute(select(PipelineRun).where(PipelineRun.run_id == run_id))
+    ).scalar_one_or_none()
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+
+    pipeline = (
+        await db.execute(select(Pipeline).where(Pipeline.id == run.pipeline_id))
+    ).scalar_one_or_none()
+    ref = f"{pipeline.namespace}/{pipeline.name}" if pipeline else "?/?"
+
+    read_own = check_permission(permissions, f"sinas.pipelines/{ref}.read:own") if pipeline else False
+    read_all = check_permission(permissions, f"sinas.pipelines/{ref}.read:all") if pipeline else False
+    if not (read_all or (read_own and str(run.user_id) == user_id)):
+        raise HTTPException(status_code=403, detail="Not authorized to read this run")
+    set_permission_used(request, f"sinas.pipelines/{ref}.read")
+
+    return PipelineRunRecord.model_validate(run)
+
+
+@router.post("/pipelines/runs/{run_id}/replay", response_model=PipelineRunEnqueuedResponse, status_code=202)
+async def replay_pipeline_run(
+    run_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """Re-enqueue a run with its stored input (the dead-letter replay path).
+
+    Safe for cursor runs: a failed run never advanced the bookmark.
+    """
+    user_id, permissions = current_user_data
+
+    run = (
+        await db.execute(select(PipelineRun).where(PipelineRun.run_id == run_id))
+    ).scalar_one_or_none()
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+
+    pipeline = (
+        await db.execute(select(Pipeline).where(Pipeline.id == run.pipeline_id))
+    ).scalar_one_or_none()
+    if not pipeline:
+        raise HTTPException(status_code=404, detail="Pipeline for this run no longer exists")
+    if not pipeline.is_active:
+        raise HTTPException(status_code=400, detail="Pipeline is inactive")
+
+    ref = f"{pipeline.namespace}/{pipeline.name}"
+    run_own = check_permission(permissions, f"sinas.pipelines/{ref}.run:own")
+    run_all = check_permission(permissions, f"sinas.pipelines/{ref}.run:all")
+    # Replaying someone else's run executes as THAT user — require :all for it.
+    if not (run_all or (run_own and str(run.user_id) == user_id)):
+        raise HTTPException(status_code=403, detail="Not authorized to replay this run")
+    set_permission_used(request, f"sinas.pipelines/{ref}.run")
+
+    job_id = await queue_service.enqueue_pipeline_run(
+        pipeline_id=str(pipeline.id),
+        run_input=run.input,
+        trigger_type=TriggerType.MANUAL.value,
+        trigger_id=f"replay:{run_id}",
+        user_id=str(run.user_id),
+    )
+    return PipelineRunEnqueuedResponse(run_id=job_id)
+
+
+@router.post("/pipelines/{namespace}/{name}/run")
+async def run_pipeline_endpoint(
+    namespace: str,
+    name: str,
+    body: PipelineRunRequest,
+    request: Request,
+    all_users: bool = Query(default=False, alias="allUsers"),
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """Manual pipeline run (testing / backfills).
+
+    - sync (default): executes inline and returns the outcome.
+    - async: enqueues one run for the calling user, returns 202.
+    - ?allUsers=true (perUser pipelines, requires run:all): fans out like a
+      trigger firing — one queued run per connected user.
+    """
+    user_id, permissions = current_user_data
+    pipeline = await _load_pipeline(db, namespace, name)
+    if not pipeline.is_active:
+        raise HTTPException(status_code=400, detail=f"Pipeline '{namespace}/{name}' is inactive")
+
+    allowed, perm = _check_run_permission(permissions, namespace, name)
+    if not allowed:
+        set_permission_used(request, perm, has_perm=False)
+        raise HTTPException(status_code=403, detail="Not authorized to run this pipeline")
+    set_permission_used(request, perm)
+
+    if all_users:
+        if not pipeline.per_user:
+            raise HTTPException(status_code=400, detail="?allUsers=true requires a perUser pipeline")
+        if not check_permission(permissions, f"sinas.pipelines/{namespace}/{name}.run:all"):
+            raise HTTPException(status_code=403, detail="?allUsers=true requires run:all permission")
+        job_ids = await pipeline_runner.fire_pipeline(
+            namespace, name, body.input,
+            trigger_type=TriggerType.MANUAL.value, trigger_id=f"manual:{user_id}",
+        )
+        return PipelineFanOutResponse(
+            runs=[PipelineRunEnqueuedResponse(run_id=j) for j in job_ids],
+            users=len(job_ids),
+        )
+
+    if body.mode == "async":
+        job_id = await queue_service.enqueue_pipeline_run(
+            pipeline_id=str(pipeline.id),
+            run_input=body.input,
+            trigger_type=TriggerType.API.value,
+            trigger_id=f"manual:{user_id}",
+            user_id=str(user_id),
+        )
+        return PipelineRunEnqueuedResponse(run_id=job_id)
+
+    # Sync: run inline under the pipeline's sync budget.
+    user_token = request.headers.get("authorization", "").replace("Bearer ", "")
+    depth = _resolve_child_depth(request)
+    try:
+        outcome = await asyncio.wait_for(
+            pipeline_runner.run_pipeline(
+                str(pipeline.id),
+                body.input,
+                trigger_type=TriggerType.API.value,
+                trigger_id=f"manual:{user_id}",
+                user_id=str(user_id),
+                user_token=user_token,
+                exec_depth=depth,
+                sync=True,
+            ),
+            timeout=pipeline.sync_timeout_seconds,
+        )
+    except PipelineBusyError as e:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A run of this pipeline is already in progress (run_id={e.active_run_id})",
+        )
+    except asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"Pipeline run exceeded syncTimeoutSeconds ({pipeline.sync_timeout_seconds}s). "
+                f"Completed steps had side effects — see GET /pipelines/{namespace}/{name}/runs. "
+                "Use mode=async for long runs."
+            ),
+        )
+
+    return PipelineRunResponse(**outcome)
+
+
+@router.get("/pipelines/{namespace}/{name}/runs", response_model=list[PipelineRunRecord])
+async def list_pipeline_runs(
+    namespace: str,
+    name: str,
+    request: Request,
+    status: str = Query(default=None),
+    user: str = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """List run records for a pipeline, newest first."""
+    user_id, permissions = current_user_data
+    pipeline = await Pipeline.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="read",
+        namespace=namespace, name=name,
+    )
+    set_permission_used(request, f"sinas.pipelines/{namespace}/{name}.read")
+
+    stmt = (
+        select(PipelineRun)
+        .where(PipelineRun.pipeline_id == pipeline.id)
+        .order_by(PipelineRun.started_at.desc())
+        .limit(limit)
+    )
+    if status:
+        stmt = stmt.where(PipelineRun.status == status)
+    if user:
+        stmt = stmt.where(PipelineRun.user_id == user)
+
+    runs = (await db.execute(stmt)).scalars().all()
+    return [PipelineRunRecord.model_validate(r) for r in runs]

--- a/backend/app/api/runtime/endpoints/webhooks.py
+++ b/backend/app/api/runtime/endpoints/webhooks.py
@@ -255,6 +255,106 @@ async def _execute_agent_webhook(
     return response
 
 
+async def _execute_pipeline_webhook(
+    webhook: Webhook,
+    request: Request,
+    user_id: str,
+    final_input: Any,
+    req_headers: dict[str, str],
+):
+    """Execute a pipeline-target webhook: the request payload becomes the run
+    input, executing as the webhook's owner. `sync` waits for the outcome,
+    `async` enqueues one run and returns 202. No perUser fan-out here — a
+    webhook event is a single occurrence, not a poll tick; fan-out stays with
+    schedules and manual ?allUsers runs."""
+    import asyncio as _asyncio
+
+    from app.api.runtime.endpoints.functions import _resolve_child_depth
+    from app.models.pipeline import Pipeline
+    from app.services import pipeline_runner
+    from app.services.pipeline_runner import PipelineBusyError
+
+    from app.core.database import AsyncSessionLocal
+
+    pipeline_namespace = webhook.pipeline_namespace or "default"
+    async with AsyncSessionLocal() as db:
+        pipeline = await Pipeline.get_by_name(db, pipeline_namespace, webhook.pipeline_name)
+        if not pipeline or not pipeline.is_active:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Webhook target pipeline '{pipeline_namespace}/{webhook.pipeline_name}' not found or inactive",
+            )
+        pipeline_id = str(pipeline.id)
+        sync_timeout = pipeline.sync_timeout_seconds
+
+    run_input = final_input if isinstance(final_input, dict) else {"input": final_input}
+
+    if webhook.response_mode == "async":
+        job_id = await queue_service.enqueue_pipeline_run(
+            pipeline_id=pipeline_id,
+            run_input=run_input,
+            trigger_type=TriggerType.WEBHOOK.value,
+            trigger_id=str(webhook.id),
+            user_id=user_id,
+        )
+        return JSONResponse({"run_id": job_id}, status_code=202)
+
+    token = await pipeline_runner.mint_run_token(user_id)
+    if not token:
+        raise HTTPException(status_code=500, detail="Webhook user not found")
+
+    try:
+        outcome = await _asyncio.wait_for(
+            pipeline_runner.run_pipeline(
+                pipeline_id,
+                run_input,
+                trigger_type=TriggerType.WEBHOOK.value,
+                trigger_id=str(webhook.id),
+                user_id=user_id,
+                user_token=token,
+                exec_depth=_resolve_child_depth(request),
+                sync=True,
+            ),
+            timeout=sync_timeout,
+        )
+    except PipelineBusyError as e:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A run of this pipeline is already in progress (run_id={e.active_run_id})",
+        )
+    except _asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"Pipeline run exceeded syncTimeoutSeconds ({sync_timeout}s). "
+                "Completed steps had side effects; use response_mode 'async' for long runs."
+            ),
+        )
+
+    if outcome["status"] != "succeeded":
+        # The run record is the dead letter; surface its id, never mask failure.
+        return JSONResponse(
+            {"success": False, "run_id": outcome["run_id"], "error": outcome.get("error")},
+            status_code=500,
+        )
+
+    response = {"success": True, "run_id": outcome["run_id"], "output": outcome["output"]}
+
+    if webhook.dedup:
+        try:
+            await store_result(
+                webhook_id=str(webhook.id),
+                body=final_input if isinstance(final_input, dict) else {},
+                headers=req_headers,
+                dedup_config=webhook.dedup,
+                result=json.dumps(response, default=str),
+            )
+        except Exception:
+            pass  # Non-critical
+
+    return response
+
+
 @router.api_route(
     "/{path:path}",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
@@ -264,7 +364,7 @@ async def execute_webhook(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
-    """Execute webhook by triggering the associated function or agent."""
+    """Execute webhook by triggering the associated function, agent, or pipeline."""
     # Look up webhook configuration
     result = await db.execute(
         select(Webhook).where(
@@ -284,6 +384,7 @@ async def execute_webhook(
         )
 
     is_agent_target = webhook.target_type == "agent"
+    is_pipeline_target = webhook.target_type == "pipeline"
 
     # Authenticate if required
     user_id: Optional[str] = None
@@ -331,6 +432,11 @@ async def execute_webhook(
                 target_perm = (
                     f"sinas.agents/{webhook.agent_namespace}/{webhook.agent_name}.chat:all"
                 )
+            elif is_pipeline_target:
+                target_perm = f"sinas.pipelines/{webhook.pipeline_namespace or 'default'}/{webhook.pipeline_name}.run:own"
+                target_perm_all = f"sinas.pipelines/{webhook.pipeline_namespace or 'default'}/{webhook.pipeline_name}.run:all"
+                if check_permission(permissions, target_perm_all):
+                    target_perm = target_perm_all
             else:
                 target_perm = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:own"
                 target_perm_all = f"sinas.functions/{webhook.function_namespace}/{webhook.function_name}.execute:all"
@@ -393,9 +499,19 @@ async def execute_webhook(
                 # mode promises.
                 if webhook.response_mode == "raw":
                     return Response(status_code=204)
-                if is_agent_target and webhook.response_mode == "async":
+                if (is_agent_target or is_pipeline_target) and webhook.response_mode == "async":
                     return JSONResponse({"deduplicated": True}, status_code=202)
                 return JSONResponse({"deduplicated": True}, status_code=200)
+
+        # Pipeline target
+        if is_pipeline_target:
+            return await _execute_pipeline_webhook(
+                webhook=webhook,
+                request=request,
+                user_id=user_id,
+                final_input=final_input,
+                req_headers=req_headers,
+            )
 
         # Agent target
         if is_agent_target:

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -19,6 +19,7 @@ from .endpoints import (
     messages,
     dependencies,
     packages,
+    pipelines,
     queries,
     queue,
     request_logs,
@@ -48,6 +49,7 @@ router.include_router(llm_providers.router, prefix="/llm-providers", tags=["llm-
 router.include_router(database_connections.router, prefix="/database-connections", tags=["database-connections"])
 router.include_router(database_schema.router, prefix="/database-connections", tags=["database-schema"])
 router.include_router(queries.router)
+router.include_router(pipelines.router)
 
 router.include_router(roles.router)
 router.include_router(users.router)

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -94,6 +94,7 @@ async def create_agent(
         enabled_collections=[c.model_dump() for c in agent_data.enabled_collections] if agent_data.enabled_collections else [],
         enabled_components=agent_data.enabled_components or [],
         enabled_connectors=agent_data.enabled_connectors or [],
+        enabled_pipelines=agent_data.enabled_pipelines or [],
         hooks=agent_data.hooks.model_dump(by_alias=True) if agent_data.hooks else None,
         icon=agent_data.icon,
         is_active=True,
@@ -246,6 +247,8 @@ async def update_agent(
         agent.enabled_components = agent_data.enabled_components
     if agent_data.enabled_connectors is not None:
         agent.enabled_connectors = agent_data.enabled_connectors
+    if agent_data.enabled_pipelines is not None:
+        agent.enabled_pipelines = agent_data.enabled_pipelines
     if agent_data.hooks is not None:
         agent.hooks = agent_data.hooks.model_dump(by_alias=True)
     if agent_data.icon is not None:

--- a/backend/app/api/v1/endpoints/database_triggers.py
+++ b/backend/app/api/v1/endpoints/database_triggers.py
@@ -70,15 +70,27 @@ async def create_database_trigger(
     if not result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Database connection not found or inactive")
 
-    # Validate function exists
-    target_func = await Function.get_by_name(
-        db, trigger_data.function_namespace, trigger_data.function_name, user_id
-    )
-    if not target_func:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Function '{trigger_data.function_namespace}/{trigger_data.function_name}' not found",
+    # Validate the target exists
+    if trigger_data.target_type == "pipeline":
+        from app.models.pipeline import Pipeline
+
+        target_pipeline = await Pipeline.get_by_name(
+            db, trigger_data.pipeline_namespace, trigger_data.pipeline_name
         )
+        if not target_pipeline:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Pipeline '{trigger_data.pipeline_namespace}/{trigger_data.pipeline_name}' not found",
+            )
+    else:
+        target_func = await Function.get_by_name(
+            db, trigger_data.function_namespace, trigger_data.function_name, user_id
+        )
+        if not target_func:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Function '{trigger_data.function_namespace}/{trigger_data.function_name}' not found",
+            )
 
     trigger = DatabaseTrigger(
         user_id=user_id,
@@ -87,8 +99,11 @@ async def create_database_trigger(
         schema_name=trigger_data.schema_name,
         table_name=trigger_data.table_name,
         operations=trigger_data.operations,
+        target_type=trigger_data.target_type,
         function_namespace=trigger_data.function_namespace,
         function_name=trigger_data.function_name,
+        pipeline_namespace=trigger_data.pipeline_namespace if trigger_data.target_type == "pipeline" else None,
+        pipeline_name=trigger_data.pipeline_name,
         poll_column=trigger_data.poll_column,
         poll_interval_seconds=trigger_data.poll_interval_seconds,
         batch_size=trigger_data.batch_size,
@@ -186,10 +201,20 @@ async def update_database_trigger(
         trigger.name = trigger_data.name
     if trigger_data.operations is not None:
         trigger.operations = trigger_data.operations
+    if trigger_data.target_type is not None:
+        trigger.target_type = trigger_data.target_type
     if trigger_data.function_namespace is not None:
         trigger.function_namespace = trigger_data.function_namespace
     if trigger_data.function_name is not None:
         trigger.function_name = trigger_data.function_name
+    if trigger_data.pipeline_namespace is not None:
+        trigger.pipeline_namespace = trigger_data.pipeline_namespace
+    if trigger_data.pipeline_name is not None:
+        trigger.pipeline_name = trigger_data.pipeline_name
+    if trigger.target_type == "pipeline" and not trigger.pipeline_name:
+        raise HTTPException(status_code=400, detail="pipeline_name is required for pipeline-target triggers")
+    if trigger.target_type == "function" and not trigger.function_name:
+        raise HTTPException(status_code=400, detail="function_name is required for function-target triggers")
     if trigger_data.poll_column is not None:
         trigger.poll_column = trigger_data.poll_column
     if trigger_data.poll_interval_seconds is not None:

--- a/backend/app/api/v1/endpoints/pipelines.py
+++ b/backend/app/api/v1/endpoints/pipelines.py
@@ -1,0 +1,215 @@
+"""Pipelines API endpoints (management plane: CRUD)."""
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user_with_permissions, set_permission_used
+from app.core.database import get_db
+from app.core.permissions import check_permission
+from app.models.pipeline import Pipeline
+from app.schemas.pipeline import PipelineCreate, PipelineResponse, PipelineUpdate
+from app.services.package_service import detach_if_package_managed
+from app.services.pipeline_validation import validate_pipeline_definition
+
+router = APIRouter(prefix="/pipelines", tags=["pipelines"])
+
+
+@router.post("", response_model=PipelineResponse, status_code=status.HTTP_201_CREATED)
+async def create_pipeline(
+    request: Request,
+    data: PipelineCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Create a new pipeline."""
+    user_id, permissions = current_user_data
+
+    permission = "sinas.pipelines.create:own"
+    if not check_permission(permissions, permission):
+        set_permission_used(request, permission, has_perm=False)
+        raise HTTPException(status_code=403, detail="Not authorized to create pipelines")
+    set_permission_used(request, permission)
+
+    result = await db.execute(
+        select(Pipeline).where(
+            and_(Pipeline.namespace == data.namespace, Pipeline.name == data.name)
+        )
+    )
+    if result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=400, detail=f"Pipeline '{data.namespace}/{data.name}' already exists"
+        )
+
+    pipeline = Pipeline(
+        user_id=user_id,
+        namespace=data.namespace,
+        name=data.name,
+        description=data.description,
+        input_schema=data.input_schema or {},
+        steps=data.steps,
+        per_user=data.per_user,
+        as_tool=data.as_tool,
+        tool_description=data.tool_description,
+        sync_timeout_seconds=data.sync_timeout_seconds,
+        concurrency=data.concurrency,
+        disable_after_failures=data.disable_after_failures,
+        output_mapping=data.output_mapping,
+    )
+    db.add(pipeline)
+    await db.flush()
+    await db.refresh(pipeline)
+    return PipelineResponse.model_validate(pipeline)
+
+
+@router.get("", response_model=list[PipelineResponse])
+async def list_pipelines(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """List pipelines."""
+    user_id, permissions = current_user_data
+
+    pipelines = await Pipeline.list_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="read"
+    )
+    set_permission_used(request, "sinas.pipelines.read")
+    return [PipelineResponse.model_validate(p) for p in pipelines]
+
+
+@router.get("/{namespace}/{name}", response_model=PipelineResponse)
+async def get_pipeline(
+    request: Request,
+    namespace: str,
+    name: str,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Get a specific pipeline."""
+    user_id, permissions = current_user_data
+
+    pipeline = await Pipeline.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="read",
+        namespace=namespace, name=name,
+    )
+    set_permission_used(request, f"sinas.pipelines/{namespace}/{name}.read")
+    return PipelineResponse.model_validate(pipeline)
+
+
+@router.put("/{namespace}/{name}", response_model=PipelineResponse)
+async def update_pipeline(
+    request: Request,
+    namespace: str,
+    name: str,
+    data: PipelineUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Update a pipeline. The merged definition is re-validated."""
+    user_id, permissions = current_user_data
+
+    pipeline = await Pipeline.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="update",
+        namespace=namespace, name=name,
+    )
+    set_permission_used(request, f"sinas.pipelines/{namespace}/{name}.update")
+
+    detach_if_package_managed(pipeline)
+
+    new_namespace = data.namespace or pipeline.namespace
+    new_name = data.name or pipeline.name
+    if new_namespace != pipeline.namespace or new_name != pipeline.name:
+        result = await db.execute(
+            select(Pipeline).where(
+                and_(
+                    Pipeline.namespace == new_namespace,
+                    Pipeline.name == new_name,
+                    Pipeline.id != pipeline.id,
+                )
+            )
+        )
+        if result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=400, detail=f"Pipeline '{new_namespace}/{new_name}' already exists"
+            )
+
+    # Validate the merged definition (partial updates can't validate in isolation)
+    merged = {
+        "steps": data.steps if data.steps is not None else pipeline.steps,
+        "per_user": data.per_user if data.per_user is not None else pipeline.per_user,
+        "as_tool": data.as_tool if data.as_tool is not None else pipeline.as_tool,
+        "input_schema": data.input_schema if data.input_schema is not None else pipeline.input_schema,
+        "description": data.description if data.description is not None else pipeline.description,
+        "tool_description": data.tool_description if data.tool_description is not None else pipeline.tool_description,
+        "concurrency": data.concurrency if data.concurrency is not None else pipeline.concurrency,
+        "output_mapping": data.output_mapping if data.output_mapping is not None else pipeline.output_mapping,
+    }
+    errors = validate_pipeline_definition(
+        merged["steps"],
+        per_user=merged["per_user"],
+        as_tool=merged["as_tool"],
+        input_schema=merged["input_schema"],
+        description=merged["description"],
+        tool_description=merged["tool_description"],
+        concurrency=merged["concurrency"],
+        output_mapping=merged["output_mapping"],
+    )
+    if errors:
+        raise HTTPException(status_code=400, detail="; ".join(errors))
+
+    if data.namespace is not None:
+        pipeline.namespace = data.namespace
+    if data.name is not None:
+        pipeline.name = data.name
+    if data.description is not None:
+        pipeline.description = data.description
+    if data.input_schema is not None:
+        pipeline.input_schema = data.input_schema
+    if data.steps is not None:
+        pipeline.steps = data.steps
+    if data.per_user is not None:
+        pipeline.per_user = data.per_user
+    if data.as_tool is not None:
+        pipeline.as_tool = data.as_tool
+    if data.tool_description is not None:
+        pipeline.tool_description = data.tool_description
+    if data.sync_timeout_seconds is not None:
+        pipeline.sync_timeout_seconds = data.sync_timeout_seconds
+    if data.concurrency is not None:
+        pipeline.concurrency = data.concurrency
+    if data.disable_after_failures is not None:
+        pipeline.disable_after_failures = data.disable_after_failures
+    if data.output_mapping is not None:
+        pipeline.output_mapping = data.output_mapping
+    if data.is_active is not None:
+        pipeline.is_active = data.is_active
+        if data.is_active:
+            # Reactivation clears the auto-disable state.
+            pipeline.consecutive_failures = 0
+            pipeline.error_message = None
+
+    await db.flush()
+    await db.refresh(pipeline)
+    return PipelineResponse.model_validate(pipeline)
+
+
+@router.delete("/{namespace}/{name}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_pipeline(
+    request: Request,
+    namespace: str,
+    name: str,
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """Delete a pipeline (its runs and cursors cascade)."""
+    user_id, permissions = current_user_data
+
+    pipeline = await Pipeline.get_with_permissions(
+        db=db, user_id=user_id, permissions=permissions, action="delete",
+        namespace=namespace, name=name,
+    )
+    set_permission_used(request, f"sinas.pipelines/{namespace}/{name}.delete")
+
+    await db.delete(pipeline)
+    await db.flush()
+    return None

--- a/backend/app/api/v1/endpoints/secrets.py
+++ b/backend/app/api/v1/endpoints/secrets.py
@@ -50,6 +50,10 @@ async def create_or_update_secret(
             existing.description = secret_data.description
         await db.flush()
         await db.refresh(existing)
+        if existing.visibility == "private":
+            from app.services.pipeline_runner import reset_user_failure_state
+
+            await reset_user_failure_state(db, str(user_id), secret_name=existing.name)
         return SecretResponse.model_validate(existing)
 
     secret = Secret(
@@ -173,6 +177,11 @@ async def update_secret(
 
     await db.flush()
     await db.refresh(secret)
+    if secret_data.value is not None and secret.visibility == "private":
+        # Re-credentialing recovery point for perUser pipelines (skip-until-re-credential).
+        from app.services.pipeline_runner import reset_user_failure_state
+
+        await reset_user_failure_state(db, str(user_id), secret_name=secret.name)
     return SecretResponse.model_validate(secret)
 
 

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -52,6 +52,28 @@ async def create_webhook(
                 status_code=404,
                 detail=f"Function '{webhook_data.function_namespace}.{webhook_data.function_name}' not found",
             )
+    elif webhook_data.target_type == "pipeline":
+        from app.models.pipeline import Pipeline
+
+        pipeline = await Pipeline.get_by_name(
+            db, webhook_data.pipeline_namespace, webhook_data.pipeline_name
+        )
+        if not pipeline:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Pipeline '{webhook_data.pipeline_namespace}/{webhook_data.pipeline_name}' not found",
+            )
+        # Fail fast if the creator can't run the target (authoritative check is
+        # at execution time, same rationale as agent targets below).
+        _run_perm = (
+            f"sinas.pipelines/{webhook_data.pipeline_namespace}/{webhook_data.pipeline_name}.run:own"
+        )
+        if not check_permission(permissions, _run_perm):
+            set_permission_used(request, _run_perm, has_perm=False)
+            raise HTTPException(
+                status_code=403,
+                detail=f"Not authorized to run pipeline '{webhook_data.pipeline_namespace}/{webhook_data.pipeline_name}'",
+            )
     else:
         # Agents are shared by design (chat:all/read:all are default grants), so
         # the lookup is intentionally not ownership-scoped — the permission check
@@ -86,6 +108,8 @@ async def create_webhook(
         function_name=webhook_data.function_name,
         agent_namespace=webhook_data.agent_namespace if webhook_data.target_type == "agent" else None,
         agent_name=webhook_data.agent_name,
+        pipeline_namespace=webhook_data.pipeline_namespace if webhook_data.target_type == "pipeline" else None,
+        pipeline_name=webhook_data.pipeline_name,
         message_template=webhook_data.message_template,
         session_key_template=webhook_data.session_key_template,
         http_method=webhook_data.http_method,
@@ -251,6 +275,37 @@ async def update_webhook(
         webhook.agent_namespace = new_agent_namespace
         webhook.agent_name = new_agent_name
 
+    if webhook_data.pipeline_namespace is not None or webhook_data.pipeline_name is not None:
+        from app.models.pipeline import Pipeline
+
+        new_pipeline_namespace = (
+            webhook_data.pipeline_namespace
+            if webhook_data.pipeline_namespace is not None
+            else (webhook.pipeline_namespace or "default")
+        )
+        new_pipeline_name = (
+            webhook_data.pipeline_name
+            if webhook_data.pipeline_name is not None
+            else webhook.pipeline_name
+        )
+
+        pipeline = await Pipeline.get_by_name(db, new_pipeline_namespace, new_pipeline_name)
+        if not pipeline:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Pipeline '{new_pipeline_namespace}/{new_pipeline_name}' not found",
+            )
+        _run_perm = f"sinas.pipelines/{new_pipeline_namespace}/{new_pipeline_name}.run:own"
+        if not check_permission(permissions, _run_perm):
+            set_permission_used(request, _run_perm, has_perm=False)
+            raise HTTPException(
+                status_code=403,
+                detail=f"Not authorized to run pipeline '{new_pipeline_namespace}/{new_pipeline_name}'",
+            )
+
+        webhook.pipeline_namespace = new_pipeline_namespace
+        webhook.pipeline_name = new_pipeline_name
+
     # `is not None` can't express "clear this field" — for optional fields that
     # a user can legitimately unset, distinguish "absent from the request" from
     # "explicitly sent as null" via the fields actually provided. Without this,
@@ -286,6 +341,16 @@ async def update_webhook(
             )
         if webhook.response_mode not in ("sync", "async", "raw"):
             raise HTTPException(status_code=400, detail="Invalid response_mode")
+    elif webhook.target_type == "pipeline":
+        if not webhook.pipeline_name:
+            raise HTTPException(
+                status_code=400, detail="pipeline_name is required for pipeline-target webhooks"
+            )
+        if webhook.response_mode == "raw":
+            raise HTTPException(
+                status_code=400,
+                detail="response_mode 'raw' is only supported for function-target webhooks",
+            )
     else:
         if not webhook.agent_name or not webhook.message_template:
             raise HTTPException(

--- a/backend/app/cdc/service.py
+++ b/backend/app/cdc/service.py
@@ -259,17 +259,29 @@ class CDCManager:
                                 "timestamp": datetime.now(timezone.utc).isoformat(),
                             }
 
-                            # Enqueue function execution
+                            # Enqueue the target: function execution or pipeline fire.
+                            # Note: CDC advances its own bookmark at enqueue time
+                            # (below) regardless of downstream success; a pipeline's
+                            # own cursor (if any) is managed by the pipeline runner.
                             execution_id = str(uuid.uuid4())
-                            await queue_service.enqueue_function(
-                                function_namespace=trigger.function_namespace,
-                                function_name=trigger.function_name,
-                                input_data=payload,
-                                execution_id=execution_id,
-                                trigger_type="CDC",
-                                trigger_id=trigger_id,
-                                user_id=str(trigger.user_id),
-                            )
+                            if trigger.target_type == "pipeline":
+                                await queue_service.enqueue_pipeline_fire(
+                                    namespace=trigger.pipeline_namespace or "default",
+                                    name=trigger.pipeline_name,
+                                    run_input=payload,
+                                    trigger_type="CDC",
+                                    trigger_id=trigger_id,
+                                )
+                            else:
+                                await queue_service.enqueue_function(
+                                    function_namespace=trigger.function_namespace,
+                                    function_name=trigger.function_name,
+                                    input_data=payload,
+                                    execution_id=execution_id,
+                                    trigger_type="CDC",
+                                    trigger_id=trigger_id,
+                                    user_id=str(trigger.user_id),
+                                )
 
                             # Update bookmark and clear error
                             async with AsyncSessionLocal() as db:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -147,6 +147,12 @@ class Settings(BaseSettings):
     queue_max_retries: int = 3
     queue_retry_delay: int = 10
 
+    # Pipeline runs (see ADR 2026-07-28-pipelines-triggers-and-linear-steps).
+    # Runs are await-heavy orchestration → high concurrency is cheap.
+    queue_pipeline_concurrency: int = 50
+    pipeline_job_timeout: int = 1800  # hard ceiling for one queued run (incl. agent steps)
+    pipeline_run_retention_days: int = 30  # pipeline_runs rows older than this are pruned
+
     # Agent job settings
     agent_job_timeout: int = 600  # Default timeout for agent jobs (10 minutes)
     code_execution_timeout: int = 120  # Default timeout for code execution (2 minutes)

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -311,6 +311,10 @@ DEFAULT_ROLE_PERMISSIONS = {
         "sinas.connectors/*/*.read:own": True,
         "sinas.connectors/*/*.update:own": True,
         "sinas.connectors/*/*.delete:own": True,
+        # Pipelines (namespaced) — read + run for users; create/update stay
+        # admin-granted (conservative default, matching queries).
+        "sinas.pipelines/*/*.read:own": True,
+        "sinas.pipelines/*/*.run:own": True,
         # Secrets (non-namespaced)
         "sinas.secrets.create:own": True,
         "sinas.secrets.read:own": True,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ from .dependency import Dependency
 from .package import Package
 from .query import Query
 from .pending_approval import PendingToolApproval
+from .pipeline import Pipeline, PipelineCursor, PipelineRun
 from .pending_delegation import PendingDelegation
 from .schedule import ScheduledJob
 from .secret import Secret

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -102,6 +102,11 @@ class Agent(Base, PermissionMixin):
         JSON, nullable=False, default=list, server_default="[]"
     )  # [{"connector": "ns/name", "operations": [...], "parameters": {...}}]
 
+    # Pipeline access (pipelines with asTool exposed as tools)
+    enabled_pipelines: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=list, server_default="[]"
+    )  # List of "namespace/name" pipeline references (wildcards supported)
+
     # Message lifecycle hooks
     hooks: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
     # {"on_user_message": [...], "on_assistant_message": [...]}

--- a/backend/app/models/database_trigger.py
+++ b/backend/app/models/database_trigger.py
@@ -26,8 +26,15 @@ class DatabaseTrigger(Base):
     schema_name: Mapped[str] = mapped_column(String(255), nullable=False, default="public")
     table_name: Mapped[str] = mapped_column(String(255), nullable=False)
     operations: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    # Target: "function" (default) or "pipeline"
+    target_type: Mapped[str] = mapped_column(
+        String(10), nullable=False, default="function", server_default="function"
+    )
     function_namespace: Mapped[str] = mapped_column(String(255), nullable=False, default="default")
-    function_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    function_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Pipeline target fields (target_type == "pipeline")
+    pipeline_namespace: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    pipeline_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     poll_column: Mapped[str] = mapped_column(String(255), nullable=False)
     poll_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
     batch_size: Mapped[int] = mapped_column(Integer, nullable=False, default=100)

--- a/backend/app/models/execution.py
+++ b/backend/app/models/execution.py
@@ -17,6 +17,7 @@ class TriggerType(str, enum.Enum):
     API = "API"  # Triggered via runtime API
     CDC = "CDC"  # Triggered by CDC (Change Data Capture) polling
     HOOK = "HOOK"  # Triggered by message lifecycle hook
+    PIPELINE = "PIPELINE"  # Child execution of a pipeline run (trigger_id = run_id)
 
 
 class ExecutionStatus(str, enum.Enum):

--- a/backend/app/models/pipeline.py
+++ b/backend/app/models/pipeline.py
@@ -1,0 +1,162 @@
+"""Pipeline models — linear typed step sequences fired by triggers.
+
+See backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md.
+"""
+import uuid
+from typing import Any, Optional
+from datetime import datetime
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, created_at, updated_at, uuid_pk
+from .execution import TriggerType
+from .mixins import PermissionMixin
+
+
+class Pipeline(Base, PermissionMixin):
+    """A named linear sequence of typed steps (connector/function/agent/query/load).
+
+    Steps are stored exactly as validated (camelCase config keys, `.$` mapping
+    keys intact) — one representation end-to-end, like input_schema JSON blobs.
+    """
+
+    __tablename__ = "pipelines"
+    __table_args__ = (UniqueConstraint("namespace", "name", name="uq_pipeline_namespace_name"),)
+
+    id: Mapped[uuid_pk]
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    namespace: Mapped[str] = mapped_column(String(255), nullable=False, default="default", index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+
+    # JSON Schema validating run input (trigger payload / tool args / manual run body)
+    input_schema: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+
+    # Ordered step list; see schemas/pipeline.py for the validated shape.
+    steps: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
+
+    # Per-user fan-out: {"connector": "ns/name", "disableAfterFailures": N} or NULL (shared).
+    per_user: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+
+    # Agent-tool exposure
+    as_tool: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    tool_description: Mapped[Optional[str]] = mapped_column(Text)
+
+    # Budget for inline (tool / sync) runs, seconds.
+    sync_timeout_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=120, server_default="120")
+
+    # "single" | "parallel" | NULL (= single when a cursor step exists, else parallel)
+    concurrency: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
+
+    # Shared-mode auto-deactivation after N consecutive failed runs (NULL = off).
+    disable_after_failures: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # Final-output shaping: {"output": <literal>} or {"output.$": "<jmespath>"} or NULL
+    # (= last step's output). Stored raw and resolved by the mapping module.
+    output_mapping: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+
+    # Shared-mode cursor bookmark (perUser pipelines use pipeline_cursors instead).
+    cursor_value: Mapped[Optional[str]] = mapped_column(Text)
+    consecutive_failures: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    error_message: Mapped[Optional[str]] = mapped_column(Text)
+
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+
+    # Config tracking
+    managed_by: Mapped[Optional[str]] = mapped_column(Text)
+    config_name: Mapped[Optional[str]] = mapped_column(Text)
+    config_checksum: Mapped[Optional[str]] = mapped_column(Text)
+
+    created_at: Mapped[created_at]
+    updated_at: Mapped[updated_at]
+
+    user: Mapped["User"] = relationship("User")
+
+    @classmethod
+    async def get_by_name(cls, db: AsyncSession, namespace: str, name: str) -> Optional["Pipeline"]:
+        result = await db.execute(select(cls).where(cls.namespace == namespace, cls.name == name))
+        return result.scalar_one_or_none()
+
+    def get_cursor_step(self) -> Optional[dict[str, Any]]:
+        """The step declaring cursor config, or None (max one, validated)."""
+        for step in (self.steps or []):
+            if step.get("cursor"):
+                return step
+        return None
+
+    def effective_concurrency(self) -> str:
+        if self.concurrency in ("single", "parallel"):
+            return self.concurrency
+        return "single" if self.get_cursor_step() else "parallel"
+
+
+class PipelineRun(Base):
+    """One execution of a pipeline. Doubles as the dead-letter record: it stores
+    the full input, per-step summaries, and the error, and can be replayed."""
+
+    __tablename__ = "pipeline_runs"
+
+    id: Mapped[uuid_pk]
+    pipeline_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("pipelines.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    run_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    # The user the run executed as (for perUser fan-out: the connected user).
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    trigger_type: Mapped[TriggerType] = mapped_column(Enum(TriggerType), nullable=False)
+    trigger_id: Mapped[Optional[str]] = mapped_column(String(255))
+
+    # running | succeeded | failed | timed_out
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="running", index=True)
+
+    input: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON)
+    # [{name, type, status, startedAt, durationMs, executionId?, chatId?, error?}]
+    steps: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
+    error: Mapped[Optional[str]] = mapped_column(Text)
+
+    cursor_before: Mapped[Optional[str]] = mapped_column(Text)
+    cursor_after: Mapped[Optional[str]] = mapped_column(Text)
+
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    duration_ms: Mapped[Optional[int]] = mapped_column(Integer)
+
+    pipeline: Mapped["Pipeline"] = relationship("Pipeline")
+
+
+class PipelineCursor(Base):
+    """Per-(pipeline, user) bookmark + failure state for perUser pipelines."""
+
+    __tablename__ = "pipeline_cursors"
+    __table_args__ = (
+        UniqueConstraint("pipeline_id", "user_id", name="uq_pipeline_cursor_pipeline_user"),
+    )
+
+    id: Mapped[uuid_pk]
+    pipeline_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("pipelines.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    cursor_value: Mapped[Optional[str]] = mapped_column(Text)
+    consecutive_failures: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    last_error: Mapped[Optional[str]] = mapped_column(Text)
+    updated_at: Mapped[updated_at]

--- a/backend/app/models/webhook.py
+++ b/backend/app/models/webhook.py
@@ -24,7 +24,7 @@ class Webhook(Base):
     id: Mapped[uuid_pk]
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     path: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
-    # Target: "function" (default) or "agent"
+    # Target: "function" (default), "agent", or "pipeline"
     target_type: Mapped[str] = mapped_column(
         String(10), default="function", server_default="function", nullable=False
     )
@@ -33,6 +33,9 @@ class Webhook(Base):
     # Agent target fields (target_type == "agent")
     agent_namespace: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     agent_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Pipeline target fields (target_type == "pipeline")
+    pipeline_namespace: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    pipeline_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     message_template: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     session_key_template: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     http_method: Mapped[HTTPMethod] = mapped_column(

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -306,6 +306,76 @@ async def agent_worker_startup(ctx: dict) -> None:
     logger.info(f"Agent worker started (id={worker_id})")
 
 
+async def execute_pipeline_run_job(ctx: dict, **kwargs: Any) -> Any:
+    """Execute one pipeline run (one user scope) in the pipeline worker."""
+    from app.services import pipeline_runner
+
+    pipeline_id = kwargs["pipeline_id"]
+    user_id = kwargs["user_id"]
+
+    token = await pipeline_runner.mint_run_token(user_id)
+    if not token:
+        logger.error(f"Pipeline run job: user {user_id} not found, dropping run")
+        return {"status": "failed", "error": f"User {user_id} not found"}
+
+    return await pipeline_runner.run_pipeline(
+        pipeline_id,
+        kwargs.get("run_input"),
+        trigger_type=kwargs.get("trigger_type", "API"),
+        trigger_id=kwargs.get("trigger_id"),
+        user_id=user_id,
+        user_token=token,
+        sync=False,
+    )
+
+
+async def execute_pipeline_fire_job(ctx: dict, **kwargs: Any) -> Any:
+    """Expand a trigger firing into per-scope run jobs (perUser fan-out)."""
+    from app.services import pipeline_runner
+
+    job_ids = await pipeline_runner.fire_pipeline(
+        kwargs["namespace"],
+        kwargs["name"],
+        kwargs.get("run_input"),
+        trigger_type=kwargs.get("trigger_type", "API"),
+        trigger_id=kwargs.get("trigger_id"),
+    )
+    return {"runs": len(job_ids), "job_ids": job_ids}
+
+
+async def pipeline_worker_startup(ctx: dict) -> None:
+    """arq startup hook for the pipeline worker.
+
+    Pipeline runs are await-heavy orchestration (they wait on child function/
+    agent executions and HTTP), so this worker runs many jobs concurrently and
+    needs no container discovery.
+    """
+    from redis.asyncio import Redis
+
+    from app.core.telemetry import init_telemetry
+    init_telemetry()
+
+    ctx["redis"] = Redis.from_url(settings.redis_url, decode_responses=True)
+
+    # Eagerly import the runner so the first job doesn't pay import cost
+    from app.services import pipeline_runner  # noqa: F401
+
+    worker_id = str(uuid.uuid4())
+    ctx["worker_id"] = worker_id
+    heartbeat_data = {
+        "worker_id": worker_id,
+        "queue": "pipelines",
+        "max_jobs": settings.queue_pipeline_concurrency,
+        "started_at": time.time(),
+        "last_heartbeat": time.time(),
+    }
+    ctx["_heartbeat_task"] = asyncio.create_task(
+        _heartbeat_loop(ctx["redis"], worker_id, heartbeat_data)
+    )
+
+    logger.info(f"Pipeline worker started (id={worker_id})")
+
+
 async def shutdown(ctx: dict) -> None:
     """arq worker shutdown hook."""
     # Cancel heartbeat
@@ -363,6 +433,24 @@ class AgentWorkerSettings:
     max_jobs = settings.queue_agent_concurrency
     job_timeout = settings.agent_job_timeout  # Default timeout, can be overridden per-job
     max_tries = 1  # No retry for agent conversations (side effects)
+
+
+class PipelineWorkerSettings:
+    """arq worker settings for pipeline runs. Own queue + process so long
+    pipeline runs never starve function workers (and vice versa). High
+    concurrency: runs mostly await child executions and HTTP.
+
+        python -m arq app.queue.worker.PipelineWorkerSettings
+    """
+
+    functions = [execute_pipeline_run_job, execute_pipeline_fire_job]
+    on_startup = pipeline_worker_startup
+    on_shutdown = shutdown
+    redis_settings = get_redis_settings()
+    queue_name = "sinas:queue:pipelines"
+    max_jobs = settings.queue_pipeline_concurrency
+    job_timeout = settings.pipeline_job_timeout
+    max_tries = 1  # runs are re-fired by triggers; never auto-retried (side effects)
 
 
 class SubAgentWorkerSettings:

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -100,6 +100,7 @@ class AgentCreate(BaseModel):
     enabled_collections: Optional[list[EnabledCollectionConfig]] = None  # Collection access configs
     enabled_components: Optional[list[str]] = None  # List of "namespace/name" component references
     enabled_connectors: Optional[list[dict[str, Any]]] = None  # [{"connector": "ns/name", "operations": [...], "parameters": {...}}]
+    enabled_pipelines: Optional[list[str]] = None  # List of "namespace/name" pipeline references (asTool)
     hooks: Optional[AgentHooks] = None
     icon: Optional[str] = None  # "collection:ns/coll/file" or "url:https://..."
     is_default: Optional[bool] = False
@@ -156,6 +157,7 @@ class AgentUpdate(BaseModel):
     enabled_collections: Optional[list[EnabledCollectionConfig]] = None  # Collection access configs
     enabled_components: Optional[list[str]] = None  # List of "namespace/name" component references
     enabled_connectors: Optional[list[dict[str, Any]]] = None  # [{"connector": "ns/name", "operations": [...], "parameters": {...}}]
+    enabled_pipelines: Optional[list[str]] = None  # List of "namespace/name" pipeline references (asTool)
     hooks: Optional[AgentHooks] = None
     icon: Optional[str] = None  # "collection:ns/coll/file" or "url:https://..."
     is_active: Optional[bool] = None
@@ -192,6 +194,7 @@ class AgentResponse(BaseModel):
     enabled_collections: list[EnabledCollectionConfig] = []
     enabled_components: list[str] = []
     enabled_connectors: list[dict[str, Any]] = []
+    enabled_pipelines: list[str] = []
     hooks: Optional[dict[str, Any]] = None
     icon: Optional[str] = None
     icon_url: Optional[str] = None

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -198,6 +198,7 @@ class AgentConfig(BaseModel):
     enabledCollections: list[Union[str, EnabledCollectionConfigYaml]] = Field(default_factory=list)
     enabledComponents: list[str] = Field(default_factory=list)  # List of "namespace/name" component refs
     enabledConnectors: list[dict[str, Any]] = Field(default_factory=list)  # [{"connector": "ns/name", "operations": [...]}]
+    enabledPipelines: list[str] = Field(default_factory=list)  # List of "namespace/name" pipeline refs (asTool)
     inputSchema: Optional[dict[str, Any]] = None
     outputSchema: Optional[dict[str, Any]] = None
     initialMessages: Optional[list[dict[str, str]]] = None
@@ -240,9 +241,10 @@ class ScheduleConfig(BaseModel):
     """Schedule configuration"""
 
     name: str
-    scheduleType: str = "function"  # "function" or "agent"
+    scheduleType: str = "function"  # "function", "agent", or "pipeline"
     functionName: Optional[str] = None  # for function schedules
     agentName: Optional[str] = None  # for agent schedules (namespace/name)
+    pipelineName: Optional[str] = None  # for pipeline schedules (namespace/name)
     content: Optional[str] = None  # message content for agent schedules
     description: Optional[str] = None
     cronExpression: str
@@ -259,6 +261,8 @@ class ScheduleConfig(BaseModel):
             raise ValueError("agentName is required for agent schedules")
         if schedule_type == "agent" and not values.get("content"):
             raise ValueError("content is required for agent schedules")
+        if schedule_type == "pipeline" and not values.get("pipelineName"):
+            raise ValueError("pipelineName is required for pipeline schedules")
         return v
 
 
@@ -330,11 +334,28 @@ class DatabaseTriggerConfig(BaseModel):
     schemaName: str = "public"
     tableName: str
     operations: list[str] = Field(default=["INSERT", "UPDATE"])
-    functionName: str  # "namespace/name" format
+    targetType: str = "function"  # "function" or "pipeline"
+    functionName: Optional[str] = None  # "namespace/name" format (function targets)
+    pipelineName: Optional[str] = None  # "namespace/name" format (pipeline targets)
     pollColumn: str
     pollIntervalSeconds: int = 10
     batchSize: int = 100
     isActive: bool = True
+
+    @validator("targetType")
+    def validate_target_type(cls, v):
+        if v not in ("function", "pipeline"):
+            raise ValueError("targetType must be 'function' or 'pipeline'")
+        return v
+
+    @validator("isActive", always=True)
+    def validate_target(cls, v, values):
+        if values.get("targetType", "function") == "pipeline":
+            if not values.get("pipelineName"):
+                raise ValueError("pipelineName is required for pipeline-target triggers")
+        elif not values.get("functionName"):
+            raise ValueError("functionName is required for function-target triggers")
+        return v
 
     @validator("operations")
     def validate_operations(cls, v):
@@ -422,6 +443,40 @@ class ConnectorConfig(BaseModel):
     operations: list[ConnectorOperationConfig] = Field(default_factory=list)
 
 
+class PipelineConfig(BaseModel):
+    """Pipeline configuration (see ADR 2026-07-28-pipelines-triggers-and-linear-steps).
+
+    `steps` and `perUser` are passed through verbatim — camelCase keys and `.$`
+    mapping keys are data (one representation across YAML/API/DB); shape is
+    validated by validate_pipeline_definition at apply time.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    namespace: str = "default"
+    name: str
+    description: Optional[str] = None
+    inputSchema: Optional[dict[str, Any]] = None
+    steps: list[dict[str, Any]] = Field(default_factory=list)
+    perUser: Optional[dict[str, Any]] = None
+    asTool: bool = False
+    toolDescription: Optional[str] = None
+    syncTimeoutSeconds: int = 120
+    concurrency: Optional[str] = None  # "single" | "parallel" | None (auto)
+    disableAfterFailures: Optional[int] = None
+    output: Optional[Any] = None
+    outputExpr: Optional[str] = Field(default=None, alias="output.$")
+    isActive: bool = True
+
+    def output_mapping(self) -> Optional[dict[str, Any]]:
+        """Build the stored output-mapping dict from the YAML-level fields."""
+        if self.outputExpr is not None:
+            return {"output.$": self.outputExpr}
+        if self.output is not None:
+            return {"output": self.output}
+        return None
+
+
 class DependencyConfig(BaseModel):
     """Python dependency configuration"""
 
@@ -473,6 +528,7 @@ class ConfigSpec(BaseModel):
     components: list[ComponentConfig] = Field(default_factory=list)
     functions: list[FunctionConfig] = Field(default_factory=list)
     queries: list[QueryConfig] = Field(default_factory=list)
+    pipelines: list[PipelineConfig] = Field(default_factory=list)
     collections: list[CollectionConfig] = Field(default_factory=list)
     templates: list[TemplateConfig] = Field(default_factory=list)
     stores: list[StoreConfig] = Field(default_factory=list)

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -238,9 +238,10 @@ class WebhookConfig(BaseModel):
     """Webhook configuration"""
 
     path: str
-    targetType: str = "function"  # "function" or "agent"
+    targetType: str = "function"  # "function", "agent", or "pipeline"
     functionName: Optional[str] = None  # for function targets ("namespace/name" or "name")
     agentName: Optional[str] = None  # for agent targets (namespace/name)
+    pipelineName: Optional[str] = None  # for pipeline targets (namespace/name)
     messageTemplate: Optional[str] = None  # Jinja2, rendered against the request payload
     sessionKeyTemplate: Optional[str] = None  # Jinja2, optional conversation continuity key
     httpMethod: str = "POST"
@@ -253,13 +254,18 @@ class WebhookConfig(BaseModel):
     @validator("dedup", always=True)
     def validate_target(cls, v, values):
         target_type = values.get("targetType", "function")
-        if target_type not in ("function", "agent"):
-            raise ValueError("targetType must be 'function' or 'agent'")
+        if target_type not in ("function", "agent", "pipeline"):
+            raise ValueError("targetType must be 'function', 'agent', or 'pipeline'")
         if values.get("responseMode") not in ("sync", "async", "raw"):
             raise ValueError("responseMode must be 'sync', 'async', or 'raw'")
         if target_type == "function":
             if not values.get("functionName"):
                 raise ValueError("functionName is required for function-target webhooks")
+        elif target_type == "pipeline":
+            if not values.get("pipelineName"):
+                raise ValueError("pipelineName is required for pipeline-target webhooks")
+            if values.get("responseMode") == "raw":
+                raise ValueError("responseMode 'raw' is only supported for function-target webhooks")
         else:
             if not values.get("agentName"):
                 raise ValueError("agentName is required for agent-target webhooks")

--- a/backend/app/schemas/database_trigger.py
+++ b/backend/app/schemas/database_trigger.py
@@ -1,9 +1,9 @@
 """Database trigger schemas for CDC."""
 import uuid
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, model_validator, validator
 
 
 VALID_OPERATIONS = {"INSERT", "UPDATE"}
@@ -15,8 +15,11 @@ class DatabaseTriggerCreate(BaseModel):
     schema_name: str = Field(default="public", max_length=255)
     table_name: str = Field(..., min_length=1, max_length=255)
     operations: list[str] = Field(default=["INSERT", "UPDATE"])
+    target_type: Literal["function", "pipeline"] = "function"
     function_namespace: str = Field(default="default", min_length=1, max_length=255)
-    function_name: str = Field(..., min_length=1, max_length=255)
+    function_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    pipeline_namespace: str = Field(default="default", min_length=1, max_length=255)
+    pipeline_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     poll_column: str = Field(..., min_length=1, max_length=255)
     poll_interval_seconds: int = Field(default=10, ge=1, le=3600)
     batch_size: int = Field(default=100, ge=1, le=10000)
@@ -30,12 +33,25 @@ class DatabaseTriggerCreate(BaseModel):
             raise ValueError("At least one operation is required")
         return v
 
+    @model_validator(mode="after")
+    def validate_target(self):
+        if self.target_type == "function":
+            if not self.function_name:
+                raise ValueError("function_name is required for function-target triggers")
+        else:  # pipeline
+            if not self.pipeline_name:
+                raise ValueError("pipeline_name is required for pipeline-target triggers")
+        return self
+
 
 class DatabaseTriggerUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     operations: Optional[list[str]] = None
+    target_type: Optional[Literal["function", "pipeline"]] = None
     function_namespace: Optional[str] = Field(default=None, min_length=1, max_length=255)
     function_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    pipeline_namespace: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    pipeline_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     poll_column: Optional[str] = Field(default=None, min_length=1, max_length=255)
     poll_interval_seconds: Optional[int] = Field(default=None, ge=1, le=3600)
     batch_size: Optional[int] = Field(default=None, ge=1, le=10000)
@@ -59,8 +75,11 @@ class DatabaseTriggerResponse(BaseModel):
     schema_name: str
     table_name: str
     operations: list[str]
+    target_type: str
     function_namespace: str
-    function_name: str
+    function_name: Optional[str]
+    pipeline_namespace: Optional[str]
+    pipeline_name: Optional[str]
     poll_column: str
     poll_interval_seconds: int
     batch_size: int

--- a/backend/app/schemas/pipeline.py
+++ b/backend/app/schemas/pipeline.py
@@ -1,0 +1,137 @@
+"""Pipeline schemas."""
+import uuid
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.services.pipeline_validation import validate_pipeline_definition
+
+NAME_PATTERN = r"^[a-zA-Z_][a-zA-Z0-9_-]*$"
+
+
+class PipelineBase(BaseModel):
+    """Shared create/update fields. Steps are free-form dicts validated by
+    validate_pipeline_definition (camelCase keys and `.$` mapping keys are data
+    and stored verbatim — one representation across YAML/API/DB)."""
+
+    description: Optional[str] = None
+    input_schema: Optional[dict[str, Any]] = None
+    steps: list[dict[str, Any]] = Field(default_factory=list)
+    per_user: Optional[dict[str, Any]] = None
+    as_tool: bool = False
+    tool_description: Optional[str] = None
+    sync_timeout_seconds: int = Field(default=120, ge=1, le=600)
+    concurrency: Optional[Literal["single", "parallel"]] = None
+    disable_after_failures: Optional[int] = Field(default=None, ge=1)
+    output_mapping: Optional[dict[str, Any]] = None
+
+
+class PipelineCreate(PipelineBase):
+    namespace: str = Field(default="default", min_length=1, max_length=255, pattern=NAME_PATTERN)
+    name: str = Field(..., min_length=1, max_length=255, pattern=NAME_PATTERN)
+
+    @model_validator(mode="after")
+    def validate_definition(self):
+        errors = validate_pipeline_definition(
+            self.steps,
+            per_user=self.per_user,
+            as_tool=self.as_tool,
+            input_schema=self.input_schema,
+            description=self.description,
+            tool_description=self.tool_description,
+            concurrency=self.concurrency,
+            output_mapping=self.output_mapping,
+        )
+        if errors:
+            raise ValueError("; ".join(errors))
+        return self
+
+
+class PipelineUpdate(BaseModel):
+    namespace: Optional[str] = Field(None, min_length=1, max_length=255, pattern=NAME_PATTERN)
+    name: Optional[str] = Field(None, min_length=1, max_length=255, pattern=NAME_PATTERN)
+    description: Optional[str] = None
+    input_schema: Optional[dict[str, Any]] = None
+    steps: Optional[list[dict[str, Any]]] = None
+    per_user: Optional[dict[str, Any]] = None
+    as_tool: Optional[bool] = None
+    tool_description: Optional[str] = None
+    sync_timeout_seconds: Optional[int] = Field(None, ge=1, le=600)
+    concurrency: Optional[Literal["single", "parallel"]] = None
+    disable_after_failures: Optional[int] = Field(None, ge=1)
+    output_mapping: Optional[dict[str, Any]] = None
+    is_active: Optional[bool] = None
+    # Note: the merged (existing + update) definition is re-validated in the endpoint,
+    # since partial updates can't be validated in isolation.
+
+
+class PipelineResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    namespace: str
+    name: str
+    description: Optional[str]
+    input_schema: dict[str, Any]
+    steps: list[dict[str, Any]]
+    per_user: Optional[dict[str, Any]]
+    as_tool: bool
+    tool_description: Optional[str]
+    sync_timeout_seconds: int
+    concurrency: Optional[str]
+    disable_after_failures: Optional[int]
+    output_mapping: Optional[dict[str, Any]]
+    cursor_value: Optional[str]
+    error_message: Optional[str]
+    is_active: bool
+    created_at: datetime
+    updated_at: Optional[datetime]
+
+    class Config:
+        from_attributes = True
+
+
+class PipelineRunRequest(BaseModel):
+    input: dict[str, Any] = Field(default_factory=dict)
+    mode: Literal["sync", "async"] = "sync"
+
+
+class PipelineRunResponse(BaseModel):
+    run_id: str
+    status: str
+    output: Optional[Any] = None
+    error: Optional[str] = None
+    steps: list[dict[str, Any]] = Field(default_factory=list)
+    duration_ms: Optional[int] = None
+
+
+class PipelineRunEnqueuedResponse(BaseModel):
+    run_id: str
+    status: str = "queued"
+
+
+class PipelineFanOutResponse(BaseModel):
+    """Response for ?allUsers=true fan-out runs."""
+    runs: list[PipelineRunEnqueuedResponse]
+    users: int
+
+
+class PipelineRunRecord(BaseModel):
+    id: uuid.UUID
+    run_id: str
+    pipeline_id: uuid.UUID
+    user_id: uuid.UUID
+    trigger_type: str
+    trigger_id: Optional[str]
+    status: str
+    input: Optional[dict[str, Any]]
+    steps: list[dict[str, Any]]
+    error: Optional[str]
+    cursor_before: Optional[str]
+    cursor_after: Optional[str]
+    started_at: datetime
+    completed_at: Optional[datetime]
+    duration_ms: Optional[int]
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, validator
 
 class ScheduledJobCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
-    schedule_type: Literal["function", "agent"] = "function"
+    schedule_type: Literal["function", "agent", "pipeline"] = "function"
     target_namespace: str = Field(
         default="default", min_length=1, max_length=255, pattern=r"^[a-zA-Z_][a-zA-Z0-9_]*$"
     )
@@ -36,7 +36,7 @@ class ScheduledJobCreate(BaseModel):
 
 class ScheduledJobUpdate(BaseModel):
     name: Optional[str] = None
-    schedule_type: Optional[Literal["function", "agent"]] = None
+    schedule_type: Optional[Literal["function", "agent", "pipeline"]] = None
     target_namespace: Optional[str] = None
     target_name: Optional[str] = None
     description: Optional[str] = None

--- a/backend/app/schemas/webhook.py
+++ b/backend/app/schemas/webhook.py
@@ -15,7 +15,7 @@ class DedupConfig(BaseModel):
 
 class WebhookCreate(BaseModel):
     path: str = Field(..., min_length=1, max_length=255, pattern=r"^[a-zA-Z0-9_/-]+$")
-    target_type: Literal["function", "agent"] = "function"
+    target_type: Literal["function", "agent", "pipeline"] = "function"
     function_namespace: str = Field(
         default="default", min_length=1, max_length=255, pattern=r"^[a-zA-Z_][a-zA-Z0-9_]*$"
     )
@@ -24,6 +24,10 @@ class WebhookCreate(BaseModel):
         default="default", min_length=1, max_length=255, pattern=r"^[a-zA-Z_][a-zA-Z0-9_]*$"
     )
     agent_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    pipeline_namespace: str = Field(
+        default="default", min_length=1, max_length=255, pattern=r"^[a-zA-Z_][a-zA-Z0-9_-]*$"
+    )
+    pipeline_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     message_template: Optional[str] = None
     session_key_template: Optional[str] = Field(default=None, max_length=500)
     http_method: HTTPMethod = HTTPMethod.POST
@@ -38,6 +42,11 @@ class WebhookCreate(BaseModel):
         if self.target_type == "function":
             if not self.function_name:
                 raise ValueError("function_name is required for function-target webhooks")
+        elif self.target_type == "pipeline":
+            if not self.pipeline_name:
+                raise ValueError("pipeline_name is required for pipeline-target webhooks")
+            if self.response_mode == "raw":
+                raise ValueError("response_mode 'raw' is only supported for function-target webhooks")
         else:  # agent
             if not self.agent_name:
                 raise ValueError("agent_name is required for agent-target webhooks")
@@ -49,11 +58,13 @@ class WebhookCreate(BaseModel):
 
 
 class WebhookUpdate(BaseModel):
-    target_type: Optional[Literal["function", "agent"]] = None
+    target_type: Optional[Literal["function", "agent", "pipeline"]] = None
     function_namespace: Optional[str] = None
     function_name: Optional[str] = None
     agent_namespace: Optional[str] = None
     agent_name: Optional[str] = None
+    pipeline_namespace: Optional[str] = None
+    pipeline_name: Optional[str] = None
     message_template: Optional[str] = None
     session_key_template: Optional[str] = None
     http_method: Optional[HTTPMethod] = None
@@ -73,6 +84,8 @@ class WebhookResponse(BaseModel):
     function_name: Optional[str]
     agent_namespace: Optional[str]
     agent_name: Optional[str]
+    pipeline_namespace: Optional[str]
+    pipeline_name: Optional[str]
     message_template: Optional[str]
     session_key_template: Optional[str]
     http_method: HTTPMethod

--- a/backend/app/services/config_apply/agents.py
+++ b/backend/app/services/config_apply/agents.py
@@ -149,6 +149,9 @@ async def apply_agents(
                     "enabled_connectors": agent_config.enabledConnectors
                     if agent_config.enabledConnectors
                     else [],
+                    "enabled_pipelines": sorted(agent_config.enabledPipelines)
+                    if agent_config.enabledPipelines
+                    else [],
                     "input_schema": agent_config.inputSchema or {},
                     "output_schema": agent_config.outputSchema or {},
                     "initial_messages": agent_config.initialMessages or [],
@@ -199,6 +202,7 @@ async def apply_agents(
                     existing.enabled_collections = normalized_collections
                     existing.enabled_components = agent_config.enabledComponents
                     existing.enabled_connectors = agent_config.enabledConnectors
+                    existing.enabled_pipelines = agent_config.enabledPipelines
                     existing.input_schema = agent_config.inputSchema or {}
                     existing.output_schema = agent_config.outputSchema or {}
                     existing.initial_messages = agent_config.initialMessages
@@ -260,6 +264,7 @@ async def apply_agents(
                         enabled_collections=normalized_collections,
                         enabled_components=agent_config.enabledComponents,
                         enabled_connectors=agent_config.enabledConnectors,
+                        enabled_pipelines=agent_config.enabledPipelines,
                         hooks=agent_config.hooks,
                         icon=agent_config.icon,
                         is_default=agent_config.isDefault,

--- a/backend/app/services/config_apply/integrations.py
+++ b/backend/app/services/config_apply/integrations.py
@@ -214,6 +214,12 @@ async def apply_schedules(
                     target_namespace, target_name = agent_ref.split("/", 1)
                 else:
                     target_namespace, target_name = "default", agent_ref
+            elif schedule_type == "pipeline":
+                pipeline_ref = schedule_config.pipelineName or ""
+                if "/" in pipeline_ref:
+                    target_namespace, target_name = pipeline_ref.split("/", 1)
+                else:
+                    target_namespace, target_name = "default", pipeline_ref
             else:
                 func_ref = schedule_config.functionName or ""
                 if "/" in func_ref:
@@ -306,12 +312,22 @@ async def apply_database_triggers(
                 )
                 continue
 
-            # Parse function name (namespace/name format)
-            func_ref = trigger_config.functionName
+            # Parse target refs (namespace/name format)
+            target_type = getattr(trigger_config, "targetType", "function")
+            func_ref = trigger_config.functionName or ""
             if "/" in func_ref:
                 func_namespace, func_name = func_ref.split("/", 1)
-            else:
+            elif func_ref:
                 func_namespace, func_name = "default", func_ref
+            else:
+                func_namespace, func_name = "default", None
+            pipeline_ref = getattr(trigger_config, "pipelineName", None) or ""
+            if "/" in pipeline_ref:
+                pipeline_namespace, pipeline_name = pipeline_ref.split("/", 1)
+            elif pipeline_ref:
+                pipeline_namespace, pipeline_name = "default", pipeline_ref
+            else:
+                pipeline_namespace, pipeline_name = None, None
 
             # Look for existing trigger
             stmt = select(DatabaseTrigger).where(DatabaseTrigger.name == trigger_config.name)
@@ -325,8 +341,11 @@ async def apply_database_triggers(
                     "schema_name": trigger_config.schemaName,
                     "table_name": trigger_config.tableName,
                     "operations": trigger_config.operations,
+                    "target_type": target_type,
                     "function_namespace": func_namespace,
                     "function_name": func_name,
+                    "pipeline_namespace": pipeline_namespace,
+                    "pipeline_name": pipeline_name,
                     "poll_column": trigger_config.pollColumn,
                     "poll_interval_seconds": trigger_config.pollIntervalSeconds,
                     "batch_size": trigger_config.batchSize,
@@ -343,8 +362,11 @@ async def apply_database_triggers(
                     existing.schema_name = trigger_config.schemaName
                     existing.table_name = trigger_config.tableName
                     existing.operations = trigger_config.operations
+                    existing.target_type = target_type
                     existing.function_namespace = func_namespace
                     existing.function_name = func_name
+                    existing.pipeline_namespace = pipeline_namespace
+                    existing.pipeline_name = pipeline_name
                     existing.poll_column = trigger_config.pollColumn
                     existing.poll_interval_seconds = trigger_config.pollIntervalSeconds
                     existing.batch_size = trigger_config.batchSize
@@ -361,8 +383,11 @@ async def apply_database_triggers(
                         schema_name=trigger_config.schemaName,
                         table_name=trigger_config.tableName,
                         operations=trigger_config.operations,
+                        target_type=target_type,
                         function_namespace=func_namespace,
                         function_name=func_name,
+                        pipeline_namespace=pipeline_namespace,
+                        pipeline_name=pipeline_name,
                         poll_column=trigger_config.pollColumn,
                         poll_interval_seconds=trigger_config.pollIntervalSeconds,
                         batch_size=trigger_config.batchSize,

--- a/backend/app/services/config_apply/integrations.py
+++ b/backend/app/services/config_apply/integrations.py
@@ -58,12 +58,19 @@ async def apply_webhooks(
             # Parse target references (may be "namespace/name" or just "name")
             func_ns, func_name = "default", None
             agent_ns, agent_name = None, None
+            pipeline_ns, pipeline_name = None, None
             if target_type == "agent":
                 agent_ref = webhook_config.agentName or ""
                 if "/" in agent_ref:
                     agent_ns, agent_name = agent_ref.split("/", 1)
                 else:
                     agent_ns, agent_name = "default", agent_ref
+            elif target_type == "pipeline":
+                pipeline_ref = getattr(webhook_config, "pipelineName", None) or ""
+                if "/" in pipeline_ref:
+                    pipeline_ns, pipeline_name = pipeline_ref.split("/", 1)
+                else:
+                    pipeline_ns, pipeline_name = "default", pipeline_ref
             else:
                 func_ref = webhook_config.functionName or ""
                 if "/" in func_ref:
@@ -77,6 +84,7 @@ async def apply_webhooks(
                     "target_type": target_type,
                     "function_name": webhook_config.functionName,
                     "agent_name": webhook_config.agentName,
+                    "pipeline_name": getattr(webhook_config, "pipelineName", None),
                     "message_template": webhook_config.messageTemplate,
                     "session_key_template": webhook_config.sessionKeyTemplate,
                     "http_method": webhook_config.httpMethod,
@@ -98,6 +106,8 @@ async def apply_webhooks(
                     existing.function_name = func_name
                     existing.agent_namespace = agent_ns
                     existing.agent_name = agent_name
+                    existing.pipeline_namespace = pipeline_ns
+                    existing.pipeline_name = pipeline_name
                     existing.message_template = webhook_config.messageTemplate
                     existing.session_key_template = webhook_config.sessionKeyTemplate
                     existing.http_method = webhook_config.httpMethod
@@ -127,6 +137,8 @@ async def apply_webhooks(
                         function_name=func_name,
                         agent_namespace=agent_ns,
                         agent_name=agent_name,
+                        pipeline_namespace=pipeline_ns,
+                        pipeline_name=pipeline_name,
                         message_template=webhook_config.messageTemplate,
                         session_key_template=webhook_config.sessionKeyTemplate,
                         user_id=owner_user_id,

--- a/backend/app/services/config_apply/resources.py
+++ b/backend/app/services/config_apply/resources.py
@@ -916,3 +916,123 @@ async def apply_dependencies(
 
         except Exception as e:
             errors.append(f"Error applying dependency '{package_name}': {str(e)}")
+
+
+async def apply_pipelines(
+    db: AsyncSession,
+    pipelines: list,
+    dry_run: bool,
+    managed_by: str,
+    config_name: str,
+    owner_user_id: str,
+    calculate_hash: Any,
+    track_change: Any,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    """Apply pipeline configurations.
+
+    Shape validation runs here (steps, mapping expressions, perUser, asTool);
+    cross-resource references (connectors/functions/agents/queries) are NOT
+    checked — install order means they may not exist yet. Missing targets fail
+    at run time with a clear error.
+    """
+    from app.models.pipeline import Pipeline
+    from app.services.pipeline_validation import validate_pipeline_definition
+
+    for pipe_config in pipelines:
+        resource_name = f"{pipe_config.namespace}/{pipe_config.name}"
+        try:
+            output_mapping = pipe_config.output_mapping()
+            validation_errors = validate_pipeline_definition(
+                pipe_config.steps,
+                per_user=pipe_config.perUser,
+                as_tool=pipe_config.asTool,
+                input_schema=pipe_config.inputSchema,
+                description=pipe_config.description,
+                tool_description=pipe_config.toolDescription,
+                concurrency=pipe_config.concurrency,
+                output_mapping=output_mapping,
+            )
+            if validation_errors:
+                errors.append(
+                    f"Invalid pipeline '{resource_name}': " + "; ".join(validation_errors)
+                )
+                continue
+
+            stmt = select(Pipeline).where(
+                Pipeline.namespace == pipe_config.namespace,
+                Pipeline.name == pipe_config.name,
+            )
+            result = await db.execute(stmt)
+            existing = result.scalar_one_or_none()
+
+            config_hash = calculate_hash({
+                "namespace": pipe_config.namespace,
+                "name": pipe_config.name,
+                "description": pipe_config.description,
+                "input_schema": pipe_config.inputSchema or {},
+                "steps": pipe_config.steps,
+                "per_user": pipe_config.perUser,
+                "as_tool": pipe_config.asTool,
+                "tool_description": pipe_config.toolDescription,
+                "sync_timeout_seconds": pipe_config.syncTimeoutSeconds,
+                "concurrency": pipe_config.concurrency,
+                "disable_after_failures": pipe_config.disableAfterFailures,
+                "output_mapping": output_mapping,
+                "is_active": pipe_config.isActive,
+            })
+
+            if existing:
+                if should_skip_existing(existing, managed_by, config_name, config_hash, "pipelines", resource_name, track_change, warnings):
+                    continue
+
+                if not dry_run:
+                    existing.description = pipe_config.description
+                    existing.input_schema = pipe_config.inputSchema or {}
+                    existing.steps = pipe_config.steps
+                    existing.per_user = pipe_config.perUser
+                    existing.as_tool = pipe_config.asTool
+                    existing.tool_description = pipe_config.toolDescription
+                    existing.sync_timeout_seconds = pipe_config.syncTimeoutSeconds
+                    existing.concurrency = pipe_config.concurrency
+                    existing.disable_after_failures = pipe_config.disableAfterFailures
+                    existing.output_mapping = output_mapping
+                    existing.is_active = pipe_config.isActive
+                    if pipe_config.isActive:
+                        # Reactivation clears the auto-disable state (cursor is kept).
+                        existing.consecutive_failures = 0
+                        existing.error_message = None
+                    existing.managed_by = managed_by
+                    existing.config_name = config_name
+                    existing.config_checksum = config_hash
+
+                track_change("update", "pipelines", resource_name)
+            else:
+                if not dry_run:
+                    pipeline = Pipeline(
+                        user_id=owner_user_id,
+                        namespace=pipe_config.namespace,
+                        name=pipe_config.name,
+                        description=pipe_config.description,
+                        input_schema=pipe_config.inputSchema or {},
+                        steps=pipe_config.steps,
+                        per_user=pipe_config.perUser,
+                        as_tool=pipe_config.asTool,
+                        tool_description=pipe_config.toolDescription,
+                        sync_timeout_seconds=pipe_config.syncTimeoutSeconds,
+                        concurrency=pipe_config.concurrency,
+                        disable_after_failures=pipe_config.disableAfterFailures,
+                        output_mapping=output_mapping,
+                        is_active=pipe_config.isActive,
+                        managed_by=managed_by,
+                        config_name=config_name,
+                        config_checksum=config_hash,
+                    )
+                    db.add(pipeline)
+
+                track_change("create", "pipelines", resource_name)
+
+        except Exception as e:
+            errors.append(f"Failed to apply pipeline '{resource_name}': {e}")
+            logger.exception(f"Error applying pipeline '{resource_name}'")

--- a/backend/app/services/config_apply/service.py
+++ b/backend/app/services/config_apply/service.py
@@ -28,6 +28,7 @@ from app.services.config_apply.resources import (
     apply_dependencies,
     apply_functions,
     apply_manifests,
+    apply_pipelines,
     apply_queries,
     apply_secrets,
     apply_skills,
@@ -236,6 +237,13 @@ class ConfigApplyService:
                     agents=config.spec.agents,
                     llm_provider_ids=self.llm_provider_ids,
                     agent_ids=self.agent_ids,
+                )
+            # Pipelines apply after connectors/functions/queries/agents (their
+            # step references), and before the triggers that may target them.
+            if "pipelines" not in self.skip_resource_types:
+                await apply_pipelines(
+                    **common_with_owner,
+                    pipelines=config.spec.pipelines,
                 )
             if "webhooks" not in self.skip_resource_types:
                 await apply_webhooks(

--- a/backend/app/services/config_export.py
+++ b/backend/app/services/config_export.py
@@ -85,6 +85,7 @@ class ConfigExportService:
         config_dict["spec"]["components"] = await self._export_components()
         config_dict["spec"]["manifests"] = await self._export_manifests()
         config_dict["spec"]["agents"] = await self._export_agents()
+        config_dict["spec"]["pipelines"] = await self._export_pipelines()
         config_dict["spec"]["webhooks"] = await self._export_webhooks()
         config_dict["spec"]["schedules"] = await self._export_schedules()
         config_dict["spec"]["databaseTriggers"] = await self._export_database_triggers()
@@ -224,6 +225,17 @@ class ConfigExportService:
             stmt = stmt.where(Connector.managed_by == self.managed_by)
         result = await self.db.execute(stmt)
         return [serialize_connector(c) for c in result.scalars().all()]
+
+    async def _export_pipelines(self) -> list[dict]:
+        """Export pipelines (cursor/failure state is runtime, not exported)."""
+        from app.models.pipeline import Pipeline
+        from app.services.resource_serializers import serialize_pipeline
+
+        stmt = select(Pipeline).where(Pipeline.is_active == True)
+        if self.managed_only:
+            stmt = stmt.where(Pipeline.managed_by == self.managed_by)
+        result = await self.db.execute(stmt)
+        return [serialize_pipeline(p) for p in result.scalars().all()]
 
     async def _export_functions(self) -> list[dict]:
         """Export functions"""

--- a/backend/app/services/config_parser.py
+++ b/backend/app/services/config_parser.py
@@ -432,9 +432,33 @@ class ConfigParser:
                         )
                     )
 
+        # Pipeline names (config + database) for webhook/schedule/trigger target checks
+        pipeline_names = {
+            f"{p.get('namespace', 'default')}/{p['name']}" for p in spec.get("pipelines", [])
+        }
+        db_pipeline_names: set[str] = set()
+        if db:
+            from app.models.pipeline import Pipeline as PipelineModel
+
+            result = await db.execute(select(PipelineModel.namespace, PipelineModel.name))
+            db_pipeline_names = {f"{namespace}/{name}" for (namespace, name) in result.fetchall()}
+        all_pipeline_names = pipeline_names | db_pipeline_names
+
         # Validate webhook references
         for i, webhook in enumerate(spec.get("webhooks", [])):
-            if webhook.get("targetType", "function") == "agent":
+            webhook_target = webhook.get("targetType", "function")
+            if webhook_target == "pipeline":
+                pipeline_ref = webhook.get("pipelineName") or ""
+                if "/" not in pipeline_ref:
+                    pipeline_ref = f"default/{pipeline_ref}"
+                if not _ref_matches_any(pipeline_ref, all_pipeline_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.webhooks[{i}].pipelineName",
+                            message=f"Referenced pipeline '{pipeline_ref}' not defined",
+                        )
+                    )
+            elif webhook_target == "agent":
                 agent_ref = webhook.get("agentName") or ""
                 if "/" not in agent_ref:
                     agent_ref = f"default/{agent_ref}"
@@ -457,18 +481,6 @@ class ConfigParser:
                             message=f"Referenced function '{func_ref}' not defined",
                         )
                     )
-
-        # Pipeline names (config + database) for schedule/trigger target checks
-        pipeline_names = {
-            f"{p.get('namespace', 'default')}/{p['name']}" for p in spec.get("pipelines", [])
-        }
-        db_pipeline_names: set[str] = set()
-        if db:
-            from app.models.pipeline import Pipeline as PipelineModel
-
-            result = await db.execute(select(PipelineModel.namespace, PipelineModel.name))
-            db_pipeline_names = {f"{namespace}/{name}" for (namespace, name) in result.fetchall()}
-        all_pipeline_names = pipeline_names | db_pipeline_names
 
         # Validate schedule references (target depends on scheduleType)
         for i, schedule in enumerate(spec.get("schedules", [])):

--- a/backend/app/services/config_parser.py
+++ b/backend/app/services/config_parser.py
@@ -446,17 +446,54 @@ class ConfigParser:
                     )
                 )
 
-        # Validate schedule references
+        # Pipeline names (config + database) for schedule/trigger target checks
+        pipeline_names = {
+            f"{p.get('namespace', 'default')}/{p['name']}" for p in spec.get("pipelines", [])
+        }
+        db_pipeline_names: set[str] = set()
+        if db:
+            from app.models.pipeline import Pipeline as PipelineModel
+
+            result = await db.execute(select(PipelineModel.namespace, PipelineModel.name))
+            db_pipeline_names = {f"{namespace}/{name}" for (namespace, name) in result.fetchall()}
+        all_pipeline_names = pipeline_names | db_pipeline_names
+
+        # Validate schedule references (target depends on scheduleType)
         for i, schedule in enumerate(spec.get("schedules", [])):
-            # Build function reference as namespace/name
-            func_namespace = schedule.get("functionNamespace", "default")
-            func_name = schedule["functionName"]
-            func_ref = f"{func_namespace}/{func_name}"
-            if not _ref_matches_any(func_ref, all_function_names):
-                errors.append(
-                    ConfigValidationError(
-                        path=f"spec.schedules[{i}].functionName",
-                        message=f"Referenced function '{func_ref}' not defined",
+            schedule_type = schedule.get("scheduleType", "function")
+            if schedule_type == "pipeline":
+                pipeline_ref = schedule.get("pipelineName") or ""
+                if "/" not in pipeline_ref:
+                    pipeline_ref = f"default/{pipeline_ref}"
+                if not _ref_matches_any(pipeline_ref, all_pipeline_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.schedules[{i}].pipelineName",
+                            message=f"Referenced pipeline '{pipeline_ref}' not defined",
+                        )
                     )
-                )
+            elif schedule_type == "agent":
+                agent_ref = schedule.get("agentName") or ""
+                if "/" not in agent_ref:
+                    agent_ref = f"default/{agent_ref}"
+                if not _ref_matches_any(agent_ref, all_agent_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.schedules[{i}].agentName",
+                            message=f"Referenced agent '{agent_ref}' not defined",
+                        )
+                    )
+            else:
+                func_namespace = schedule.get("functionNamespace", "default")
+                func_name = schedule.get("functionName")
+                func_ref = f"{func_namespace}/{func_name}"
+                if "/" in (func_name or ""):
+                    func_ref = func_name
+                if not _ref_matches_any(func_ref, all_function_names):
+                    errors.append(
+                        ConfigValidationError(
+                            path=f"spec.schedules[{i}].functionName",
+                            message=f"Referenced function '{func_ref}' not defined",
+                        )
+                    )
 

--- a/backend/app/services/pipeline_mapping.py
+++ b/backend/app/services/pipeline_mapping.py
@@ -1,0 +1,95 @@
+"""Declarative data mapping for pipelines: JMESPath with AWS States-style keys.
+
+One convention used everywhere (step input, cursor.path, primaryKey, items,
+pipeline output):
+
+- ``key: value``        — literal, passed through (recursively for dicts/lists).
+- ``key.$: <jmespath>`` — evaluated against the run context; result bound to ``key``.
+- A whole value may be an expression via the ``.$``-suffixed variant of its
+  field (e.g. step ``input.$``).
+
+A missing path yields ``None`` (JMESPath semantics). Syntactically invalid
+expressions are rejected at save/config-apply time via `validate_expression`.
+"""
+from typing import Any
+
+import jmespath
+from jmespath.exceptions import ParseError
+
+EXPR_SUFFIX = ".$"
+
+
+class MappingError(ValueError):
+    """Raised for invalid mapping shapes or expressions."""
+
+
+def validate_expression(expr: Any, where: str) -> list[str]:
+    """Validate one JMESPath expression; returns a list of error strings."""
+    if not isinstance(expr, str) or not expr.strip():
+        return [f"{where}: expression must be a non-empty string"]
+    try:
+        jmespath.compile(expr)
+    except ParseError as e:
+        return [f"{where}: invalid JMESPath expression: {e}"]
+    return []
+
+
+def validate_template(template: Any, where: str) -> list[str]:
+    """Recursively validate a mapping template (dict/list/scalars with .$ keys)."""
+    errors: list[str] = []
+    if isinstance(template, dict):
+        for key, value in template.items():
+            if isinstance(key, str) and key.endswith(EXPR_SUFFIX):
+                base = key[: -len(EXPR_SUFFIX)]
+                if base + EXPR_SUFFIX != key or not base:
+                    errors.append(f"{where}: invalid expression key '{key}'")
+                    continue
+                if base in template:
+                    errors.append(
+                        f"{where}: both '{base}' and '{key}' present — pick literal or expression"
+                    )
+                errors.extend(validate_expression(value, f"{where}.{key}"))
+            else:
+                errors.extend(validate_template(value, f"{where}.{key}"))
+    elif isinstance(template, list):
+        for i, item in enumerate(template):
+            errors.extend(validate_template(item, f"{where}[{i}]"))
+    return errors
+
+
+def evaluate_expression(expr: str, context: dict[str, Any]) -> Any:
+    """Evaluate a single JMESPath expression against the run context."""
+    return jmespath.search(expr, context)
+
+
+def resolve_template(template: Any, context: dict[str, Any]) -> Any:
+    """Resolve a mapping template against the run context.
+
+    Dicts: ``key.$`` entries are evaluated and bound to ``key``; other entries
+    recurse. Lists recurse per element. Scalars pass through.
+    """
+    if isinstance(template, dict):
+        resolved: dict[str, Any] = {}
+        for key, value in template.items():
+            if isinstance(key, str) and key.endswith(EXPR_SUFFIX):
+                resolved[key[: -len(EXPR_SUFFIX)]] = evaluate_expression(value, context)
+            else:
+                resolved[key] = resolve_template(value, context)
+        return resolved
+    if isinstance(template, list):
+        return [resolve_template(item, context) for item in template]
+    return template
+
+
+def resolve_field(container: dict[str, Any], field: str, context: dict[str, Any], default: Any = None) -> Any:
+    """Resolve a field that may be given as ``field`` (template) or ``field.$`` (expression).
+
+    Used for step ``input`` / pipeline ``output`` style fields where the whole
+    value may be one expression.
+    """
+    expr_key = field + EXPR_SUFFIX
+    if expr_key in container:
+        return evaluate_expression(container[expr_key], context)
+    if field in container:
+        return resolve_template(container[field], context)
+    return default

--- a/backend/app/services/pipeline_runner.py
+++ b/backend/app/services/pipeline_runner.py
@@ -1,0 +1,929 @@
+"""Pipeline runner — one async runner, two entry points (queued job / inline sync).
+
+See backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md.
+
+Key invariants:
+- The cursor commits ONLY when the whole run succeeds (at-least-once delivery;
+  a failed run holds the bookmark).
+- Single-flight per run scope (pipeline, or pipeline+user for perUser) via a
+  Redis lock; queued fires that hit a held lock leave a coalesce flag that the
+  lock holder re-enqueues once on completion. Sync callers get PipelineBusyError.
+- One user's failure never blocks or fails other users' runs (perUser isolation).
+- Never dispatch a step with a half-resolved input: mapping errors fail the run
+  before the step executes.
+"""
+import asyncio
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import jsonschema
+from sqlalchemy import select, update
+
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.core.redis import get_redis
+from app.models.connector import Connector
+from app.models.database_connection import DatabaseConnection
+from app.models.execution import TriggerType
+from app.models.pipeline import Pipeline, PipelineCursor, PipelineRun
+from app.models.query import Query
+from app.models.user import User
+from app.services import pipeline_mapping as pm
+
+logger = logging.getLogger(__name__)
+
+LOCK_PREFIX = "sinas:pipeline:lock:"
+PENDING_PREFIX = "sinas:pipeline:pending:"
+LOCK_MARGIN_SECONDS = 600
+PENDING_TTL = 3600
+
+# Release the lock only if we still own it (value = run_id).
+_RELEASE_LUA = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+
+class PipelineBusyError(Exception):
+    """A sync run hit the single-flight lock: another run is active."""
+
+    def __init__(self, active_run_id: Optional[str]):
+        self.active_run_id = active_run_id
+        super().__init__(f"Pipeline run already in progress (run_id={active_run_id})")
+
+
+class StepError(Exception):
+    """A step failed after exhausting its retries."""
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _lock_key(pipeline: Pipeline, user_id: str) -> str:
+    if pipeline.per_user:
+        return f"{LOCK_PREFIX}{pipeline.id}:{user_id}"
+    return f"{LOCK_PREFIX}{pipeline.id}"
+
+
+def _pending_key(pipeline: Pipeline, user_id: str) -> str:
+    if pipeline.per_user:
+        return f"{PENDING_PREFIX}{pipeline.id}:{user_id}"
+    return f"{PENDING_PREFIX}{pipeline.id}"
+
+
+def _backoff_delay(attempt: int, strategy: str) -> float:
+    if strategy == "exponential":
+        return min(2**attempt * 0.5, 30.0)
+    if strategy == "linear":
+        return min((attempt + 1) * 1.0, 30.0)
+    return 0.0
+
+
+def _split_ref(ref: str) -> tuple[str, str]:
+    namespace, name = ref.split("/", 1)
+    return namespace, name
+
+
+def _summarize(value: Any, limit: int = 2000) -> str:
+    try:
+        text = value if isinstance(value, str) else json.dumps(value, default=str)
+    except Exception:
+        text = str(value)
+    return text[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Step executors. Each returns the step's context output on success and raises
+# StepError on failure. They receive the *resolved* input.
+# ---------------------------------------------------------------------------
+
+
+async def _execute_connector_step(
+    step: dict[str, Any], step_input: Any, *, user_id: str, user_token: Optional[str]
+) -> Any:
+    from app.services.connector_service import ConnectorAuthError, connector_service
+
+    namespace, name = _split_ref(step["connector"])
+    operation = step["operation"]
+
+    async with AsyncSessionLocal() as db:
+        connector = await Connector.get_by_name(db, namespace, name)
+        if not connector or not connector.is_active:
+            raise StepError(f"Connector '{namespace}/{name}' not found or inactive")
+        params = step_input if isinstance(step_input, dict) else {}
+        try:
+            result = await connector_service.execute_operation(
+                db=db,
+                connector=connector,
+                operation_name=operation,
+                parameters=params,
+                user_token=user_token,
+                user_id=user_id,
+            )
+        except ConnectorAuthError as e:
+            raise StepError(str(e))
+        except ValueError as e:
+            raise StepError(str(e))
+
+    status_code = result.get("status_code", 0)
+    allowed = step.get("allowStatuses") or []
+    if not (200 <= status_code < 300) and status_code not in allowed:
+        raise StepError(
+            f"Connector {namespace}/{name}/{operation} returned {status_code}: "
+            f"{_summarize(result.get('body'), 500)}"
+        )
+    return {
+        "statusCode": status_code,
+        "body": result.get("body"),
+        "elapsedMs": result.get("elapsed_ms"),
+    }
+
+
+async def _execute_function_step(
+    step: dict[str, Any], step_input: Any, *,
+    user_id: str, run_id: str, depth: int, summary: dict[str, Any],
+) -> Any:
+    from app.services.queue_service import queue_service
+
+    namespace, name = _split_ref(step["function"])
+    execution_id = str(uuid.uuid4())
+    summary["executionId"] = execution_id
+    try:
+        return await queue_service.enqueue_and_wait(
+            function_namespace=namespace,
+            function_name=name,
+            input_data=step_input if isinstance(step_input, dict) else {"input": step_input},
+            execution_id=execution_id,
+            trigger_type=TriggerType.PIPELINE.value,
+            trigger_id=run_id,
+            user_id=user_id,
+            depth=depth,
+        )
+    except TimeoutError as e:
+        raise StepError(f"Function {namespace}/{name} timed out: {e}")
+    except Exception as e:
+        raise StepError(f"Function {namespace}/{name} failed: {e}")
+
+
+async def _execute_query_step(
+    step: dict[str, Any], step_input: Any, *, user_id: str
+) -> Any:
+    from app.services.database_pool import DatabasePoolManager
+
+    namespace, name = _split_ref(step["query"])
+    async with AsyncSessionLocal() as db:
+        query = await Query.get_by_name(db, namespace, name)
+        if not query or not query.is_active:
+            raise StepError(f"Query '{namespace}/{name}' not found or inactive")
+
+        params = dict(step_input) if isinstance(step_input, dict) else {}
+        params.setdefault("user_id", str(user_id))
+        user = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if user:
+            params.setdefault("user_email", user.email)
+
+        try:
+            result = await DatabasePoolManager.get_instance().execute_query(
+                db=db,
+                connection_id=str(query.database_connection_id),
+                sql=query.sql,
+                params=params,
+                operation=query.operation,
+                timeout_ms=query.timeout_ms,
+                max_rows=query.max_rows,
+            )
+        except Exception as e:
+            raise StepError(f"Query {namespace}/{name} failed: {e}")
+
+    return {
+        "rows": result.get("rows"),
+        "rowCount": result.get("row_count"),
+        "affectedRows": result.get("affected_rows"),
+    }
+
+
+async def _execute_agent_step(
+    step: dict[str, Any], step_input: Any, *,
+    user_id: str, user_token: str, run_id: str, agent_depth: int,
+    pipeline_label: str, summary: dict[str, Any],
+) -> Any:
+    from app.models.agent import Agent
+    from app.models.chat import Chat
+    from app.services.queue_service import queue_service
+    from app.services.stream_relay import stream_relay
+
+    namespace, name = _split_ref(step["agent"])
+
+    async with AsyncSessionLocal() as db:
+        agent = await Agent.get_by_name(db, namespace, name)
+        if not agent:
+            raise StepError(f"Agent '{namespace}/{name}' not found or inactive")
+
+        input_data = step_input if isinstance(step_input, dict) else {}
+        chat = Chat(
+            user_id=user_id,
+            agent_id=agent.id,
+            agent_namespace=agent.namespace,
+            agent_name=agent.name,
+            title=f"pipeline:{pipeline_label} — {_now().strftime('%Y-%m-%d %H:%M')}",
+            chat_metadata={"agent_input": input_data} if input_data else None,
+            job_timeout=agent.default_job_timeout,
+        )
+        db.add(chat)
+        await db.commit()
+        await db.refresh(chat)
+        chat_id = str(chat.id)
+        output_schema = agent.output_schema or {}
+        agent_timeout = agent.default_job_timeout or settings.agent_delegate_timeout
+
+    summary["chatId"] = chat_id
+
+    # Message: explicit template/expression, else the JSON-serialized input.
+    if "message" in step or "message.$" in step:
+        message = step.get("message")
+        if message is None:
+            message = step_input  # resolved from message.$ upstream
+        if not isinstance(message, str):
+            message = json.dumps(message, default=str)
+    else:
+        message = json.dumps(input_data, default=str) if input_data else "Run your task."
+
+    channel_id = str(uuid.uuid4())
+    await queue_service.enqueue_agent_message(
+        chat_id=chat_id,
+        user_id=user_id,
+        user_token=user_token,
+        content=message,
+        channel_id=channel_id,
+        agent=f"{namespace}/{name}",
+        trigger_type=TriggerType.PIPELINE.value.lower(),
+        depth=agent_depth,
+    )
+
+    final_content = ""
+    got_terminal = False
+    async for event in stream_relay.subscribe(channel_id, timeout=agent_timeout):
+        if event.get("content"):
+            final_content += event["content"]
+        if event.get("type") in ("done", "error"):
+            got_terminal = True
+            if event.get("type") == "error":
+                raise StepError(f"Agent {namespace}/{name} failed: {event.get('error', 'unknown error')}")
+            break
+
+    if not got_terminal:
+        raise StepError(f"Agent {namespace}/{name} did not respond within {agent_timeout}s")
+
+    if output_schema.get("properties"):
+        try:
+            parsed = json.loads(final_content)
+        except json.JSONDecodeError as e:
+            raise StepError(
+                f"Agent {namespace}/{name} reply is not valid JSON despite outputSchema: {e}. "
+                f"Reply started with: {final_content[:200]!r}"
+            )
+        try:
+            jsonschema.validate(instance=parsed, schema=output_schema)
+        except jsonschema.ValidationError as e:
+            raise StepError(f"Agent {namespace}/{name} reply violates outputSchema: {e.message}")
+        return parsed
+    return final_content
+
+
+def _quote_table(table: str) -> str:
+    parts = table.split(".")
+    return ".".join(f'"{p}"' for p in parts)
+
+
+async def _execute_load_step(
+    step: dict[str, Any], *, context: dict[str, Any], user_id: str, per_user: bool
+) -> Any:
+    from app.services.database_pool import DatabasePoolManager
+
+    items = pm.evaluate_expression(step["items.$"], context)
+    if items is None:
+        items = []
+    if isinstance(items, dict):
+        items = [items]
+    if not isinstance(items, list):
+        raise StepError("load: items.$ must resolve to an array (or single object)")
+
+    async with AsyncSessionLocal() as db:
+        conn_model = await DatabaseConnection.get_by_name(db, step["connection"])
+        if not conn_model:
+            raise StepError(f"Database connection '{step['connection']}' not found")
+        pool = await DatabasePoolManager.get_instance().get_pool(db, str(conn_model.id))
+
+    table_sql = _quote_table(step["table"])
+    rows: list[tuple] = []
+    for i, item in enumerate(items):
+        pk = pm.evaluate_expression(step["primaryKey.$"], {**context, "item": item})
+        if pk is None:
+            raise StepError(f"load: primaryKey.$ resolved to null for item {i}")
+        rows.append((str(pk), json.dumps(item, default=str)))
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            if per_user:
+                await conn.execute(
+                    f"CREATE TABLE IF NOT EXISTS {table_sql} ("
+                    f"user_id uuid NOT NULL, pk text NOT NULL, payload jsonb NOT NULL, "
+                    f"synced_at timestamptz NOT NULL DEFAULT now(), PRIMARY KEY (user_id, pk))"
+                )
+                await conn.executemany(
+                    f"INSERT INTO {table_sql} (user_id, pk, payload) VALUES ($1, $2, $3::jsonb) "
+                    f"ON CONFLICT (user_id, pk) DO UPDATE SET payload = EXCLUDED.payload, synced_at = now()",
+                    [(uuid.UUID(str(user_id)), pk, payload) for pk, payload in rows],
+                )
+            else:
+                await conn.execute(
+                    f"CREATE TABLE IF NOT EXISTS {table_sql} ("
+                    f"pk text PRIMARY KEY, payload jsonb NOT NULL, "
+                    f"synced_at timestamptz NOT NULL DEFAULT now())"
+                )
+                await conn.executemany(
+                    f"INSERT INTO {table_sql} (pk, payload) VALUES ($1, $2::jsonb) "
+                    f"ON CONFLICT (pk) DO UPDATE SET payload = EXCLUDED.payload, synced_at = now()",
+                    rows,
+                )
+
+    return {"upserted": len(rows), "table": step["table"]}
+
+
+# ---------------------------------------------------------------------------
+# Cursor state
+# ---------------------------------------------------------------------------
+
+
+async def _read_cursor(pipeline: Pipeline, user_id: str) -> Optional[str]:
+    if not pipeline.per_user:
+        return pipeline.cursor_value
+    async with AsyncSessionLocal() as db:
+        row = (
+            await db.execute(
+                select(PipelineCursor).where(
+                    PipelineCursor.pipeline_id == pipeline.id,
+                    PipelineCursor.user_id == user_id,
+                )
+            )
+        ).scalar_one_or_none()
+        return row.cursor_value if row else None
+
+
+async def _finalize_success(
+    pipeline: Pipeline, user_id: str, new_cursor: Optional[str]
+) -> None:
+    """Commit the cursor (if any) and reset failure counters for the run scope."""
+    async with AsyncSessionLocal() as db:
+        if pipeline.per_user:
+            row = (
+                await db.execute(
+                    select(PipelineCursor).where(
+                        PipelineCursor.pipeline_id == pipeline.id,
+                        PipelineCursor.user_id == user_id,
+                    )
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                row = PipelineCursor(pipeline_id=pipeline.id, user_id=user_id)
+                db.add(row)
+            if new_cursor is not None:
+                row.cursor_value = new_cursor
+            row.consecutive_failures = 0
+            row.last_error = None
+        else:
+            values: dict[str, Any] = {"consecutive_failures": 0, "error_message": None}
+            if new_cursor is not None:
+                values["cursor_value"] = new_cursor
+            await db.execute(update(Pipeline).where(Pipeline.id == pipeline.id).values(**values))
+        await db.commit()
+
+
+async def _finalize_failure(pipeline: Pipeline, user_id: str, error: str) -> None:
+    """Hold the cursor, bump failure counters, apply auto-disable/skip policy."""
+    async with AsyncSessionLocal() as db:
+        if pipeline.per_user:
+            row = (
+                await db.execute(
+                    select(PipelineCursor).where(
+                        PipelineCursor.pipeline_id == pipeline.id,
+                        PipelineCursor.user_id == user_id,
+                    )
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                row = PipelineCursor(pipeline_id=pipeline.id, user_id=user_id)
+                db.add(row)
+            row.consecutive_failures = (row.consecutive_failures or 0) + 1
+            row.last_error = error[:2000]
+        else:
+            db_pipeline = (
+                await db.execute(select(Pipeline).where(Pipeline.id == pipeline.id))
+            ).scalar_one_or_none()
+            if db_pipeline:
+                db_pipeline.consecutive_failures = (db_pipeline.consecutive_failures or 0) + 1
+                db_pipeline.error_message = error[:2000]
+                threshold = db_pipeline.disable_after_failures
+                if threshold and db_pipeline.consecutive_failures >= threshold:
+                    db_pipeline.is_active = False
+                    logger.warning(
+                        f"Pipeline {db_pipeline.namespace}/{db_pipeline.name} deactivated "
+                        f"after {db_pipeline.consecutive_failures} consecutive failures"
+                    )
+        await db.commit()
+
+
+async def reset_user_failure_state(
+    db, user_id: str, *, connector_id: Any = None, secret_name: Optional[str] = None
+) -> None:
+    """Reset per-user failure counters when a user re-credentials.
+
+    Called from the OAuth callback (fresh token stored, pass connector_id) and
+    private-secret create/update (pass secret_name) — the natural recovery
+    points for skip-until-re-credential. Matches pipelines whose
+    perUser.connector resolves to the affected connector(s). Best-effort:
+    failures here must never break the credential operation itself.
+    """
+    try:
+        refs: set[str] = set()
+        if connector_id is not None:
+            connector = (
+                await db.execute(select(Connector).where(Connector.id == connector_id))
+            ).scalar_one_or_none()
+            if connector:
+                refs.add(f"{connector.namespace}/{connector.name}")
+        if secret_name:
+            connectors = (
+                await db.execute(select(Connector).where(Connector.is_active == True))  # noqa: E712
+            ).scalars().all()
+            refs.update(
+                f"{c.namespace}/{c.name}"
+                for c in connectors
+                if (c.auth or {}).get("secret") == secret_name
+            )
+        if not refs:
+            return
+
+        pipelines = (
+            await db.execute(select(Pipeline).where(Pipeline.per_user.isnot(None)))
+        ).scalars().all()
+        ids = [p.id for p in pipelines if (p.per_user or {}).get("connector") in refs]
+        if not ids:
+            return
+        await db.execute(
+            update(PipelineCursor)
+            .where(PipelineCursor.pipeline_id.in_(ids), PipelineCursor.user_id == user_id)
+            .values(consecutive_failures=0, last_error=None)
+        )
+    except Exception:
+        logger.exception("Failed to reset pipeline failure state on re-credential")
+
+
+# ---------------------------------------------------------------------------
+# The runner
+# ---------------------------------------------------------------------------
+
+
+async def run_pipeline(
+    pipeline_id: str,
+    run_input: Optional[dict[str, Any]],
+    *,
+    trigger_type: str,
+    trigger_id: Optional[str],
+    user_id: str,
+    user_token: str,
+    exec_depth: int = 0,
+    agent_depth: int = 0,
+    sync: bool = False,
+) -> dict[str, Any]:
+    """Execute one pipeline run for one user scope. Returns the run outcome:
+
+        {"run_id", "status", "output", "error", "steps", "duration_ms"}
+
+    status: succeeded | failed | timed_out | skipped (queued fire coalesced).
+    Raises PipelineBusyError for sync callers when the single-flight lock is held.
+    """
+    async with AsyncSessionLocal() as db:
+        pipeline = (
+            await db.execute(select(Pipeline).where(Pipeline.id == pipeline_id))
+        ).scalar_one_or_none()
+        if pipeline is None:
+            raise ValueError(f"Pipeline {pipeline_id} not found")
+        if not pipeline.is_active:
+            raise ValueError(f"Pipeline {pipeline.namespace}/{pipeline.name} is inactive")
+        db.expunge(pipeline)
+
+    label = f"{pipeline.namespace}/{pipeline.name}"
+    run_id = str(uuid.uuid4())
+    redis = await get_redis()
+
+    # --- single-flight ---
+    lock_key = _lock_key(pipeline, user_id)
+    lock_ttl = pipeline.sync_timeout_seconds + LOCK_MARGIN_SECONDS
+    use_lock = pipeline.effective_concurrency() == "single"
+    if use_lock:
+        acquired = await redis.set(lock_key, run_id, nx=True, ex=lock_ttl)
+        if not acquired:
+            active = await redis.get(lock_key)
+            if sync:
+                raise PipelineBusyError(active)
+            # Coalesce: remember the latest fire so the lock holder re-runs once.
+            await redis.set(
+                _pending_key(pipeline, user_id),
+                json.dumps({
+                    "input": run_input,
+                    "trigger_type": trigger_type,
+                    "trigger_id": trigger_id,
+                    "user_id": str(user_id),
+                }),
+                ex=PENDING_TTL,
+            )
+            logger.info(f"Pipeline {label}: run in progress ({active}), coalesced this fire")
+            return {"run_id": run_id, "status": "skipped", "output": None,
+                    "error": None, "steps": [], "duration_ms": 0}
+
+    started = _now()
+    t0 = time.monotonic()
+    cursor_before = await _read_cursor(pipeline, user_id)
+
+    # Create the run record up front (it doubles as the dead-letter record).
+    async with AsyncSessionLocal() as db:
+        db.add(PipelineRun(
+            pipeline_id=pipeline.id,
+            run_id=run_id,
+            user_id=user_id,
+            trigger_type=TriggerType(trigger_type),
+            trigger_id=trigger_id,
+            status="running",
+            input=run_input,
+            steps=[],
+            cursor_before=cursor_before,
+            started_at=started,
+        ))
+        await db.commit()
+
+    context: dict[str, Any] = {
+        "input": run_input or {},
+        "steps": {},
+        "cursor": cursor_before,
+        "run": {
+            "id": run_id,
+            "triggerType": trigger_type,
+            "firedAt": started.isoformat(),
+            "userId": str(user_id),
+        },
+    }
+    step_summaries: list[dict[str, Any]] = []
+    status = "failed"
+    error: Optional[str] = None
+    output: Any = None
+    new_cursor: Optional[str] = None
+
+    try:
+        # Validate run input against the pipeline's input schema.
+        if pipeline.input_schema and pipeline.input_schema.get("properties"):
+            try:
+                jsonschema.validate(instance=run_input or {}, schema=pipeline.input_schema)
+            except jsonschema.ValidationError as e:
+                raise StepError(f"Run input validation failed: {e.message}")
+
+        cursor_step_name = None
+        cursor_path = None
+
+        for step in pipeline.steps:
+            name = step["name"]
+            step_type = step["type"]
+            summary: dict[str, Any] = {
+                "name": name, "type": step_type, "status": "running",
+                "startedAt": _now().isoformat(),
+            }
+            step_summaries.append(summary)
+            step_t0 = time.monotonic()
+
+            # Resolve input (mapping failure must fail the run BEFORE dispatch).
+            try:
+                step_input = pm.resolve_field(step, "input", context, default={})
+                if step_type == "agent" and "message.$" in step:
+                    # Pre-resolve message.$ so the executor sees the final string.
+                    step = {**step, "message": pm.evaluate_expression(step["message.$"], context)}
+            except Exception as e:
+                raise StepError(f"Step '{name}': input mapping failed: {e}")
+
+            # Cursor injection
+            cursor_cfg = step.get("cursor")
+            if cursor_cfg:
+                cursor_step_name = name
+                cursor_path = cursor_cfg["path"]
+                param = cursor_cfg["param"]
+                if isinstance(step_input, dict) and param not in step_input:
+                    value = context["cursor"]
+                    if value is None:
+                        if "initial.$" in cursor_cfg:
+                            value = pm.evaluate_expression(cursor_cfg["initial.$"], context)
+                        elif "initial" in cursor_cfg:
+                            value = cursor_cfg["initial"]
+                    if value is not None:
+                        step_input[param] = value
+
+            retry_cfg = step.get("retry") or {}
+            max_attempts = retry_cfg.get("maxAttempts", 1)
+            if step_type == "agent":
+                max_attempts = 1  # agent steps are never retried by the runner (v1)
+            backoff = retry_cfg.get("backoff", "none")
+
+            result: Any = None
+            last_err: Optional[Exception] = None
+            for attempt in range(max_attempts):
+                try:
+                    if step_type == "connector":
+                        result = await _execute_connector_step(
+                            step, step_input, user_id=user_id, user_token=user_token
+                        )
+                    elif step_type == "function":
+                        result = await _execute_function_step(
+                            step, step_input, user_id=user_id, run_id=run_id,
+                            depth=exec_depth, summary=summary,
+                        )
+                    elif step_type == "query":
+                        result = await _execute_query_step(step, step_input, user_id=user_id)
+                    elif step_type == "agent":
+                        result = await _execute_agent_step(
+                            step, step_input, user_id=user_id, user_token=user_token,
+                            run_id=run_id, agent_depth=agent_depth,
+                            pipeline_label=label, summary=summary,
+                        )
+                    elif step_type == "load":
+                        result = await _execute_load_step(
+                            step, context=context, user_id=user_id,
+                            per_user=bool(pipeline.per_user),
+                        )
+                    else:  # unreachable post-validation
+                        raise StepError(f"Unknown step type '{step_type}'")
+                    last_err = None
+                    break
+                except StepError as e:
+                    last_err = e
+                    if attempt < max_attempts - 1:
+                        delay = _backoff_delay(attempt, backoff)
+                        logger.warning(
+                            f"Pipeline {label} step '{name}' attempt {attempt + 1}/{max_attempts} "
+                            f"failed: {e}; retrying in {delay:.1f}s"
+                        )
+                        if delay > 0:
+                            await asyncio.sleep(delay)
+
+            summary["durationMs"] = round((time.monotonic() - step_t0) * 1000)
+            if last_err is not None:
+                summary["status"] = "failed"
+                summary["error"] = str(last_err)[:2000]
+                raise StepError(f"Step '{name}': {last_err}")
+
+            summary["status"] = "succeeded"
+            context["steps"][name] = {"output": result}
+
+            # Candidate cursor: read right after the cursor step succeeds.
+            if cursor_cfg and cursor_path:
+                candidate = pm.evaluate_expression(cursor_path, {**context, "steps": context["steps"]})
+                if candidate is not None:
+                    new_cursor = str(candidate)
+                # None → leave the bookmark unchanged (never regress on "no data").
+
+        # Final output
+        if pipeline.output_mapping:
+            output = pm.resolve_field(pipeline.output_mapping, "output", context)
+        elif pipeline.steps:
+            last_name = pipeline.steps[-1]["name"]
+            output = context["steps"].get(last_name, {}).get("output")
+
+        status = "succeeded"
+
+    except StepError as e:
+        error = str(e)
+        logger.error(f"Pipeline {label} run {run_id} failed: {error}")
+    except asyncio.CancelledError:
+        # Sync caller's wait_for timed out (or the job was cancelled).
+        status = "timed_out"
+        running = [s["name"] for s in step_summaries if s.get("status") == "running"]
+        error = (
+            f"Run timed out after {pipeline.sync_timeout_seconds}s"
+            + (f" while executing step '{running[0]}'" if running else "")
+            + f". Completed steps had side effects; see run {run_id}."
+        )
+        for s in step_summaries:
+            if s.get("status") == "running":
+                s["status"] = "timed_out"
+        await _persist_outcome(
+            pipeline, user_id, run_id, status, error, None, step_summaries,
+            new_cursor=None, t0=t0, use_lock=use_lock, lock_key=lock_key, redis=redis,
+        )
+        raise
+    except Exception as e:  # defensive: mapping/DB bugs must still finalize the run
+        error = f"Internal pipeline error: {e}"
+        logger.exception(f"Pipeline {label} run {run_id} internal error")
+
+    duration_ms = await _persist_outcome(
+        pipeline, user_id, run_id, status, error, output, step_summaries,
+        new_cursor=new_cursor if status == "succeeded" else None,
+        t0=t0, use_lock=use_lock, lock_key=lock_key, redis=redis,
+    )
+
+    return {
+        "run_id": run_id,
+        "status": status,
+        "output": output if status == "succeeded" else None,
+        "error": error,
+        "steps": step_summaries,
+        "duration_ms": duration_ms,
+    }
+
+
+async def _persist_outcome(
+    pipeline: Pipeline,
+    user_id: str,
+    run_id: str,
+    status: str,
+    error: Optional[str],
+    output: Any,
+    step_summaries: list[dict[str, Any]],
+    *,
+    new_cursor: Optional[str],
+    t0: float,
+    use_lock: bool,
+    lock_key: str,
+    redis,
+) -> int:
+    """Finalize the run record, commit/hold cursor state, release the lock, and
+    re-enqueue one coalesced fire if any arrived while we ran."""
+    duration_ms = round((time.monotonic() - t0) * 1000)
+    try:
+        if status == "succeeded":
+            await _finalize_success(pipeline, user_id, new_cursor)
+        else:
+            await _finalize_failure(pipeline, user_id, error or status)
+
+        async with AsyncSessionLocal() as db:
+            await db.execute(
+                update(PipelineRun)
+                .where(PipelineRun.run_id == run_id)
+                .values(
+                    status=status,
+                    error=error,
+                    steps=step_summaries,
+                    cursor_after=new_cursor,
+                    completed_at=_now(),
+                    duration_ms=duration_ms,
+                )
+            )
+            await db.commit()
+    finally:
+        if use_lock:
+            try:
+                await redis.eval(_RELEASE_LUA, 1, lock_key, run_id)
+                pending_key = _pending_key(pipeline, user_id)
+                pending = await redis.get(pending_key)
+                if pending:
+                    await redis.delete(pending_key)
+                    data = json.loads(pending)
+                    from app.services.queue_service import queue_service
+
+                    await queue_service.enqueue_pipeline_run(
+                        pipeline_id=str(pipeline.id),
+                        run_input=data.get("input"),
+                        trigger_type=data.get("trigger_type", TriggerType.API.value),
+                        trigger_id=data.get("trigger_id"),
+                        user_id=data.get("user_id", str(user_id)),
+                    )
+                    logger.info(
+                        f"Pipeline {pipeline.namespace}/{pipeline.name}: re-enqueued coalesced fire"
+                    )
+            except Exception:
+                logger.exception("Pipeline lock release/coalesce failed")
+    return duration_ms
+
+
+# ---------------------------------------------------------------------------
+# Fan-out ("fire"): expand a trigger firing into per-user runs.
+# ---------------------------------------------------------------------------
+
+
+async def enumerate_connected_users(db, pipeline: Pipeline) -> list[str]:
+    """Users connected to the perUser source connector, minus skip-listed ones.
+
+    Enumeration depends on the connector's auth type:
+    - oauth2_authorization_code → users with a connector_oauth_tokens row;
+    - secret-based auth → users holding a PRIVATE Secret named auth.secret;
+    - none/sinas_token → rejected at validation, empty here.
+    """
+    from app.models.connector_oauth_token import ConnectorOAuthToken
+    from app.models.secret import Secret
+
+    per_user = pipeline.per_user or {}
+    ref = per_user.get("connector", "")
+    if "/" not in ref:
+        return []
+    namespace, name = _split_ref(ref)
+    connector = await Connector.get_by_name(db, namespace, name)
+    if not connector:
+        logger.warning(f"perUser connector '{ref}' not found for pipeline {pipeline.namespace}/{pipeline.name}")
+        return []
+
+    auth_type = (connector.auth or {}).get("type", "none")
+    if auth_type == "oauth2_authorization_code":
+        rows = await db.execute(
+            select(ConnectorOAuthToken.user_id).where(
+                ConnectorOAuthToken.connector_id == connector.id
+            )
+        )
+        user_ids = [str(r[0]) for r in rows.all()]
+    elif auth_type in ("bearer", "basic", "api_key", "oauth2_client_credentials"):
+        secret_name = (connector.auth or {}).get("secret")
+        if not secret_name:
+            return []
+        rows = await db.execute(
+            select(Secret.user_id).where(
+                Secret.name == secret_name, Secret.visibility == "private"
+            )
+        )
+        user_ids = [str(r[0]) for r in rows.all() if r[0] is not None]
+    else:
+        return []
+
+    # Skip users past the per-user failure threshold (until they re-credential).
+    threshold = per_user.get("disableAfterFailures")
+    if threshold and user_ids:
+        rows = await db.execute(
+            select(PipelineCursor.user_id).where(
+                PipelineCursor.pipeline_id == pipeline.id,
+                PipelineCursor.consecutive_failures >= threshold,
+            )
+        )
+        skipped = {str(r[0]) for r in rows.all()}
+        if skipped:
+            logger.info(
+                f"Pipeline {pipeline.namespace}/{pipeline.name}: skipping "
+                f"{len(skipped & set(user_ids))} user(s) past failure threshold"
+            )
+            user_ids = [u for u in user_ids if u not in skipped]
+
+    return user_ids
+
+
+async def fire_pipeline(
+    namespace: str,
+    name: str,
+    run_input: Optional[dict[str, Any]],
+    *,
+    trigger_type: str,
+    trigger_id: Optional[str],
+) -> list[str]:
+    """Expand a trigger firing into queued run(s). Returns enqueued run job ids.
+
+    Shared pipelines → one run as the pipeline owner. perUser pipelines → one
+    run per connected user, each executing as that user (the run job mints the
+    user's JWT worker-side, so tokens never sit in Redis job payloads).
+    """
+    from app.services.queue_service import queue_service
+
+    async with AsyncSessionLocal() as db:
+        pipeline = await Pipeline.get_by_name(db, namespace, name)
+        if not pipeline or not pipeline.is_active:
+            logger.warning(f"fire_pipeline: '{namespace}/{name}' not found or inactive")
+            return []
+
+        if pipeline.per_user:
+            user_ids = await enumerate_connected_users(db, pipeline)
+        else:
+            user_ids = [str(pipeline.user_id)]
+
+        job_ids = []
+        for uid in user_ids:
+            job_id = await queue_service.enqueue_pipeline_run(
+                pipeline_id=str(pipeline.id),
+                run_input=run_input,
+                trigger_type=trigger_type,
+                trigger_id=trigger_id,
+                user_id=uid,
+            )
+            job_ids.append(job_id)
+
+    logger.info(f"Pipeline {namespace}/{name}: fired {len(job_ids)} run(s) ({trigger_type})")
+    return job_ids
+
+
+async def mint_run_token(user_id: str) -> Optional[str]:
+    """Mint a short-lived JWT for the run's user (scheduler/webhook pattern)."""
+    from app.core.auth import create_access_token
+
+    async with AsyncSessionLocal() as db:
+        user = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if not user:
+            return None
+        return create_access_token(user_id=str(user.id), email=user.email)

--- a/backend/app/services/pipeline_tools.py
+++ b/backend/app/services/pipeline_tools.py
@@ -1,0 +1,149 @@
+"""Pipeline-to-tool converter — exposes asTool pipelines as agent tools.
+
+A tool-invoked pipeline runs inline (the interactive chat path) under the
+pipeline's syncTimeoutSeconds budget, executing as the chat's user. Agent steps
+inside it are delegation-depth-checked so agent→pipeline→agent chains stay
+bounded (issue #90 protections apply unchanged).
+"""
+import asyncio
+import logging
+from typing import Any, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_user_permissions
+from app.core.permissions import check_permission
+from app.models.execution import TriggerType
+from app.models.pipeline import Pipeline
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_TOOL_PREFIX = "pipeline_"
+
+
+class PipelineToolConverter:
+    """Converts asTool pipelines to OpenAI-format tools and executes them."""
+
+    async def get_available_pipelines(
+        self,
+        db: AsyncSession,
+        user_id: str,
+        enabled_pipelines: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Build tool definitions for enabled asTool pipelines."""
+        if not enabled_pipelines:
+            return []
+
+        from app.services.resource_resolver import resolve_resource_refs
+
+        resolved = await resolve_resource_refs(db, enabled_pipelines, Pipeline)
+
+        tools = []
+        for ref, pipeline in resolved:
+            if not pipeline.is_active:
+                continue
+            if not pipeline.as_tool:
+                logger.warning(f"Pipeline '{ref}' is enabled for an agent but has asTool=false; skipping")
+                continue
+
+            description = pipeline.tool_description or pipeline.description or f"Run pipeline {ref}"
+            tools.append({
+                "type": "function",
+                "function": {
+                    "name": f"{PIPELINE_TOOL_PREFIX}{pipeline.namespace}__{pipeline.name}",
+                    "description": description,
+                    "parameters": pipeline.input_schema or {"type": "object", "properties": {}},
+                    "_metadata": {
+                        "type": "pipeline",
+                        "namespace": pipeline.namespace,
+                        "name": pipeline.name,
+                    },
+                },
+            })
+        return tools
+
+    async def execute_pipeline_tool(
+        self,
+        db: AsyncSession,
+        tool_name: str,
+        arguments: dict[str, Any],
+        user_id: str,
+        user_token: str,
+        enabled_pipelines: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Execute a pipeline tool call inline (sync mode)."""
+        from app.services import pipeline_runner
+        from app.services.pipeline_runner import PipelineBusyError
+
+        if not tool_name.startswith(PIPELINE_TOOL_PREFIX):
+            return {"error": f"Invalid pipeline tool name: {tool_name}"}
+        parts = tool_name[len(PIPELINE_TOOL_PREFIX):].split("__", 1)
+        if len(parts) != 2:
+            return {"error": f"Invalid pipeline tool name: {tool_name}"}
+        namespace, name = parts
+        ref = f"{namespace}/{name}"
+
+        # SECURITY: validate against the agent's enabled list (supports wildcards)
+        from app.services.resource_resolver import matches_ref_pattern
+
+        if enabled_pipelines is not None and not matches_ref_pattern(ref, enabled_pipelines):
+            logger.warning(f"Security: LLM attempted to call non-enabled pipeline '{ref}'")
+            return {
+                "error": "Pipeline not enabled",
+                "message": f"Pipeline '{ref}' is not enabled for this agent.",
+            }
+
+        pipeline = await Pipeline.get_by_name(db, namespace, name)
+        if not pipeline or not pipeline.is_active or not pipeline.as_tool:
+            return {"error": f"Pipeline '{ref}' not found, inactive, or not exposed as a tool"}
+
+        user_permissions = await get_user_permissions(db, user_id)
+        if not check_permission(user_permissions, f"sinas.pipelines/{ref}.run:own"):
+            return {
+                "error": "Permission denied",
+                "message": f"You don't have permission to run pipeline '{ref}'.",
+            }
+
+        # Bound agent steps by the existing delegation-depth counter.
+        from app.services.delegation import child_depth_or_error
+
+        agent_depth, depth_error = child_depth_or_error()
+        if depth_error and any(s.get("type") == "agent" for s in (pipeline.steps or [])):
+            return {"error": depth_error}
+
+        try:
+            outcome = await asyncio.wait_for(
+                pipeline_runner.run_pipeline(
+                    str(pipeline.id),
+                    arguments or {},
+                    trigger_type=TriggerType.AGENT.value,
+                    trigger_id=f"tool:{user_id}",
+                    user_id=str(user_id),
+                    user_token=user_token,
+                    agent_depth=agent_depth,
+                    sync=True,
+                ),
+                timeout=pipeline.sync_timeout_seconds,
+            )
+        except PipelineBusyError as e:
+            return {
+                "error": "Pipeline busy",
+                "message": f"A run of '{ref}' is already in progress (run_id={e.active_run_id}). Try again shortly.",
+            }
+        except asyncio.TimeoutError:
+            return {
+                "error": "Pipeline timed out",
+                "message": (
+                    f"Pipeline '{ref}' exceeded its {pipeline.sync_timeout_seconds}s budget. "
+                    "Completed steps may have had side effects."
+                ),
+            }
+
+        if outcome["status"] == "succeeded":
+            return {"output": outcome["output"], "run_id": outcome["run_id"]}
+        return {
+            "error": f"Pipeline run {outcome['status']}",
+            "message": outcome.get("error"),
+            "run_id": outcome["run_id"],
+            "steps": outcome.get("steps", []),
+        }

--- a/backend/app/services/pipeline_validation.py
+++ b/backend/app/services/pipeline_validation.py
@@ -1,0 +1,221 @@
+"""Save-time validation for pipeline definitions.
+
+Shape-level rules only: step types/fields, mapping-expression compilation,
+cursor/perUser/asTool constraints. Cross-resource existence (does the connector
+operation / function / agent exist?) is deliberately NOT enforced here — config
+apply installs resources in order and references may not exist yet; missing
+targets fail at run time with a clear error, matching the rest of config apply.
+"""
+import re
+from typing import Any, Optional
+
+from app.services.pipeline_mapping import validate_expression, validate_template
+
+STEP_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+REF_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*/[a-zA-Z_][a-zA-Z0-9_-]*$")
+TABLE_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$")
+
+MAX_STEPS = 32
+
+STEP_TYPES = ("connector", "function", "agent", "query", "load")
+
+# Allowed keys per step type. `input` / `message` / `items` / `primaryKey` also
+# accept their `.$` expression variant.
+_COMMON_KEYS = {"name", "type", "input", "input.$", "retry"}
+_ALLOWED_KEYS: dict[str, set[str]] = {
+    "connector": _COMMON_KEYS | {"connector", "operation", "cursor", "allowStatuses", "paginate"},
+    "function": _COMMON_KEYS | {"function", "cursor"},
+    "agent": _COMMON_KEYS | {"agent", "message", "message.$"},
+    "query": _COMMON_KEYS | {"query"},
+    "load": {"name", "type", "retry", "connection", "table", "primaryKey.$", "items.$"},
+}
+
+_BACKOFFS = ("none", "linear", "exponential")
+
+
+def _validate_retry(retry: Any, where: str) -> list[str]:
+    if not isinstance(retry, dict):
+        return [f"{where}: retry must be an object"]
+    errors = []
+    unknown = set(retry) - {"maxAttempts", "backoff"}
+    if unknown:
+        errors.append(f"{where}: unknown retry keys: {sorted(unknown)}")
+    attempts = retry.get("maxAttempts", 1)
+    if not isinstance(attempts, int) or not (1 <= attempts <= 10):
+        errors.append(f"{where}: retry.maxAttempts must be an integer 1–10")
+    if retry.get("backoff", "none") not in _BACKOFFS:
+        errors.append(f"{where}: retry.backoff must be one of {_BACKOFFS}")
+    return errors
+
+
+def _validate_cursor(cursor: Any, where: str) -> list[str]:
+    if not isinstance(cursor, dict):
+        return [f"{where}: cursor must be an object"]
+    errors = []
+    unknown = set(cursor) - {"param", "path", "initial", "initial.$"}
+    if unknown:
+        errors.append(f"{where}: unknown cursor keys: {sorted(unknown)}")
+    if not isinstance(cursor.get("param"), str) or not cursor.get("param"):
+        errors.append(f"{where}: cursor.param is required (string)")
+    if not isinstance(cursor.get("path"), str) or not cursor.get("path"):
+        errors.append(f"{where}: cursor.path is required (JMESPath expression)")
+    else:
+        errors.extend(validate_expression(cursor["path"], f"{where}.cursor.path"))
+    if "initial" in cursor and "initial.$" in cursor:
+        errors.append(f"{where}: cursor has both 'initial' and 'initial.$'")
+    if "initial.$" in cursor:
+        errors.extend(validate_expression(cursor["initial.$"], f"{where}.cursor.initial.$"))
+    return errors
+
+
+def _validate_step(step: Any, index: int) -> list[str]:
+    where = f"steps[{index}]"
+    if not isinstance(step, dict):
+        return [f"{where}: step must be an object"]
+    errors: list[str] = []
+
+    name = step.get("name")
+    if not isinstance(name, str) or not STEP_NAME_RE.match(name or ""):
+        errors.append(f"{where}: invalid or missing step name")
+    else:
+        where = f"steps[{index}] ({name})"
+
+    step_type = step.get("type")
+    if step_type not in STEP_TYPES:
+        errors.append(f"{where}: type must be one of {STEP_TYPES}")
+        return errors
+
+    unknown = set(step) - _ALLOWED_KEYS[step_type]
+    if unknown:
+        errors.append(f"{where}: unknown keys for type '{step_type}': {sorted(unknown)}")
+
+    # Resource reference per type
+    ref_field = {"connector": "connector", "function": "function", "agent": "agent", "query": "query"}.get(step_type)
+    if ref_field:
+        ref = step.get(ref_field)
+        if not isinstance(ref, str) or not REF_RE.match(ref or ""):
+            errors.append(f"{where}: '{ref_field}' must be a 'namespace/name' reference")
+
+    if step_type == "connector" and (not isinstance(step.get("operation"), str) or not step.get("operation")):
+        errors.append(f"{where}: 'operation' is required")
+
+    if step_type == "connector" and "allowStatuses" in step:
+        statuses = step["allowStatuses"]
+        if not isinstance(statuses, list) or not all(isinstance(s, int) for s in statuses):
+            errors.append(f"{where}: allowStatuses must be a list of integers")
+
+    if step_type == "connector" and "paginate" in step:
+        # Reserved for v1.1; reject now rather than silently ignoring.
+        errors.append(f"{where}: 'paginate' is not supported yet")
+
+    if step_type == "load":
+        if not isinstance(step.get("connection"), str) or not step.get("connection"):
+            errors.append(f"{where}: 'connection' is required")
+        table = step.get("table")
+        if not isinstance(table, str) or not TABLE_RE.match(table or ""):
+            errors.append(f"{where}: 'table' must be a (schema-qualified) identifier")
+        if not isinstance(step.get("primaryKey.$"), str):
+            errors.append(f"{where}: 'primaryKey.$' is required (JMESPath over each item)")
+        else:
+            errors.extend(validate_expression(step["primaryKey.$"], f"{where}.primaryKey.$"))
+        if not isinstance(step.get("items.$"), str):
+            errors.append(f"{where}: 'items.$' is required (JMESPath expression)")
+        else:
+            errors.extend(validate_expression(step["items.$"], f"{where}.items.$"))
+
+    # Mapping fields
+    if "input" in step and "input.$" in step:
+        errors.append(f"{where}: step has both 'input' and 'input.$'")
+    if "input.$" in step:
+        errors.extend(validate_expression(step["input.$"], f"{where}.input.$"))
+    if "input" in step:
+        if not isinstance(step["input"], dict):
+            errors.append(f"{where}: 'input' must be an object (use 'input.$' for an expression)")
+        else:
+            errors.extend(validate_template(step["input"], f"{where}.input"))
+
+    if step_type == "agent":
+        if "message" in step and "message.$" in step:
+            errors.append(f"{where}: step has both 'message' and 'message.$'")
+        if "message.$" in step:
+            errors.extend(validate_expression(step["message.$"], f"{where}.message.$"))
+        if "message" in step and not isinstance(step["message"], str):
+            errors.append(f"{where}: 'message' must be a string")
+
+    if "cursor" in step:
+        errors.extend(_validate_cursor(step["cursor"], where))
+
+    if "retry" in step:
+        errors.extend(_validate_retry(step["retry"], where))
+
+    return errors
+
+
+def validate_pipeline_definition(
+    steps: Any,
+    *,
+    per_user: Optional[dict[str, Any]] = None,
+    as_tool: bool = False,
+    input_schema: Optional[dict[str, Any]] = None,
+    description: Optional[str] = None,
+    tool_description: Optional[str] = None,
+    concurrency: Optional[str] = None,
+    output_mapping: Optional[dict[str, Any]] = None,
+) -> list[str]:
+    """Validate a full pipeline definition. Returns a list of error strings."""
+    errors: list[str] = []
+
+    if not isinstance(steps, list) or not steps:
+        return ["steps must be a non-empty list"]
+    if len(steps) > MAX_STEPS:
+        errors.append(f"too many steps ({len(steps)} > {MAX_STEPS})")
+
+    names = [s.get("name") for s in steps if isinstance(s, dict)]
+    dupes = {n for n in names if n and names.count(n) > 1}
+    if dupes:
+        errors.append(f"duplicate step names: {sorted(dupes)}")
+
+    cursor_steps = [
+        s.get("name") for s in steps
+        if isinstance(s, dict) and s.get("cursor")
+    ]
+    if len(cursor_steps) > 1:
+        errors.append(f"at most one step may declare cursor config (found: {cursor_steps})")
+
+    for i, step in enumerate(steps):
+        errors.extend(_validate_step(step, i))
+
+    if per_user is not None:
+        if not isinstance(per_user, dict):
+            errors.append("perUser must be an object")
+        else:
+            unknown = set(per_user) - {"connector", "disableAfterFailures"}
+            if unknown:
+                errors.append(f"unknown perUser keys: {sorted(unknown)}")
+            ref = per_user.get("connector")
+            if not isinstance(ref, str) or not REF_RE.match(ref or ""):
+                errors.append("perUser.connector must be a 'namespace/name' reference")
+            daf = per_user.get("disableAfterFailures")
+            if daf is not None and (not isinstance(daf, int) or daf < 1):
+                errors.append("perUser.disableAfterFailures must be a positive integer")
+
+    if as_tool:
+        if not isinstance(input_schema, dict) or not input_schema.get("properties"):
+            errors.append("asTool pipelines require an inputSchema with properties")
+        if not (tool_description or description):
+            errors.append("asTool pipelines require a description (or toolDescription)")
+
+    if concurrency is not None and concurrency not in ("single", "parallel"):
+        errors.append("concurrency must be 'single' or 'parallel'")
+
+    if output_mapping is not None:
+        if not isinstance(output_mapping, dict) or set(output_mapping) - {"output", "output.$"}:
+            errors.append("output mapping must contain only 'output' or 'output.$'")
+        elif "output" in output_mapping and "output.$" in output_mapping:
+            errors.append("output mapping has both 'output' and 'output.$'")
+        elif "output.$" in output_mapping:
+            errors.extend(validate_expression(output_mapping["output.$"], "output.$"))
+        elif "output" in output_mapping:
+            errors.extend(validate_template(output_mapping["output"], "output"))
+
+    return errors

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -17,6 +17,8 @@ JOB_STATUS_PREFIX = "sinas:job:status:"
 AGENT_QUEUE = "sinas:queue:agents"
 # Dedicated queue for delegated (agent-to-agent) jobs — see issue #90.
 SUB_AGENT_QUEUE = "sinas:queue:agents:sub"
+# Pipeline runs — own queue so long runs never starve function workers.
+PIPELINE_QUEUE = "sinas:queue:pipelines"
 JOB_RESULT_PREFIX = "sinas:job:result:"
 JOB_DONE_CHANNEL_PREFIX = "sinas:job:done:"
 DLQ_KEY = "sinas:queue:dlq"
@@ -103,6 +105,62 @@ class QueueService:
             f"(execution_id={execution_id})"
         )
         return execution_id
+
+    async def enqueue_pipeline_run(
+        self,
+        pipeline_id: str,
+        run_input: Optional[dict[str, Any]],
+        trigger_type: str,
+        trigger_id: Optional[str],
+        user_id: str,
+    ) -> str:
+        """Enqueue one pipeline run for one user scope. Returns the job id.
+
+        The worker mints the run user's JWT itself — no tokens in job payloads.
+        """
+        pool = await get_arq_pool()
+        job_id = str(uuid.uuid4())
+        await pool.enqueue_job(
+            "execute_pipeline_run_job",
+            job_id=job_id,
+            pipeline_id=pipeline_id,
+            run_input=run_input,
+            trigger_type=trigger_type,
+            trigger_id=trigger_id,
+            user_id=user_id,
+            trace_context=inject_trace_context(),
+            _job_id=job_id,
+            _queue_name=PIPELINE_QUEUE,
+        )
+        logger.info(f"Enqueued pipeline run job {job_id} (pipeline={pipeline_id})")
+        return job_id
+
+    async def enqueue_pipeline_fire(
+        self,
+        namespace: str,
+        name: str,
+        run_input: Optional[dict[str, Any]],
+        trigger_type: str,
+        trigger_id: Optional[str],
+    ) -> str:
+        """Enqueue a pipeline *fire* (trigger firing). The fire job expands to one
+        run per user for perUser pipelines — triggers stay dumb."""
+        pool = await get_arq_pool()
+        job_id = str(uuid.uuid4())
+        await pool.enqueue_job(
+            "execute_pipeline_fire_job",
+            job_id=job_id,
+            namespace=namespace,
+            name=name,
+            run_input=run_input,
+            trigger_type=trigger_type,
+            trigger_id=trigger_id,
+            trace_context=inject_trace_context(),
+            _job_id=job_id,
+            _queue_name=PIPELINE_QUEUE,
+        )
+        logger.info(f"Enqueued pipeline fire job {job_id} ({namespace}/{name}, {trigger_type})")
+        return job_id
 
     async def get_job_status(self, job_id: str) -> Optional[dict[str, Any]]:
         """Get job status from Redis."""

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -129,6 +129,9 @@ def serialize_webhook(webhook) -> dict:
         "agentName": f"{webhook.agent_namespace}/{webhook.agent_name}"
         if target_type == "agent"
         else None,
+        "pipelineName": f"{webhook.pipeline_namespace or 'default'}/{webhook.pipeline_name}"
+        if target_type == "pipeline"
+        else None,
         "messageTemplate": webhook.message_template if target_type == "agent" else None,
         "sessionKeyTemplate": webhook.session_key_template if target_type == "agent" else None,
         "httpMethod": webhook.http_method,

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -140,6 +140,9 @@ def serialize_schedule(schedule) -> dict:
         "agentName": f"{schedule.target_namespace}/{schedule.target_name}"
         if schedule.schedule_type == "agent"
         else None,
+        "pipelineName": f"{schedule.target_namespace}/{schedule.target_name}"
+        if schedule.schedule_type == "pipeline"
+        else None,
         "content": schedule.content,
         "cronExpression": schedule.cron_expression,
         "isActive": schedule.is_active,
@@ -213,6 +216,7 @@ def serialize_agent(agent, provider_name: Optional[str] = None) -> dict:
         "enabledCollections": agent.enabled_collections or None,
         "enabledComponents": agent.enabled_components or None,
         "enabledConnectors": agent.enabled_connectors or None,
+        "enabledPipelines": agent.enabled_pipelines or None,
         "hooks": agent.hooks or None,
         "icon": agent.icon,
         "isDefault": agent.is_default if agent.is_default else None,
@@ -244,9 +248,41 @@ def serialize_database_trigger(trigger, connection_name: Optional[str] = None) -
         "schemaName": trigger.schema_name,
         "tableName": trigger.table_name,
         "operations": trigger.operations,
-        "functionName": f"{trigger.function_namespace}/{trigger.function_name}",
+        "targetType": trigger.target_type if trigger.target_type != "function" else None,
+        "functionName": f"{trigger.function_namespace}/{trigger.function_name}"
+        if trigger.function_name
+        else None,
+        "pipelineName": f"{trigger.pipeline_namespace or 'default'}/{trigger.pipeline_name}"
+        if trigger.pipeline_name
+        else None,
         "pollColumn": trigger.poll_column,
         "pollIntervalSeconds": trigger.poll_interval_seconds,
         "batchSize": trigger.batch_size,
         "isActive": trigger.is_active,
     })
+
+
+def serialize_pipeline(pipeline) -> dict:
+    """Export a pipeline. cursor_value / error_message / failure counters are
+    runtime state, not config — deliberately not exported. Steps/perUser are
+    stored verbatim (camelCase, `.$` keys intact) and pass straight through."""
+    out = {
+        "namespace": pipeline.namespace,
+        "name": pipeline.name,
+        "description": pipeline.description,
+        "inputSchema": pipeline.input_schema or None,
+        "steps": pipeline.steps,
+        "perUser": pipeline.per_user,
+        "asTool": pipeline.as_tool or None,
+        "toolDescription": pipeline.tool_description,
+        "syncTimeoutSeconds": pipeline.sync_timeout_seconds if pipeline.sync_timeout_seconds != 120 else None,
+        "concurrency": pipeline.concurrency,
+        "disableAfterFailures": pipeline.disable_after_failures,
+        "isActive": pipeline.is_active,
+    }
+    mapping = pipeline.output_mapping or {}
+    if "output.$" in mapping:
+        out["output.$"] = mapping["output.$"]
+    elif "output" in mapping:
+        out["output"] = mapping["output"]
+    return _remove_none_values(out)

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -145,6 +145,34 @@ async def _execute_scheduled_agent(
         )
 
 
+async def _execute_scheduled_pipeline(
+    job_id: str,
+    target_namespace: str,
+    target_name: str,
+    input_data: dict[str, Any],
+):
+    """Enqueue a pipeline fire for a scheduled run. The fire job expands perUser
+    pipelines to one run per connected user (see pipeline_runner.fire_pipeline)."""
+    from app.services.queue_service import queue_service
+
+    try:
+        logger.info(
+            f"Enqueuing scheduled pipeline: {target_namespace}/{target_name} (job: {job_id})"
+        )
+        await _update_job_last_run(job_id)
+        await queue_service.enqueue_pipeline_fire(
+            namespace=target_namespace,
+            name=target_name,
+            run_input=input_data or {},
+            trigger_type="SCHEDULE",
+            trigger_id=job_id,
+        )
+    except Exception as e:
+        logger.error(
+            f"Scheduled pipeline {target_namespace}/{target_name} enqueue failed: {e}"
+        )
+
+
 async def _update_job_last_run(job_id: str):
     """Update the last_run and next_run timestamps for a scheduled job."""
     async with AsyncSessionLocal() as db:
@@ -217,7 +245,23 @@ class FunctionScheduler:
         try:
             cron_params = self._parse_cron_expression(job.cron_expression)
 
-            if job.schedule_type == "agent":
+            if job.schedule_type == "pipeline":
+                self.scheduler.add_job(
+                    func=_execute_scheduled_pipeline,
+                    trigger="cron",
+                    args=[
+                        str(job.id),
+                        job.target_namespace,
+                        job.target_name,
+                        job.input_data,
+                    ],
+                    id=str(job.id),
+                    name=job.name,
+                    timezone=job.timezone,
+                    **cron_params,
+                    replace_existing=True,
+                )
+            elif job.schedule_type == "agent":
                 self.scheduler.add_job(
                     func=_execute_scheduled_agent,
                     trigger="cron",

--- a/backend/app/services/tool_discovery.py
+++ b/backend/app/services/tool_discovery.py
@@ -276,6 +276,16 @@ async def get_available_tools(
         )
         tools.extend(connector_tools)
 
+    # Get pipeline tools (only if list has items - opt-in)
+    enabled_pipelines = getattr(agent, "enabled_pipelines", None) or []
+    if enabled_pipelines:
+        from app.services.pipeline_tools import PipelineToolConverter
+
+        pipeline_tools = await PipelineToolConverter().get_available_pipelines(
+            db=db, user_id=user_id, enabled_pipelines=enabled_pipelines
+        )
+        tools.extend(pipeline_tools)
+
     # Add built-in retrieve_tool_result tool (always available).
     # The description is deliberately strict: agents (especially Claude) tend
     # to invent ids if the description is vague, then the result lookup

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -115,6 +115,8 @@ def tool_name_to_status_key(tool_name: str) -> str:
         return "skill:" + tool_name[len("get_skill_"):].replace("__", "/", 1)
     if tool_name.startswith("query_"):
         return "query:" + tool_name[len("query_"):].replace("__", "/", 1)
+    if tool_name.startswith("pipeline_"):
+        return "pipeline:" + tool_name[len("pipeline_"):].replace("__", "/", 1)
     if tool_name.startswith("search_collection_"):
         return "collection:" + tool_name[len("search_collection_"):].replace("__", "/", 1)
     if tool_name.startswith("get_file_"):
@@ -155,6 +157,9 @@ def build_tool_status(tool_name: str, arguments: dict, status_templates: dict[st
     if key.startswith("query:"):
         ref = key[6:]
         return f"Running query {ref.split('/')[-1].replace('_', ' ')}"
+    if key.startswith("pipeline:"):
+        ref = key[9:]
+        return f"Running pipeline {ref.split('/')[-1].replace('_', ' ')}"
     if key.startswith("collection:"):
         if tool_name.startswith("write_file_"):
             return "Writing file"
@@ -641,6 +646,28 @@ async def execute_single_tool(
                     metadata=tool_metadata,
                 )
                 logger.debug(f"Collection tool completed in {time.time() - start_time:.3f}s: {tool_name}")
+            elif tool_metadata.get("type") == "pipeline":
+                start_time = time.time()
+                from app.services.pipeline_tools import PipelineToolConverter
+
+                enabled_pipeline_list = []
+                if chat and chat.agent_id:
+                    result_agent = await db.execute(
+                        select(Agent).where(Agent.id == chat.agent_id)
+                    )
+                    chat_agent = result_agent.scalar_one_or_none()
+                    if chat_agent:
+                        enabled_pipeline_list = chat_agent.enabled_pipelines or []
+
+                result = await PipelineToolConverter().execute_pipeline_tool(
+                    db=db,
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    user_id=user_id,
+                    user_token=user_token,
+                    enabled_pipelines=enabled_pipeline_list,
+                )
+                logger.debug(f"Pipeline tool completed in {time.time() - start_time:.3f}s: {tool_name}")
             elif tool_metadata.get("type") == "connector":
                 start_time = time.time()
                 connector_tool_converter = ConnectorToolConverter()

--- a/backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md
+++ b/backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md
@@ -1,0 +1,467 @@
+# ADR: Pipelines — unified triggers + linear typed steps
+
+- **Status:** Proposed
+- **Date:** 2026-07-28
+- **Authors:** Kjeld Oostra (with Claude)
+- **Related code:**
+  - `backend/app/cdc/service.py` — reference implementation for the runner's ops model (dedicated process, per-resource loops, pub/sub config reload)
+  - `backend/app/queue/worker.py`, `backend/app/services/queue_service.py` — arq queues the pipeline job type plugs into
+  - `backend/app/services/scheduler.py`, `backend/app/models/schedule.py` — schedule trigger (already has generic `schedule_type`/target columns)
+  - `backend/app/models/webhook.py`, `backend/app/api/runtime/endpoints/webhooks.py` — webhook trigger (parallel branch adds `target_type` "agent" + raw mode; we add the third value)
+  - `backend/app/models/database_trigger.py` — CDC trigger
+  - `backend/app/services/connector_service.py`, `execution_engine.py`, `database_pool.py`, `message_service.py` — step executors
+  - `backend/app/services/tool_execution.py`, `tool_discovery.py` — pipelines-as-tools
+  - `backend/app/schemas/config.py`, `config_apply/`, `config_export.py`, `resource_serializers.py` — config round-trip
+
+## Context
+
+A recurring shape shows up across every planned integration (Gmail triage, Jira
+worklog sync, webhook→agent, CDC→function, airbyte-lite ELT):
+
+> poll or receive from a source → transform → optionally invoke an agent →
+> deterministically act on its output (upsert to a DB, call a connector op)
+
+Today each instance is hand-built: a function re-implements HTTP+auth, a schedule
+fires an agent that is *prompted* to call the right tools in the right order, cursor
+state is kept in ad-hoc store keys. Prompting an agent to chain tool calls is the
+least reliable link — taking the agent's **structured output** (agents already have
+`output_schema` + enforced JSON replies) and executing the follow-ups
+deterministically is strictly more dependable.
+
+This ADR introduces **`pipelines`**: a named, **linear** sequence of typed steps,
+fired by the existing trigger resources, with platform-managed cursor state and
+optional exposure as an agent tool.
+
+**Explicitly not a DAG.** No branching, fan-out, or joins in v1. A `function` step
+is the escape hatch for anything conditional or computational; the most we
+anticipate later is a per-step `when:` condition. Pipelines calling pipelines is
+also excluded in v1 (no recursion source beyond agents).
+
+This design **supersedes** the parked "declarative input/output transforms on
+connector operations" + "runtime connector-execute API" brief (2026-07-27); see
+Future work for what was parked and the narrow forms in which those could return.
+
+## Resource schema
+
+YAML/API is camelCase; DB/Python snake_case, per repo convention.
+
+```yaml
+pipelines:
+  - namespace: gmail
+    name: inbox-triage
+    description: Poll Gmail history and triage new messages
+    inputSchema:            # validates run input (trigger payload / tool args / manual run)
+      type: object
+      properties: {}
+    steps:
+      - name: fetch
+        type: connector
+        connector: google/gmail
+        operation: list-history
+        input:
+          userId: me
+          startHistoryId.$: cursor      # JMESPath — see Mapping
+        cursor:
+          param: startHistoryId          # where the cursor value is injected
+          path: body.historyId           # where the new high-water mark is read
+        retry: { maxAttempts: 3, backoff: exponential }
+
+      - name: extract
+        type: function
+        function: gmail/extract-messages
+        input.$: steps.fetch.output.body
+
+      - name: triage
+        type: agent
+        agent: gmail/triage
+        input.$: steps.extract.output    # mapped to the agent's inputSchema
+        # message: optional; defaults to the JSON-serialized step input
+
+      - name: act
+        type: connector
+        connector: google/gmail
+        operation: modify-message
+        input:
+          id.$: steps.triage.output.messageId
+          addLabelIds.$: steps.triage.output.labels
+
+    # Optional: expose as ONE semantic agent tool
+    asTool: false
+    toolDescription: null      # defaults to description
+    syncTimeoutSeconds: 120    # budget for sync (tool / manual sync) runs
+    concurrency: single        # single | parallel; default single when any cursor
+                               # config present, else parallel
+    output.$: steps.act.output # optional final-output shaping; default = last step's output
+```
+
+### Step types
+
+| type | executes via | output |
+|---|---|---|
+| `connector` | `connector_service.execute_operation` in-process (auth incl. per-user OAuth, retries reused) | `{statusCode, body, elapsedMs}`; non-2xx = step failure by default (`allowStatuses: [404]` opts specific codes out) |
+| `function` | `queue_service.enqueue_and_wait` (existing runtime, depth-propagated) | function return value |
+| `agent` | fresh chat + agent queue (queued runs) / delegation-depth-checked enqueue (sync runs) — see Execution | parsed JSON reply validated against the agent's `outputSchema` (step failure if invalid); raw text when no schema |
+| `query` | `DatabasePoolManager.execute_query` in-process | `{rows, rowCount, affectedRows}` |
+| `load` | upsert sink, see below | `{upserted: n, table}` |
+
+Step names are unique per pipeline (`^[a-zA-Z_][a-zA-Z0-9_-]*$`); step count capped
+(32) as a footgun guard.
+
+### `load` — the upsert sink
+
+```yaml
+- name: land
+  type: load
+  connection: reporting          # DatabaseConnection name
+  table: jira_worklogs           # optionally schema-qualified
+  primaryKey.$: item.id          # evaluated per item
+  items.$: steps.extract.output.worklogs    # array (or single object)
+```
+
+v1 lands **raw JSONB** — no schema evolution, no column mapping. The table is
+auto-created on first run if missing:
+
+```sql
+CREATE TABLE IF NOT EXISTS "<table>" (
+  pk         text PRIMARY KEY,
+  payload    jsonb NOT NULL,
+  synced_at  timestamptz NOT NULL DEFAULT now()
+);
+INSERT ... ON CONFLICT (pk) DO UPDATE SET payload = EXCLUDED.payload, synced_at = now();
+```
+
+All items in one run are upserted in a single transaction (all-or-nothing), so a
+failed run holds the cursor and safely replays. `primaryKey` is evaluated per item
+with the item bound as `item`; a null/missing pk fails the step (never silently
+drop rows). Typed columns / schema evolution is explicitly future work.
+
+## Data mapping — JMESPath, AWS States-style keys
+
+One mapping convention everywhere (step `input`, `cursor.path`, `primaryKey`,
+`items`, pipeline `output`). We adopt **JMESPath** (battle-tested, safe — no code
+execution, handles projections and simple aggregations) with the AWS States
+Language key convention, rather than inventing an expression language:
+
+- `key: value` — literal, passed through (recursively for objects/arrays).
+- `key.$: "<jmespath>"` — evaluated against the run context; result bound to `key`.
+- A step's whole input may be an expression: `input.$: steps.fetch.output.body`.
+
+The run context document:
+
+```json
+{
+  "input":  { },                  // pipeline run input (trigger payload / tool args / run body)
+  "steps":  { "<name>": { "output": ... } },   // completed steps only
+  "cursor": "...",                // current committed cursor value, or null
+  "run":    { "id": "...", "triggerType": "SCHEDULE", "firedAt": "..." }
+}
+```
+
+An expression that references a missing path yields `null` (JMESPath semantics); a
+syntactically invalid expression is rejected at save/config-apply time (compiled
+once at validation). Anything beyond projection/selection belongs in a `function`
+step (embeddings, MIME building, format conversion, heavy aggregation) — the
+mapping layer is deliberately not a computation layer.
+
+New dependency: `jmespath` (pure-Python, no transitive deps).
+
+## Triggers stay separate resources
+
+No trigger config inside the pipeline. The three trigger resources each gain
+`pipeline` as a target, which buys: one pipeline reusable across triggers, a manual
+run API for testing/backfills, and a uniform "trigger payload = pipeline input"
+rule.
+
+- **Webhooks** — composes with the in-flight "agent targets + raw response mode"
+  branch (`claude/sharp-poincare-b5bb8a`): `target_type` becomes
+  `Literal["function", "agent", "pipeline"]` (column is already `String(10)`;
+  "pipeline" is 8 chars). New nullable `pipeline_namespace`/`pipeline_name`
+  columns, mirroring that branch's agent columns exactly, with the analogous
+  `model_validator` arm (`pipeline_name` required; `message_template` n/a; `raw`
+  response mode stays function-only). Request body+headers+query defaults become
+  the pipeline input. `sync` waits for the run result; `async` returns
+  `202 {run_id}`. Our migration lands **after** and `Revises:` that branch's
+  `w2a3b4t5g6t7` — coordinate merge order, do not fork the enum.
+- **Schedules** — `schedule_type` (String(20)) gains `"pipeline"`;
+  `target_namespace`/`target_name`/`input_data` are already generic. No migration
+  needed beyond validation. "Poll Gmail every 2 min" = schedule → pipeline whose
+  first step declares cursor config.
+- **Database triggers (CDC)** — `target_type` column (default `"function"`) +
+  nullable `pipeline_namespace`/`pipeline_name`, same pattern. The CDC service
+  enqueues a pipeline run with the rows payload as input instead of a function
+  execution. Note the semantic difference: CDC advances its *own* bookmark at
+  enqueue time (at-most-once w.r.t. downstream success, unchanged); a pipeline's
+  *own* cursor commits only on run success (at-least-once). Both are documented;
+  CDC-triggered pipelines usually don't also declare cursor config.
+
+Trigger-side permission checks follow the webhook-branch precedent: the pipeline
+target requires `sinas.pipelines/{ns}/{name}.run:own|:all` for the webhook's owner
+model, and schedules/CDC run as the resource owner as today.
+
+## Execution model — one runner, two entry points
+
+The highest-risk requirement is that tool-invoked pipelines sit in the interactive
+chat path while trigger-fired runs go through workers. We do **not** build two
+execution engines. There is one async runner:
+
+```python
+async def run_pipeline(pipeline, input, *, trigger_type, trigger_id,
+                       user_id, user_token, depth) -> PipelineRunResult
+```
+
+in a new `backend/app/services/pipeline_runner.py`, and two entry points:
+
+1. **Queued** — a new arq job `execute_pipeline_job` on its own queue
+   (`sinas:queue:pipelines`, new `PipelineWorkerSettings`, its own process in
+   docker-compose like the CDC service). Runs are await-heavy (they mostly wait on
+   child executions and HTTP), so this worker gets high concurrency (default 50)
+   and long job timeout. A dedicated queue means long pipeline runs can never
+   starve function workers, and vice versa.
+2. **Inline (sync)** — the runner is awaited directly with
+   `asyncio.wait_for(..., timeout=pipeline.sync_timeout_seconds)`:
+   - from the agent tool path (`pipeline_tools.py` converter, `_metadata.type ==
+     "pipeline"`, dispatched from `tool_execution.execute_single_tool` like the
+     other converters), and
+   - from `POST /pipelines/{ns}/{name}/run` with `mode: sync`, and
+   - from sync webhook responses.
+
+### Step execution details
+
+- **connector / query / load** — direct in-process calls; milliseconds of overhead.
+  No new HTTP surface needed (this is what removes the need for the parked
+  connector-execute API in the common case). Connector steps reuse retry config
+  from the step (falling back to the connector's own `retry`).
+- **function** — `enqueue_and_wait` with `depth` threaded through, so a pipeline
+  triggered from inside a function execution (or whose function step nests
+  further) is bounded by `MAX_EXECUTION_DEPTH` and admission control (PR #81
+  guarantees hold).
+- **agent** — a fresh chat per run (scheduler pattern; `title="pipeline:{ns}/{name} — {ts}"`,
+  no session continuity in v1), then `enqueue_agent_message` + wait on the
+  stream-relay channel — the same machinery as `execute_agent_tool`. For
+  tool-invoked (sync) pipelines the enqueue is preceded by
+  `delegation.child_depth_or_error()` so agent→pipeline→agent chains count against
+  the existing delegation-depth limit and land on the sub-agent queue (issue #90
+  starvation protections apply unchanged). The reply must parse as JSON valid
+  against the agent's `output_schema` when one is set — parse/validation failure is
+  a step failure (no silent passthrough); without a schema the raw text is the
+  step output.
+
+### Sync-mode risk assessment (scrutinized as required)
+
+| Concern | Position |
+|---|---|
+| Slow agent step inside a tool-invoked pipeline | Allowed but bounded: the whole run is under `syncTimeoutSeconds` (default 120s, max 600). On timeout the tool call returns a clear error including the run id and which step was in flight. Docs + console will state plainly: agent steps in `asTool` pipelines cost seconds-to-minutes; prefer connector/query/function steps there. |
+| Timeout ≠ rollback | Steps already executed have had side effects. The run record marks the timed-out step; the error message says "steps up to N completed". Same honesty rule as everywhere else — never mask partial execution. |
+| Worker-slot pressure | A sync pipeline holds its caller's slot (agent worker for tool calls, request handler for API/webhook) exactly as a chained sequence of individual tool calls would today — pipelines replace those chains roughly 1:1, so net pressure does not increase. Child agent steps go through the sub-agent queue; child function steps through depth-checked admission. |
+| Recursion | No pipeline step type "pipeline"; agents are the only re-entry, and they are depth-bounded via the existing delegation counter. |
+| Latency floor | connector/query/load steps are in-process (ms). A function step adds one queue round-trip (tens of ms warm, `shared_pool` recommended for mapping-adjacent functions). An `asTool` pipeline of connector+query steps is comfortably interactive. |
+
+## Cursor state ("reversed CDC")
+
+Any step may declare `cursor: {param, path, initial?}`; in practice it's step 1.
+Semantics:
+
+- Before the step runs, the committed cursor value is available as `cursor` in the
+  context and injected as `input[param]` (unless the mapping already set it). On
+  the very first run, `initial` (literal or `.$` expression over `{input}`) is
+  used; absent that, the param is omitted (APIs like Gmail then return
+  "everything", and bootstrap functions can handle it).
+- The step's *candidate* new cursor is read from its output at `path` immediately
+  after the step succeeds, but it is **committed only when the whole run
+  completes successfully** — one `UPDATE pipelines SET cursor_value = ...` in the
+  run-finalization transaction alongside the run record.
+- Failed/timed-out runs hold the cursor → the next firing re-reads from the same
+  high-water mark → **at-least-once** delivery. This is safe because `load` steps
+  are idempotent upserts, and agent steps are documented as at-least-once
+  (duplicate triage of the same email on retry is acceptable; exactly-once via
+  dedup keys is future work).
+- If `path` yields null on a successful run (e.g. empty poll), the cursor is left
+  unchanged — never regress or clear a bookmark on "no data".
+
+Cursor storage: `cursor_value TEXT` on the `pipelines` row (exactly like
+`DatabaseTrigger.last_poll_value` — one bookmark per pipeline). Multiple cursor
+steps per pipeline are rejected at validation in v1.
+
+Optional pagination on a cursor-bearing (or any connector/function) step is
+deferred to v1.1 unless trivially cheap during implementation:
+`paginate: {param, tokenPath.$, itemsPath.$, maxPages: 10}` — loop the step feeding
+`tokenPath` back into `param`, output `{items: [...concatenated], pages: n}`. The
+Gmail and Jira consumers can ship without it (batch sizes cover the poll interval).
+
+## Single-flight & overlap
+
+A slow run and the next trigger firing must not overlap (CDC gets this for free
+from its one-loop-per-trigger process model; queued pipeline runs do not). Design:
+
+- Per-pipeline Redis lock `sinas:pipeline:lock:{id}` acquired with `SET NX EX
+  <syncTimeout+margin>` at run start, held for the run, refreshed by the runner on
+  long runs, released in a `finally`.
+- `concurrency: single` (the default whenever cursor config is present): if the
+  lock is held, a queued firing sets a *coalesce flag*
+  (`sinas:pipeline:pending:{id}`) and exits; the lock holder checks the flag on
+  completion and immediately runs once more (with fresh trigger metadata). N
+  fires during a run collapse to one follow-up — correct for polling (the
+  follow-up reads from the committed cursor).
+- Sync/manual runs against a held lock return `409 {active_run_id}` rather than
+  queueing — an interactive caller should not silently wait behind a poll run.
+- `concurrency: parallel` (default for cursor-less pipelines): no lock; concurrent
+  tool invocations of e.g. an embed-search pipeline are naturally fine.
+- Stale locks self-heal via the EX TTL (a crashed worker's lock expires; the run
+  record is finalized as failed by the arq job's exception path, mirroring how the
+  shared-pool admission set self-heals).
+
+## Failure semantics
+
+- **Per-step retry**: `retry: {maxAttempts (1–10), backoff: none|linear|exponential}`,
+  same vocabulary as `ConnectorRetry`. Applies to connector/query/load/function
+  steps. Agent steps are **not** retried by the runner in v1 (side effects +
+  cost); their one-shot failure fails the run.
+- **Run failure**: first step to exhaust retries fails the run: status `failed`,
+  error + failing step recorded, cursor held, remaining steps skipped. There is no
+  `continueOnError` in v1 — a linear pipeline whose step N failed has nothing
+  sound to feed step N+1 (`when:` conditions are the future home for "optional"
+  steps).
+- **Dead-letter**: the `pipeline_runs` row *is* the dead letter — it stores the
+  full run input, per-step summaries, and the error, and is queryable/rerunnable
+  (`POST /pipelines/runs/{run_id}/replay` re-enqueues with the stored input;
+  replay of a cursor run is safe because the cursor never advanced).
+- **Persistent failure**: optional `disableAfterFailures: N` — after N
+  *consecutive* failed runs the pipeline is deactivated (`is_active = false`) with
+  `error_message` set (the `DatabaseTrigger.error_message` pattern), surfacing in
+  console/config export rather than silently burning quota forever. Default: off
+  (halt-and-hold-cursor only, cadence bounded by the trigger).
+
+## Observability
+
+New `pipeline_runs` table:
+
+```
+id, pipeline_id (FK), run_id (unique str), trigger_type (enum), trigger_id,
+status (running|succeeded|failed|timed_out), input (JSON),
+steps (JSON: [{name, type, status, startedAt, durationMs, executionId?, chatId?, error?}]),
+error, cursor_before, cursor_after, started_at, completed_at, duration_ms, user_id
+```
+
+Child executions link through the existing machinery: function/agent steps enqueue
+with `trigger_type=TriggerType.PIPELINE` (new enum value + migration) and
+`trigger_id=<run_id>`, so the existing executions UI/API shows them grouped per
+run; the run's `steps` array carries the `execution_id`/`chat_id` back-references.
+Connector/query/load steps (in-process, no Execution row) record their outcome in
+the `steps` summary only — acceptable for v1 and consistent with how connector
+tool calls are (not) recorded today. Runs API:
+
+```
+POST /pipelines/{ns}/{name}/run          {input?, mode: sync|async}
+GET  /pipelines/{ns}/{name}/runs         ?status=&limit=
+GET  /pipelines/runs/{run_id}
+POST /pipelines/runs/{run_id}/replay
+```
+
+Retention: `pipeline_runs` rows pruned by the same janitor cadence as executions
+(config `PIPELINE_RUN_RETENTION_DAYS`, default 30).
+
+## Pipelines as agent tools
+
+`asTool: true` requires a non-empty `inputSchema` and `description` (or
+`toolDescription`). Agents opt in via a new `enabledPipelines: ["ns/name", ...]`
+list (plain refs, wildcards supported via `resource_resolver`, same as
+`enabledQueries`). Tool name `pipeline_<ns>__<name>`; tool parameters = the
+pipeline's `inputSchema` verbatim (no derivation magic — that complexity died with
+the parked transforms design); `_metadata.type = "pipeline"`. Execution enforces
+`sinas.pipelines/{ns}/{name}.run:own` per the query-tool precedent.
+
+This absorbs the parked transforms use cases as whole semantic tools:
+- *semantic search*: embed(query_text) via function step → tsvector/vector query
+  step → shape rows via `output.$` — one tool call, small token surface.
+- *token-cheap reads*: get-issue connector step → flatten via `output.$`
+  (JMESPath projection alone often suffices — no function needed).
+
+## Resource plumbing (mechanical, follows existing patterns)
+
+- `pipelines` table: id, user_id, namespace, name (unique together), description,
+  input_schema, steps (JSON), as_tool, tool_description, sync_timeout_seconds,
+  concurrency, disable_after_failures, cursor_value, error_message, output
+  (JSON), is_active, managed_by/config_name/config_checksum, timestamps.
+  `PermissionMixin`; permission base `sinas.pipelines/{ns}/{name}` with actions
+  `create/read/update/delete/run`; default Users role: `read:own` + `run:own`
+  (creation/update stay admin-granted, matching queries' conservative default
+  rather than connectors' permissive one).
+- CRUD endpoints `backend/app/api/v1/endpoints/pipelines.py` (standard shape);
+  runtime endpoints for run/runs as above; config: `PipelineConfig` in
+  `schemas/config.py` (camelCase incl. `steps` passed through with `.$` keys
+  intact — they're data), `apply_pipelines` in config_apply (ordered after
+  connectors/functions/queries/agents so references usually exist; missing
+  references are a save-time warning, run-time error, same lazy philosophy as the
+  rest of config apply), `serialize_pipeline` for export (cursor_value and
+  error_message are runtime state — **not** exported), docs page
+  `docs-mint/build-resources/pipelines.mdx` + trigger-page updates.
+- Steps validation at save/apply: known `type`, unique names, JMESPath
+  compilation, one cursor max, `asTool ⇒ inputSchema`, cap 32 steps, per-type
+  required fields. Cross-resource reference existence is warned, not enforced
+  (install order).
+- Config reload for triggers: webhook/schedule paths already reload on CRUD; the
+  CDC process's pub/sub reload channel handles database-trigger changes; the
+  pipeline worker itself is stateless per job (config read at run start), so no
+  reload machinery is needed for pipelines themselves. Only cursor bootstrap
+  mutates the pipeline row outside CRUD.
+
+## Future work (recorded, deliberately not built)
+
+Parked from the superseded 2026-07-27 brief:
+
+1. **Connector-execute HTTP API for functions**
+   (`POST /connectors/{ns}/{name}/execute/{operation}` + SDK
+   `client.connectors.execute`) — still useful someday as the escape hatch for
+   custom-shaped connector interaction *inside one function*: pagination loops,
+   multipart upload, binary download (Drive uploads, Gmail attachments,
+   `gmail/send_email` convenience functions). Small and non-blocking. Sketch, for
+   when it's picked up: runtime-API placement (root router, next to
+   `/functions/.../execute`), permission spelling
+   `sinas.connectors/{ns}/{name}/{op}.execute:own` OR the 2-segment
+   connector-level fallback (the matcher compares path segments 1:1, so both
+   spellings must be checked), depth threaded via `_resolve_child_depth`, dispatch
+   reusing `connector_service.execute_operation` unchanged.
+2. **Per-operation transforms on connectors/queries** — superseded by
+   pipelines-as-tools. If per-op response bloat remains painful for ops agents
+   call *directly*, the revival is a lightweight declarative JMESPath
+   `outputFilter` on the operation — pure projection, no function execution — not
+   function transforms.
+3. **Embeddings API decision** (carried open question): embedding steps/functions
+   need an embeddings API; LLM providers are infrastructure-only today. Either a
+   platform embeddings endpoint for the function runtime (preferred eventually)
+   or per-function API-key secrets (works today). Pipelines are agnostic.
+
+Also future: `when:` per-step conditions, typed-column `load` with schema
+evolution, pagination config (if not landed in v1), session-continuity agent
+steps, dedup keys for effectively-once agent steps, pipeline-level `env`/constants
+block.
+
+## Open questions
+
+1. **Webhook branch coordination** — our webhook migration must `Revises:`
+   `w2a3b4t5g6t7` and the `target_type` Literal must be extended in one place;
+   if that branch's shape changes before merge, this ADR's webhook section
+   follows it, not vice versa.
+2. **Agent-step message** — default is the JSON-serialized mapped input; is an
+   optional `message` template (Jinja, matching webhook `message_template`)
+   wanted in v1, or is structured input + system prompt enough? Leaning: include
+   `message` as an optional literal/`.$` string, default JSON input.
+3. **Sync webhook + slow pipeline** — sync webhook responses inherit
+   `syncTimeoutSeconds`; providers with short webhook timeouts (Slack: 3s)
+   should use `async`. Document, or auto-force async when a pipeline contains an
+   agent step? Leaning: document only.
+
+## Verification plan
+
+- Unit: mapping resolution (literal/`.$`/whole-input/missing-path→null), step
+  input assembly, cursor inject/read/hold-on-failure/no-regress-on-null, retry
+  policy, single-flight lock + coalesce flag, run finalization (status, cursor
+  commit atomicity), agent-reply schema validation, `load` pk extraction +
+  transactional upsert, steps validation rules, config round-trip
+  (YAML→DB→export) with `.$` keys intact.
+- Integration (dev stack): schedule→pipeline Gmail-shaped poll with a stub
+  connector (cursor advances only on success), webhook→pipeline sync+async,
+  tool-invoked pipeline from a chat, replay of a failed run.
+- Latency: measure inline runner overhead for a 3-step connector/query pipeline
+  (target: <100ms added over the raw calls) and function-step queue round-trip;
+  record numbers in the PR.

--- a/backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md
+++ b/backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md
@@ -53,6 +53,9 @@ pipelines:
     inputSchema:            # validates run input (trigger payload / tool args / manual run)
       type: object
       properties: {}
+    perUser:                # optional: fan out one run per user connected to this
+      connector: google/gmail        # connector (oauth2_authorization_code)
+      disableAfterFailures: 5        # per-user skip-until-reconnect (optional)
     steps:
       - name: fetch
         type: connector
@@ -119,7 +122,7 @@ Step names are unique per pipeline (`^[a-zA-Z_][a-zA-Z0-9_-]*$`); step count cap
 ```
 
 v1 lands **raw JSONB** — no schema evolution, no column mapping. The table is
-auto-created on first run if missing:
+auto-created on first run if missing. Shared pipelines:
 
 ```sql
 CREATE TABLE IF NOT EXISTS "<table>" (
@@ -129,6 +132,25 @@ CREATE TABLE IF NOT EXISTS "<table>" (
 );
 INSERT ... ON CONFLICT (pk) DO UPDATE SET payload = EXCLUDED.payload, synced_at = now();
 ```
+
+`perUser` pipelines (see Per-user runs) write many users' data into one table, and
+source ids (Gmail message ids, Slack ts) are only unique *per account* — so rows
+carry the user they were synced for and the key is composite:
+
+```sql
+CREATE TABLE IF NOT EXISTS "<table>" (
+  user_id    uuid NOT NULL,
+  pk         text NOT NULL,
+  payload    jsonb NOT NULL,
+  synced_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, pk)
+);
+```
+
+with `user_id` = the run's user, injected implicitly (not mappable — attribution
+must not be spoofable from payload data). The conflict target matches the shape.
+Switching a pipeline between shared and perUser after the table exists is a
+validation error (shape mismatch), not a silent migration.
 
 All items in one run are upserted in a single transaction (all-or-nothing), so a
 failed run holds the cursor and safely replays. `primaryKey` is evaluated per item
@@ -152,8 +174,8 @@ The run context document:
 {
   "input":  { },                  // pipeline run input (trigger payload / tool args / run body)
   "steps":  { "<name>": { "output": ... } },   // completed steps only
-  "cursor": "...",                // current committed cursor value, or null
-  "run":    { "id": "...", "triggerType": "SCHEDULE", "firedAt": "..." }
+  "cursor": "...",                // committed cursor for this run's scope (see Per-user), or null
+  "run":    { "id": "...", "triggerType": "SCHEDULE", "firedAt": "...", "userId": "..." }
 }
 ```
 
@@ -256,6 +278,80 @@ in a new `backend/app/services/pipeline_runner.py`, and two entry points:
 | Recursion | No pipeline step type "pipeline"; agents are the only re-entry, and they are depth-bounded via the existing delegation counter. |
 | Latency floor | connector/query/load steps are in-process (ms). A function step adds one queue round-trip (tens of ms warm, `shared_pool` recommended for mapping-adjacent functions). An `asTool` pipeline of connector+query steps is comfortably interactive. |
 
+## Per-user runs (fan-out)
+
+The single-global-cursor model is wrong for any pipeline whose source connector
+authenticates per user: each connected user is an independent source with their
+own position in the stream. Motivating case: a personal cross-platform inbox —
+per-user ingestion of Gmail/Slack messages into one table, agents sort
+downstream.
+
+Per-user auth exists in two forms today, and both make a source per-user:
+
+1. `oauth2_authorization_code` — per-user tokens in `connector_oauth_tokens`
+   (PR #85).
+2. **Private secret overrides** — for `bearer`/`basic`/`api_key`/
+   `oauth2_client_credentials`, `_resolve_secret_value` resolves a private Secret
+   (visibility `private`, owned by the user) over the shared one of the same
+   name; the client-credentials token cache is keyed by `user_id` for exactly
+   this reason. Users who each store their own API key under the connector's
+   secret name are independent sources too.
+
+`perUser: {connector: <ns/name>}` declares this. Semantics:
+
+- **Fan-out**: a trigger firing the pipeline enqueues one *fire* job; the fire job
+  expands to one queued run per **connected user**, enumerated by the declared
+  connector's auth type:
+  - `oauth2_authorization_code` → users with a `connector_oauth_tokens` row (the
+    set the OAuth status endpoint reports);
+  - secret-based auth (`bearer`/`basic`/`api_key`/`oauth2_client_credentials`) →
+    users holding a **private** Secret named by the connector's `auth.secret`.
+    Users without a private override are *not* fanned out — they'd silently run
+    against the shared credential, which is never what a per-user pipeline means.
+  - `none`/`sinas_token` → no user registry exists; `perUser` on such a
+    connector is a validation error.
+
+  Triggers stay dumb; expansion lives in the pipeline job handler.
+- **Identity**: each run executes *as* that user — `user_id` is theirs, a JWT is
+  minted for them (scheduler pattern), so connector steps resolve their OAuth
+  token exactly as `execute_operation(user_id=...)` already does, and function/
+  agent/query steps run under their permissions. The run context exposes
+  `run.userId`.
+- **Isolation**: cursor, single-flight lock, coalesce flag, hold-on-failure, and
+  consecutive-failure counting are all keyed per `(pipeline, user)`. One user's
+  revoked token or failing mailbox must never block or fail other users' runs.
+  `perUser.disableAfterFailures: N` skips a user after N consecutive failures
+  *until they re-credential* — the OAuth callback storing a fresh token, or a
+  create/update of their private Secret, resets the counter (the natural
+  recovery points) — rather than deactivating the pipeline.
+- **Validation**: `perUser` requires an auth type with a user registry (the
+  enumeration rules above); `none`/`sinas_token` is a validation error. Global
+  cursor (`perUser` absent) remains correct for shared-credential sources (a
+  shared secret with no private overrides in play) and CDC-fed pipelines.
+- **Manual runs / tools**: `POST .../run` on a perUser pipeline runs for the
+  *calling* user only (natural for testing and for `asTool` invocation, which
+  always executes as the chat's user); `?allUsers=true` requires `run:all` and
+  fans out like a trigger.
+- **Concurrency across users**: runs for different users may execute in parallel
+  (bounded by the pipeline queue's worker concurrency); a per-pipeline
+  `maxConcurrentUsers` throttle is future work if fan-out sizes demand it.
+- **Consent note**: fan-out is gated on the OAuth connection itself — connecting
+  a connector is the user's consent for pipelines sourced from it to run on their
+  behalf (admins control which pipelines exist). A per-user opt-in/opt-out flag
+  per pipeline is future work.
+
+Source specifics that shaped this (and belong in the docs examples):
+
+- *Gmail* `history.list` — a true since-cursor (`startHistoryId` → response
+  `historyId`), per user. The schema example above.
+- *Slack* `search.messages` with a **user** token (scope `search:read`; Slack's
+  OAuth v2 nests it under `authed_user.access_token` — the configurable
+  token-response path for connector OAuth is being added separately in the 0.3.0
+  work, and this design assumes it). Slack's `after:` filter is day-granular, so
+  the cursor is the last-synced *day* re-polled with overlap; the duplicates this
+  produces are exactly what the at-least-once + idempotent-upsert contract
+  absorbs (conflict target `(user_id, pk)` with pk = `channel:ts`).
+
 ## Cursor state ("reversed CDC")
 
 Any step may declare `cursor: {param, path, initial?}`; in practice it's step 1.
@@ -278,9 +374,18 @@ Semantics:
 - If `path` yields null on a successful run (e.g. empty poll), the cursor is left
   unchanged — never regress or clear a bookmark on "no data".
 
-Cursor storage: `cursor_value TEXT` on the `pipelines` row (exactly like
-`DatabaseTrigger.last_poll_value` — one bookmark per pipeline). Multiple cursor
-steps per pipeline are rejected at validation in v1.
+Cursor storage:
+
+- Shared pipelines: `cursor_value TEXT` on the `pipelines` row (exactly like
+  `DatabaseTrigger.last_poll_value` — one bookmark per pipeline).
+- `perUser` pipelines: a `pipeline_cursors` table —
+  `(pipeline_id FK, user_id FK, cursor_value TEXT, consecutive_failures INT,
+  last_error TEXT, updated_at)`, unique `(pipeline_id, user_id)`, CASCADE on both
+  FKs. Keeping the shared bookmark on the pipeline row and per-user bookmarks in
+  their own table avoids NULL-in-unique-constraint contortions and gives per-user
+  failure state a natural home.
+
+Multiple cursor steps per pipeline are rejected at validation in v1.
 
 Optional pagination on a cursor-bearing (or any connector/function) step is
 deferred to v1.1 unless trivially cheap during implementation:
@@ -293,9 +398,11 @@ Gmail and Jira consumers can ship without it (batch sizes cover the poll interva
 A slow run and the next trigger firing must not overlap (CDC gets this for free
 from its one-loop-per-trigger process model; queued pipeline runs do not). Design:
 
-- Per-pipeline Redis lock `sinas:pipeline:lock:{id}` acquired with `SET NX EX
-  <syncTimeout+margin>` at run start, held for the run, refreshed by the runner on
-  long runs, released in a `finally`.
+- A Redis lock per run scope — `sinas:pipeline:lock:{id}` for shared pipelines,
+  `sinas:pipeline:lock:{id}:{user_id}` for perUser runs (the coalesce flag is
+  keyed identically) — acquired with `SET NX EX <syncTimeout+margin>` at run
+  start, held for the run, refreshed by the runner on long runs, released in a
+  `finally`. Different users' runs of the same perUser pipeline never contend.
 - `concurrency: single` (the default whenever cursor config is present): if the
   lock is held, a queued firing sets a *coalesce flag*
   (`sinas:pipeline:pending:{id}`) and exits; the lock holder checks the flag on
@@ -317,7 +424,8 @@ from its one-loop-per-trigger process model; queued pipeline runs do not). Desig
   steps. Agent steps are **not** retried by the runner in v1 (side effects +
   cost); their one-shot failure fails the run.
 - **Run failure**: first step to exhaust retries fails the run: status `failed`,
-  error + failing step recorded, cursor held, remaining steps skipped. There is no
+  error + failing step recorded, cursor held (for the run's scope — one user's
+  failure holds only that user's cursor), remaining steps skipped. There is no
   `continueOnError` in v1 — a linear pipeline whose step N failed has nothing
   sound to feed step N+1 (`when:` conditions are the future home for "optional"
   steps).
@@ -329,7 +437,10 @@ from its one-loop-per-trigger process model; queued pipeline runs do not). Desig
   *consecutive* failed runs the pipeline is deactivated (`is_active = false`) with
   `error_message` set (the `DatabaseTrigger.error_message` pattern), surfacing in
   console/config export rather than silently burning quota forever. Default: off
-  (halt-and-hold-cursor only, cadence bounded by the trigger).
+  (halt-and-hold-cursor only, cadence bounded by the trigger). For perUser
+  pipelines the analogous knob lives under `perUser.disableAfterFailures` and
+  applies per user (skip-until-reconnect, counter on `pipeline_cursors`) — a
+  single user's dead token never deactivates the pipeline for everyone.
 
 ## Observability
 
@@ -351,11 +462,14 @@ the `steps` summary only — acceptable for v1 and consistent with how connector
 tool calls are (not) recorded today. Runs API:
 
 ```
-POST /pipelines/{ns}/{name}/run          {input?, mode: sync|async}
-GET  /pipelines/{ns}/{name}/runs         ?status=&limit=
+POST /pipelines/{ns}/{name}/run          {input?, mode: sync|async}   (?allUsers=true for perUser fan-out, requires run:all)
+GET  /pipelines/{ns}/{name}/runs         ?status=&user=&limit=
 GET  /pipelines/runs/{run_id}
 POST /pipelines/runs/{run_id}/replay
 ```
+
+`pipeline_runs.user_id` is the user the run executed as — for perUser fan-out,
+the connected user, not the trigger's owner.
 
 Retention: `pipeline_runs` rows pruned by the same janitor cadence as executions
 (config `PIPELINE_RUN_RETENTION_DAYS`, default 30).
@@ -379,9 +493,11 @@ This absorbs the parked transforms use cases as whole semantic tools:
 ## Resource plumbing (mechanical, follows existing patterns)
 
 - `pipelines` table: id, user_id, namespace, name (unique together), description,
-  input_schema, steps (JSON), as_tool, tool_description, sync_timeout_seconds,
-  concurrency, disable_after_failures, cursor_value, error_message, output
-  (JSON), is_active, managed_by/config_name/config_checksum, timestamps.
+  input_schema, steps (JSON), per_user (JSON, nullable), as_tool,
+  tool_description, sync_timeout_seconds, concurrency, disable_after_failures,
+  cursor_value, error_message, output (JSON), is_active,
+  managed_by/config_name/config_checksum, timestamps. Plus the `pipeline_cursors`
+  table (see Cursor state) for perUser bookmarks and per-user failure counters.
   `PermissionMixin`; permission base `sinas.pipelines/{ns}/{name}` with actions
   `create/read/update/delete/run`; default Users role: `read:own` + `run:own`
   (creation/update stay admin-granted, matching queries' conservative default
@@ -434,7 +550,8 @@ Parked from the superseded 2026-07-27 brief:
 Also future: `when:` per-step conditions, typed-column `load` with schema
 evolution, pagination config (if not landed in v1), session-continuity agent
 steps, dedup keys for effectively-once agent steps, pipeline-level `env`/constants
-block.
+block, per-user opt-in/opt-out flags for perUser pipelines, `maxConcurrentUsers`
+fan-out throttle.
 
 ## Open questions
 
@@ -455,13 +572,19 @@ block.
 
 - Unit: mapping resolution (literal/`.$`/whole-input/missing-path→null), step
   input assembly, cursor inject/read/hold-on-failure/no-regress-on-null, retry
-  policy, single-flight lock + coalesce flag, run finalization (status, cursor
-  commit atomicity), agent-reply schema validation, `load` pk extraction +
-  transactional upsert, steps validation rules, config round-trip
+  policy, single-flight lock + coalesce flag (shared and per-user keying), run
+  finalization (status, cursor commit atomicity), agent-reply schema validation,
+  `load` pk extraction + transactional upsert (both table shapes, implicit
+  user_id not spoofable via mapping), fan-out expansion (connected-user
+  enumeration for both OAuth-token and private-secret registries, per-user
+  failure isolation, skip-until-re-credential + counter reset on token store /
+  private-secret update), steps validation rules, config round-trip
   (YAML→DB→export) with `.$` keys intact.
 - Integration (dev stack): schedule→pipeline Gmail-shaped poll with a stub
-  connector (cursor advances only on success), webhook→pipeline sync+async,
-  tool-invoked pipeline from a chat, replay of a failed run.
+  connector (cursor advances only on success), a perUser fan-out with two
+  connected users where one token is revoked (the other user's runs proceed,
+  cursors stay independent), webhook→pipeline sync+async, tool-invoked pipeline
+  from a chat, replay of a failed run.
 - Latency: measure inline runner overhead for a 3-step connector/query pipeline
   (target: <100ms added over the raw calls) and function-step queue round-trip;
   record numbers in the PR.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "croniter>=1.4.0",
     "asyncpg>=0.29.0",
     "jsonschema>=4.20.0",
+    "jmespath>=1.0.0",
     "python-jose[cryptography]>=3.3.0",
     "bcrypt (>=4.1.0)",
     "openai>=1.3.0",

--- a/backend/tests/unit/test_pipelines.py
+++ b/backend/tests/unit/test_pipelines.py
@@ -370,3 +370,87 @@ def test_serialize_pipeline_round_trips_dollar_keys():
     cfg = PipelineConfig.model_validate(out)
     assert cfg.output_mapping() == {"output.$": "steps.fetch.output.body"}
     assert cfg.steps == pipeline.steps
+
+
+# ---------------------------------------------------------------------------
+# Webhook pipeline target (post-#111)
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_schema_pipeline_target_requires_name():
+    from app.schemas.webhook import WebhookCreate
+
+    with pytest.raises(ValueError, match="pipeline_name is required"):
+        WebhookCreate(path="x", target_type="pipeline")
+
+
+def test_webhook_schema_pipeline_target_rejects_raw():
+    from app.schemas.webhook import WebhookCreate
+
+    with pytest.raises(ValueError, match="raw"):
+        WebhookCreate(
+            path="x", target_type="pipeline", pipeline_name="p", response_mode="raw"
+        )
+
+
+def test_webhook_schema_pipeline_target_valid():
+    from app.schemas.webhook import WebhookCreate
+
+    hook = WebhookCreate(
+        path="crm/contact-updated",
+        target_type="pipeline",
+        pipeline_namespace="crm",
+        pipeline_name="upsert-contact",
+        response_mode="async",
+    )
+    assert hook.pipeline_namespace == "crm"
+    # message_template is an agent-target concern only
+    assert hook.message_template is None
+
+
+def test_webhook_config_pipeline_target_round_trip():
+    import types
+
+    from app.schemas.config import WebhookConfig
+    from app.services.resource_serializers import serialize_webhook
+
+    cfg = WebhookConfig.model_validate({
+        "path": "crm/contact-updated",
+        "targetType": "pipeline",
+        "pipelineName": "crm/upsert-contact",
+        "responseMode": "async",
+        "requiresAuth": False,
+    })
+    assert cfg.pipelineName == "crm/upsert-contact"
+
+    webhook = types.SimpleNamespace(
+        path="crm/contact-updated",
+        target_type="pipeline",
+        function_namespace="default",
+        function_name=None,
+        agent_namespace=None,
+        agent_name=None,
+        pipeline_namespace="crm",
+        pipeline_name="upsert-contact",
+        message_template=None,
+        session_key_template=None,
+        http_method="POST",
+        requires_auth=False,
+        description=None,
+        default_values=None,
+        response_mode="async",
+        dedup=None,
+    )
+    out = serialize_webhook(webhook)
+    assert out["targetType"] == "pipeline"
+    assert out["pipelineName"] == "crm/upsert-contact"
+    assert "functionName" not in out and "agentName" not in out
+    # Export parses back through the config schema
+    WebhookConfig.model_validate(out)
+
+
+def test_webhook_config_pipeline_target_requires_pipeline_name():
+    from app.schemas.config import WebhookConfig
+
+    with pytest.raises(ValueError, match="pipelineName"):
+        WebhookConfig.model_validate({"path": "x", "targetType": "pipeline"})

--- a/backend/tests/unit/test_pipelines.py
+++ b/backend/tests/unit/test_pipelines.py
@@ -1,0 +1,372 @@
+"""Unit tests for the pipelines feature: mapping resolution, definition
+validation, and the pure runner helpers.
+
+Covers the invariants the ADR calls out:
+- `.$` keys are JMESPath, plain keys are literals, missing paths yield null;
+- invalid definitions are rejected at save time with actionable messages;
+- cursor/perUser/asTool/output constraints;
+- load-step identifier quoting and effective concurrency defaults.
+
+Runner semantics that need Redis + Postgres (single-flight, cursor
+commit/hold, fan-out) are integration-tested on the dev stack.
+"""
+import types
+
+import pytest
+
+from app.services import pipeline_mapping as pm
+from app.services.pipeline_validation import validate_pipeline_definition
+
+
+# ---------------------------------------------------------------------------
+# Mapping
+# ---------------------------------------------------------------------------
+
+CTX = {
+    "input": {"query": "hello", "n": 3},
+    "steps": {
+        "fetch": {"output": {"statusCode": 200, "body": {"historyId": "777", "items": [1, 2]}}},
+    },
+    "cursor": "42",
+    "run": {"id": "r1", "triggerType": "SCHEDULE", "userId": "u1"},
+}
+
+
+def test_literal_values_pass_through():
+    assert pm.resolve_template({"a": 1, "b": "text", "c": {"d": True}}, CTX) == {
+        "a": 1, "b": "text", "c": {"d": True}
+    }
+
+
+def test_expression_keys_are_evaluated_and_renamed():
+    out = pm.resolve_template({"startHistoryId.$": "cursor", "q.$": "input.query"}, CTX)
+    assert out == {"startHistoryId": "42", "q": "hello"}
+
+
+def test_nested_and_list_templates():
+    out = pm.resolve_template(
+        {"outer": {"inner.$": "steps.fetch.output.body.historyId"}, "arr": [{"x.$": "input.n"}]},
+        CTX,
+    )
+    assert out == {"outer": {"inner": "777"}, "arr": [{"x": 3}]}
+
+
+def test_missing_path_yields_none():
+    assert pm.resolve_template({"gone.$": "steps.nope.output"}, CTX) == {"gone": None}
+
+
+def test_whole_field_expression_via_resolve_field():
+    step = {"input.$": "steps.fetch.output.body"}
+    assert pm.resolve_field(step, "input", CTX) == {"historyId": "777", "items": [1, 2]}
+
+
+def test_resolve_field_literal_and_default():
+    assert pm.resolve_field({"input": {"a.$": "cursor"}}, "input", CTX) == {"a": "42"}
+    assert pm.resolve_field({}, "input", CTX, default={}) == {}
+
+
+def test_jmespath_projection():
+    out = pm.evaluate_expression("steps.fetch.output.body.items[*]", CTX)
+    assert out == [1, 2]
+
+
+def test_validate_template_rejects_bad_expression():
+    errors = pm.validate_template({"x.$": "steps.[unclosed"}, "steps[0].input")
+    assert len(errors) == 1 and "invalid JMESPath" in errors[0]
+
+
+def test_validate_template_rejects_literal_and_expression_for_same_key():
+    errors = pm.validate_template({"x": 1, "x.$": "cursor"}, "input")
+    assert any("pick literal or expression" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Definition validation
+# ---------------------------------------------------------------------------
+
+
+def _connector_step(**over):
+    step = {
+        "name": "fetch",
+        "type": "connector",
+        "connector": "google/gmail",
+        "operation": "list-history",
+    }
+    step.update(over)
+    return step
+
+
+def test_valid_minimal_pipeline():
+    assert validate_pipeline_definition([_connector_step()]) == []
+
+
+def test_steps_must_be_nonempty():
+    assert validate_pipeline_definition([]) == ["steps must be a non-empty list"]
+
+
+def test_unknown_step_type_rejected():
+    errors = validate_pipeline_definition([{"name": "x", "type": "webhook"}])
+    assert any("type must be one of" in e for e in errors)
+
+
+def test_unknown_keys_rejected():
+    errors = validate_pipeline_definition([_connector_step(imput={"a": 1})])
+    assert any("unknown keys" in e for e in errors)
+
+
+def test_duplicate_step_names_rejected():
+    errors = validate_pipeline_definition([_connector_step(), _connector_step()])
+    assert any("duplicate step names" in e for e in errors)
+
+
+def test_bad_resource_ref_rejected():
+    errors = validate_pipeline_definition([_connector_step(connector="no-slash")])
+    assert any("namespace/name" in e for e in errors)
+
+
+def test_input_and_input_expr_mutually_exclusive():
+    errors = validate_pipeline_definition(
+        [_connector_step(**{"input": {"a": 1}, "input.$": "input"})]
+    )
+    assert any("both 'input' and 'input.$'" in e for e in errors)
+
+
+def test_cursor_requires_param_and_valid_path():
+    errors = validate_pipeline_definition(
+        [_connector_step(cursor={"param": "start", "path": "body.["})]
+    )
+    assert any("invalid JMESPath" in e for e in errors)
+
+    errors = validate_pipeline_definition([_connector_step(cursor={"path": "body.h"})])
+    assert any("cursor.param is required" in e for e in errors)
+
+
+def test_at_most_one_cursor_step():
+    s1 = _connector_step(cursor={"param": "a", "path": "body.h"})
+    s2 = _connector_step(name="second", cursor={"param": "b", "path": "body.h"})
+    errors = validate_pipeline_definition([s1, s2])
+    assert any("at most one step may declare cursor" in e for e in errors)
+
+
+def test_retry_bounds():
+    errors = validate_pipeline_definition(
+        [_connector_step(retry={"maxAttempts": 99, "backoff": "cubic"})]
+    )
+    assert any("maxAttempts" in e for e in errors)
+    assert any("backoff" in e for e in errors)
+
+
+def test_load_step_requires_expressions_and_valid_table():
+    errors = validate_pipeline_definition([
+        {"name": "land", "type": "load", "connection": "db", "table": "bad-table;drop"}
+    ])
+    assert any("table" in e for e in errors)
+    assert any("primaryKey.$" in e for e in errors)
+    assert any("items.$" in e for e in errors)
+
+    ok = validate_pipeline_definition([
+        {
+            "name": "land", "type": "load", "connection": "db",
+            "table": "public.rows", "primaryKey.$": "item.id", "items.$": "input.items",
+        }
+    ])
+    assert ok == []
+
+
+def test_agent_step_message_expression():
+    ok = validate_pipeline_definition([
+        {"name": "triage", "type": "agent", "agent": "gmail/triage", "message.$": "input.text"}
+    ])
+    assert ok == []
+
+
+def test_paginate_reserved():
+    errors = validate_pipeline_definition([_connector_step(paginate={"param": "p"})])
+    assert any("not supported yet" in e for e in errors)
+
+
+def test_as_tool_requires_schema_and_description():
+    errors = validate_pipeline_definition([_connector_step()], as_tool=True)
+    assert any("inputSchema" in e for e in errors)
+    assert any("description" in e for e in errors)
+
+    ok = validate_pipeline_definition(
+        [_connector_step()],
+        as_tool=True,
+        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+        description="Search things",
+    )
+    assert ok == []
+
+
+def test_per_user_shape():
+    errors = validate_pipeline_definition([_connector_step()], per_user={"connector": "nope"})
+    assert any("perUser.connector" in e for e in errors)
+
+    errors = validate_pipeline_definition(
+        [_connector_step()],
+        per_user={"connector": "google/gmail", "disableAfterFailures": 0},
+    )
+    assert any("disableAfterFailures" in e for e in errors)
+
+    ok = validate_pipeline_definition(
+        [_connector_step()],
+        per_user={"connector": "google/gmail", "disableAfterFailures": 5},
+    )
+    assert ok == []
+
+
+def test_output_mapping_validation():
+    errors = validate_pipeline_definition(
+        [_connector_step()], output_mapping={"output": 1, "output.$": "cursor"}
+    )
+    assert any("both" in e for e in errors)
+
+    errors = validate_pipeline_definition(
+        [_connector_step()], output_mapping={"output.$": "steps.["}
+    )
+    assert any("invalid JMESPath" in e for e in errors)
+
+    assert validate_pipeline_definition(
+        [_connector_step()], output_mapping={"output.$": "steps.fetch.output.body"}
+    ) == []
+
+
+def test_step_cap():
+    steps = [_connector_step(name=f"s{i}") for i in range(33)]
+    errors = validate_pipeline_definition(steps)
+    assert any("too many steps" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Pure runner helpers
+# ---------------------------------------------------------------------------
+
+
+def test_quote_table():
+    from app.services.pipeline_runner import _quote_table
+
+    assert _quote_table("rows") == '"rows"'
+    assert _quote_table("public.rows") == '"public"."rows"'
+
+
+def test_backoff_delay():
+    from app.services.pipeline_runner import _backoff_delay
+
+    assert _backoff_delay(0, "none") == 0.0
+    assert _backoff_delay(0, "exponential") == 0.5
+    assert _backoff_delay(2, "linear") == 3.0
+
+
+def _pipeline_stub(steps, concurrency=None, per_user=None):
+    from app.models.pipeline import Pipeline
+
+    stub = types.SimpleNamespace(
+        steps=steps, concurrency=concurrency, per_user=per_user, id="pid"
+    )
+    stub.get_cursor_step = lambda: Pipeline.get_cursor_step(stub)
+    stub.effective_concurrency = lambda: Pipeline.effective_concurrency(stub)
+    return stub
+
+
+def test_effective_concurrency_defaults():
+    cursor_step = {"name": "a", "type": "connector", "cursor": {"param": "p", "path": "x"}}
+    assert _pipeline_stub([cursor_step]).effective_concurrency() == "single"
+    assert _pipeline_stub([{"name": "a", "type": "query"}]).effective_concurrency() == "parallel"
+    assert _pipeline_stub([cursor_step], concurrency="parallel").effective_concurrency() == "parallel"
+
+
+def test_lock_keys_scope_per_user():
+    from app.services.pipeline_runner import _lock_key, _pending_key
+
+    shared = _pipeline_stub([], per_user=None)
+    per_user = _pipeline_stub([], per_user={"connector": "g/gmail"})
+    assert _lock_key(shared, "u1") == "sinas:pipeline:lock:pid"
+    assert _lock_key(per_user, "u1") == "sinas:pipeline:lock:pid:u1"
+    assert _lock_key(per_user, "u2") != _lock_key(per_user, "u1")
+    assert _pending_key(per_user, "u1").endswith(":u1")
+
+
+# ---------------------------------------------------------------------------
+# API schema (PipelineCreate) surfaces validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_create_schema_rejects_invalid_definition():
+    from app.schemas.pipeline import PipelineCreate
+
+    with pytest.raises(ValueError, match="duplicate step names"):
+        PipelineCreate(
+            name="p", steps=[_connector_step(), _connector_step()],
+        )
+
+
+def test_pipeline_create_schema_accepts_valid_definition():
+    from app.schemas.pipeline import PipelineCreate
+
+    p = PipelineCreate(
+        namespace="gmail",
+        name="inbox-triage",
+        steps=[
+            _connector_step(cursor={"param": "startHistoryId", "path": "body.historyId"}),
+            {"name": "land", "type": "load", "connection": "db", "table": "msgs",
+             "primaryKey.$": "item.id", "items.$": "steps.fetch.output.body.items"},
+        ],
+        per_user={"connector": "google/gmail"},
+    )
+    assert p.steps[0]["cursor"]["param"] == "startHistoryId"
+
+
+# ---------------------------------------------------------------------------
+# Config-layer round-trip pieces
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_config_output_mapping_aliases():
+    from app.schemas.config import PipelineConfig
+
+    cfg = PipelineConfig.model_validate({
+        "name": "p", "steps": [_connector_step()], "output.$": "steps.fetch.output.body",
+    })
+    assert cfg.output_mapping() == {"output.$": "steps.fetch.output.body"}
+
+    cfg2 = PipelineConfig.model_validate({
+        "name": "p", "steps": [_connector_step()], "output": {"fixed": True},
+    })
+    assert cfg2.output_mapping() == {"output": {"fixed": True}}
+
+    cfg3 = PipelineConfig.model_validate({"name": "p", "steps": [_connector_step()]})
+    assert cfg3.output_mapping() is None
+
+
+def test_serialize_pipeline_round_trips_dollar_keys():
+    from app.services.resource_serializers import serialize_pipeline
+
+    pipeline = types.SimpleNamespace(
+        namespace="gmail",
+        name="inbox-triage",
+        description="d",
+        input_schema={"type": "object", "properties": {}},
+        steps=[_connector_step(**{"input.$": "input"})],
+        per_user={"connector": "google/gmail", "disableAfterFailures": 5},
+        as_tool=True,
+        tool_description="td",
+        sync_timeout_seconds=120,
+        concurrency=None,
+        disable_after_failures=None,
+        output_mapping={"output.$": "steps.fetch.output.body"},
+        is_active=True,
+    )
+    out = serialize_pipeline(pipeline)
+    assert out["steps"][0]["input.$"] == "input"
+    assert out["output.$"] == "steps.fetch.output.body"
+    assert out["perUser"]["disableAfterFailures"] == 5
+    assert "cursorValue" not in out and "cursor_value" not in out
+    assert "syncTimeoutSeconds" not in out  # default elided
+
+    # And the exported dict parses back through the config schema.
+    from app.schemas.config import PipelineConfig
+
+    cfg = PipelineConfig.model_validate(out)
+    assert cfg.output_mapping() == {"output.$": "steps.fetch.output.body"}
+    assert cfg.steps == pipeline.steps

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -42,6 +42,8 @@ import { QueryDetail } from './pages/QueryDetail';
 import { DatabaseTriggers } from './pages/DatabaseTriggers';
 import { Connectors } from './pages/Connectors';
 import { ConnectorEditor } from './pages/ConnectorEditor';
+import { Pipelines } from './pages/Pipelines';
+import { PipelineEditor } from './pages/PipelineEditor';
 import { Secrets } from './pages/Secrets';
 import { Stores } from './pages/Stores';
 
@@ -153,6 +155,8 @@ function App() {
               <Route path="config" element={<ConfigManager />} />
               <Route path="connectors" element={<Connectors />} />
               <Route path="connectors/:namespace/:name" element={<ConnectorEditor />} />
+              <Route path="pipelines" element={<Pipelines />} />
+              <Route path="pipelines/:namespace/:name" element={<PipelineEditor />} />
               <Route path="secrets" element={<Secrets />} />
               <Route path="stores" element={<Stores />} />
               <Route path="logs" element={<RequestLogs />} />

--- a/console/src/components/Layout.tsx
+++ b/console/src/components/Layout.tsx
@@ -29,6 +29,7 @@ import {
   HardDrive,
   KeyRound,
   Plug,
+  Workflow,
 } from 'lucide-react';
 import { useState } from 'react';
 
@@ -56,6 +57,7 @@ const navigationSections = [
       { name: 'Databases', href: '/database-connections', icon: Cable },
       { name: 'Templates', href: '/templates', icon: FileText },
       { name: 'Connectors', href: '/connectors', icon: Plug },
+      { name: 'Pipelines', href: '/pipelines', icon: Workflow },
       { name: 'Secrets', href: '/secrets', icon: KeyRound },
     ],
   },

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -77,6 +77,11 @@ import type {
   QueryCreate,
   QueryUpdate,
   QueryExecuteResponse,
+  Pipeline,
+  PipelineCreate,
+  PipelineUpdate,
+  PipelineRun,
+  PipelineRunOutcome,
 } from '../types';
 
 // Auto-detect API base URL based on environment
@@ -1002,6 +1007,51 @@ class APIClient {
 
   async executeQuery(namespace: string, name: string, input: Record<string, any> = {}): Promise<QueryExecuteResponse> {
     const response = await this.configClient.post(`/queries/${namespace}/${name}/execute`, { input });
+    return response.data;
+  }
+
+  // Pipelines
+  async listPipelines(): Promise<Pipeline[]> {
+    const response = await this.configClient.get('/pipelines');
+    return response.data;
+  }
+
+  async getPipeline(namespace: string, name: string): Promise<Pipeline> {
+    const response = await this.configClient.get(`/pipelines/${namespace}/${name}`);
+    return response.data;
+  }
+
+  async createPipeline(data: PipelineCreate): Promise<Pipeline> {
+    const response = await this.configClient.post('/pipelines', data);
+    return response.data;
+  }
+
+  async updatePipeline(namespace: string, name: string, data: PipelineUpdate): Promise<Pipeline> {
+    const response = await this.configClient.put(`/pipelines/${namespace}/${name}`, data);
+    return response.data;
+  }
+
+  async deletePipeline(namespace: string, name: string): Promise<void> {
+    await this.configClient.delete(`/pipelines/${namespace}/${name}`);
+  }
+
+  async runPipeline(
+    namespace: string,
+    name: string,
+    input: Record<string, any> = {},
+    mode: 'sync' | 'async' = 'sync'
+  ): Promise<PipelineRunOutcome> {
+    const response = await this.runtimeClient.post(`/pipelines/${namespace}/${name}/run`, { input, mode });
+    return response.data;
+  }
+
+  async listPipelineRuns(namespace: string, name: string, limit: number = 50): Promise<PipelineRun[]> {
+    const response = await this.runtimeClient.get(`/pipelines/${namespace}/${name}/runs`, { params: { limit } });
+    return response.data;
+  }
+
+  async replayPipelineRun(runId: string): Promise<{ run_id: string; status: string }> {
+    const response = await this.runtimeClient.post(`/pipelines/runs/${runId}/replay`);
     return response.data;
   }
 

--- a/console/src/pages/PipelineEditor.tsx
+++ b/console/src/pages/PipelineEditor.tsx
@@ -1,0 +1,581 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient, getApiErrorMessage } from '../lib/api';
+import { useToast } from '../lib/toast-context';
+import {
+  Save, ArrowLeft, Play, RotateCcw, ChevronDown, ChevronRight, AlertCircle,
+  CheckCircle2, XCircle, Clock, Loader2,
+} from 'lucide-react';
+import CodeEditor from '@uiw/react-textarea-code-editor';
+import { JSONSchemaEditor } from '../components/JSONSchemaEditor';
+import type { PipelineRun, PipelineRunOutcome } from '../types';
+
+const STEPS_PLACEHOLDER = `[
+  {
+    "name": "fetch",
+    "type": "connector",
+    "connector": "google/gmail",
+    "operation": "list-history",
+    "input": { "userId": "me", "startHistoryId.$": "cursor" },
+    "cursor": { "param": "startHistoryId", "path": "body.historyId" },
+    "retry": { "maxAttempts": 3, "backoff": "exponential" }
+  },
+  {
+    "name": "extract",
+    "type": "function",
+    "function": "gmail/extract-messages",
+    "input.$": "steps.fetch.output.body"
+  }
+]`;
+
+const codeEditorStyle = {
+  fontSize: 13,
+  backgroundColor: '#111111',
+  color: '#ededed',
+  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+  borderRadius: 6,
+  border: '1px solid rgba(255,255,255,0.08)',
+};
+
+function statusIcon(status: string) {
+  switch (status) {
+    case 'succeeded':
+      return <CheckCircle2 className="w-4 h-4 text-green-400" />;
+    case 'failed':
+      return <XCircle className="w-4 h-4 text-red-400" />;
+    case 'timed_out':
+      return <Clock className="w-4 h-4 text-yellow-400" />;
+    case 'running':
+      return <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />;
+    default:
+      return <Clock className="w-4 h-4 text-gray-500" />;
+  }
+}
+
+function RunRow({ run, onReplay }: { run: PipelineRun; onReplay: (runId: string) => void }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="border border-white/[0.06] rounded-lg">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between px-3 py-2 text-left"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-gray-500 flex-shrink-0" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-gray-500 flex-shrink-0" />
+          )}
+          {statusIcon(run.status)}
+          <span className="font-mono text-xs text-gray-400 truncate">{run.run_id}</span>
+          <span className="px-1.5 py-0.5 text-xs rounded bg-gray-800 text-gray-400">{run.trigger_type}</span>
+        </div>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {run.duration_ms != null && <span className="text-xs text-gray-500">{run.duration_ms} ms</span>}
+          <span className="text-xs text-gray-500">{new Date(run.started_at).toLocaleString()}</span>
+        </div>
+      </button>
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2 border-t border-white/[0.06] pt-2">
+          {run.error && <p className="text-xs text-red-400 whitespace-pre-wrap">{run.error}</p>}
+          {run.steps?.length > 0 && (
+            <div className="space-y-1">
+              {run.steps.map((s) => (
+                <div key={s.name} className="flex items-center gap-2 text-xs">
+                  {statusIcon(s.status)}
+                  <span className="font-mono text-gray-300">{s.name}</span>
+                  <span className="text-gray-600">({s.type})</span>
+                  {s.durationMs != null && <span className="text-gray-500">{s.durationMs} ms</span>}
+                  {s.executionId && <span className="text-gray-600 font-mono truncate">exec {s.executionId.slice(0, 8)}</span>}
+                  {s.chatId && (
+                    <Link to={`/chats/${s.chatId}`} className="text-primary-400 hover:underline">
+                      chat
+                    </Link>
+                  )}
+                  {s.error && <span className="text-red-400 truncate">{s.error}</span>}
+                </div>
+              ))}
+            </div>
+          )}
+          {(run.cursor_before != null || run.cursor_after != null) && (
+            <p className="text-xs text-gray-500">
+              cursor: <span className="font-mono">{run.cursor_before ?? '∅'}</span> →{' '}
+              <span className="font-mono">{run.cursor_after ?? '(held)'}</span>
+            </p>
+          )}
+          {(run.status === 'failed' || run.status === 'timed_out') && (
+            <button
+              type="button"
+              onClick={() => onReplay(run.run_id)}
+              className="btn btn-secondary btn-sm inline-flex items-center text-xs"
+            >
+              <RotateCcw className="w-3 h-3 mr-1" />
+              Replay with stored input
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PipelineEditor() {
+  const { namespace = '', name = '' } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const isNew = namespace === 'new' && name === 'new';
+  const { showSuccess, showError } = useToast();
+
+  const [formData, setFormData] = useState({
+    namespace: 'default',
+    name: '',
+    description: '',
+    sync_timeout_seconds: 120,
+    concurrency: '' as '' | 'single' | 'parallel',
+    disable_after_failures: '' as string,
+    as_tool: false,
+    tool_description: '',
+    per_user_enabled: false,
+    per_user_connector: '',
+    per_user_disable_after: '' as string,
+    is_active: true,
+  });
+  const [stepsText, setStepsText] = useState('');
+  const [outputMappingText, setOutputMappingText] = useState('');
+  const [inputSchema, setInputSchema] = useState<any>({});
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Manual run box
+  const [runInputText, setRunInputText] = useState('{}');
+  const [runMode, setRunMode] = useState<'sync' | 'async'>('sync');
+  const [runResult, setRunResult] = useState<PipelineRunOutcome | null>(null);
+
+  const { data: pipeline, isLoading } = useQuery({
+    queryKey: ['pipeline', namespace, name],
+    queryFn: () => apiClient.getPipeline(namespace, name),
+    enabled: !isNew,
+    retry: false,
+  });
+
+  const { data: runs } = useQuery({
+    queryKey: ['pipelineRuns', namespace, name],
+    queryFn: () => apiClient.listPipelineRuns(namespace, name, 25),
+    enabled: !isNew,
+    retry: false,
+    refetchInterval: (q) =>
+      q.state.data?.some((r: PipelineRun) => r.status === 'running') ? 3000 : false,
+  });
+
+  useEffect(() => {
+    if (pipeline) {
+      setFormData({
+        namespace: pipeline.namespace,
+        name: pipeline.name,
+        description: pipeline.description || '',
+        sync_timeout_seconds: pipeline.sync_timeout_seconds,
+        concurrency: (pipeline.concurrency as '' | 'single' | 'parallel') || '',
+        disable_after_failures: pipeline.disable_after_failures?.toString() || '',
+        as_tool: pipeline.as_tool,
+        tool_description: pipeline.tool_description || '',
+        per_user_enabled: !!pipeline.per_user,
+        per_user_connector: pipeline.per_user?.connector || '',
+        per_user_disable_after: pipeline.per_user?.disableAfterFailures?.toString() || '',
+        is_active: pipeline.is_active,
+      });
+      setStepsText(JSON.stringify(pipeline.steps, null, 2));
+      setOutputMappingText(pipeline.output_mapping ? JSON.stringify(pipeline.output_mapping, null, 2) : '');
+      setInputSchema(pipeline.input_schema || {});
+    }
+  }, [pipeline]);
+
+  const buildPayload = () => {
+    let steps: any;
+    try {
+      steps = JSON.parse(stepsText);
+    } catch (e: any) {
+      throw new Error(`Steps is not valid JSON: ${e.message}`);
+    }
+    let outputMapping: any = null;
+    if (outputMappingText.trim()) {
+      try {
+        outputMapping = JSON.parse(outputMappingText);
+      } catch (e: any) {
+        throw new Error(`Output mapping is not valid JSON: ${e.message}`);
+      }
+    }
+    return {
+      namespace: formData.namespace,
+      name: formData.name,
+      description: formData.description || null,
+      input_schema: inputSchema,
+      steps,
+      per_user: formData.per_user_enabled
+        ? {
+            connector: formData.per_user_connector,
+            ...(formData.per_user_disable_after
+              ? { disableAfterFailures: parseInt(formData.per_user_disable_after, 10) }
+              : {}),
+          }
+        : null,
+      as_tool: formData.as_tool,
+      tool_description: formData.tool_description || null,
+      sync_timeout_seconds: formData.sync_timeout_seconds,
+      concurrency: formData.concurrency || null,
+      disable_after_failures: formData.disable_after_failures
+        ? parseInt(formData.disable_after_failures, 10)
+        : null,
+      output_mapping: outputMapping,
+      ...(isNew ? {} : { is_active: formData.is_active }),
+    };
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: (data: any) =>
+      isNew ? apiClient.createPipeline(data) : apiClient.updatePipeline(namespace, name, data),
+    onSuccess: (saved) => {
+      queryClient.invalidateQueries({ queryKey: ['pipelines'] });
+      queryClient.invalidateQueries({ queryKey: ['pipeline', saved.namespace, saved.name] });
+      showSuccess(`Pipeline ${saved.namespace}/${saved.name} saved`);
+      if (isNew || saved.namespace !== namespace || saved.name !== name) {
+        navigate(`/pipelines/${saved.namespace}/${saved.name}`);
+      }
+    },
+    onError: (err) => setSaveError(getApiErrorMessage(err, 'Failed to save pipeline')),
+  });
+
+  const runMutation = useMutation({
+    mutationFn: async () => {
+      let input: any;
+      try {
+        input = JSON.parse(runInputText || '{}');
+      } catch (e: any) {
+        throw new Error(`Run input is not valid JSON: ${e.message}`);
+      }
+      return apiClient.runPipeline(namespace, name, input, runMode);
+    },
+    onSuccess: (result) => {
+      setRunResult(result);
+      queryClient.invalidateQueries({ queryKey: ['pipelineRuns', namespace, name] });
+    },
+    onError: (err: any) => {
+      setRunResult(null);
+      showError(err?.message?.startsWith('Run input') ? err.message : getApiErrorMessage(err, 'Run failed'));
+    },
+  });
+
+  const replayMutation = useMutation({
+    mutationFn: (runId: string) => apiClient.replayPipelineRun(runId),
+    onSuccess: () => {
+      showSuccess('Run re-enqueued');
+      queryClient.invalidateQueries({ queryKey: ['pipelineRuns', namespace, name] });
+    },
+    onError: (err) => showError(getApiErrorMessage(err, 'Replay failed')),
+  });
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaveError(null);
+    let payload: any;
+    try {
+      payload = buildPayload();
+    } catch (err: any) {
+      setSaveError(err.message);
+      return;
+    }
+    saveMutation.mutate(payload);
+  };
+
+  if (!isNew && isLoading) return <div className="text-gray-400">Loading...</div>;
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link to="/pipelines" className="p-1.5 text-gray-500 hover:text-gray-300">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-100">
+            {isNew ? 'New Pipeline' : (
+              <span className="font-mono">
+                <span className="text-gray-500">{namespace}/</span>{name}
+              </span>
+            )}
+          </h1>
+          {!isNew && pipeline && !pipeline.is_active && (
+            <span className="px-2 py-0.5 text-xs font-medium rounded bg-red-900/30 text-red-400">Inactive</span>
+          )}
+        </div>
+        <button onClick={handleSave} disabled={saveMutation.isPending} className="btn btn-primary flex items-center">
+          <Save className="w-4 h-4 mr-2" />
+          {saveMutation.isPending ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+
+      {saveError && (
+        <div className="card border-red-900/50 bg-red-950/20 flex items-start gap-2 text-sm text-red-300">
+          <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+          <span className="whitespace-pre-wrap">{saveError}</span>
+        </div>
+      )}
+
+      {!isNew && pipeline?.error_message && (
+        <div className="card border-yellow-900/50 bg-yellow-950/20 text-sm text-yellow-300">
+          Last failure: {pipeline.error_message}
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-6">
+        <div className="card space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Namespace</label>
+              <input
+                value={formData.namespace}
+                onChange={(e) => setFormData({ ...formData, namespace: e.target.value })}
+                className="input w-full font-mono"
+                disabled={!isNew}
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Name</label>
+              <input
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="input w-full font-mono"
+                disabled={!isNew}
+                required
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Description</label>
+            <input
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="input w-full"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Sync timeout (s)</label>
+              <input
+                type="number"
+                min={1}
+                max={600}
+                value={formData.sync_timeout_seconds}
+                onChange={(e) => setFormData({ ...formData, sync_timeout_seconds: parseInt(e.target.value || '120', 10) })}
+                className="input w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Concurrency</label>
+              <select
+                value={formData.concurrency}
+                onChange={(e) => setFormData({ ...formData, concurrency: e.target.value as any })}
+                className="input w-full"
+              >
+                <option value="">Auto (single if cursor, else parallel)</option>
+                <option value="single">single</option>
+                <option value="parallel">parallel</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Disable after failures</label>
+              <input
+                type="number"
+                min={1}
+                placeholder="off"
+                value={formData.disable_after_failures}
+                onChange={(e) => setFormData({ ...formData, disable_after_failures: e.target.value })}
+                className="input w-full"
+              />
+            </div>
+          </div>
+          {!isNew && (
+            <label className="flex items-center gap-2 text-sm text-gray-300">
+              <input
+                type="checkbox"
+                checked={formData.is_active}
+                onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
+              />
+              Active {!formData.is_active && pipeline?.is_active === false && '(re-activating clears the failure counter)'}
+            </label>
+          )}
+        </div>
+
+        <div className="card space-y-3">
+          <div>
+            <h3 className="text-sm font-medium text-gray-300">Steps</h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              JSON array of typed steps. Keys ending in <code className="font-mono">.$</code> are JMESPath
+              expressions over {'{'}input, steps.&lt;name&gt;.output, cursor, run{'}'}.
+            </p>
+          </div>
+          <CodeEditor
+            value={stepsText}
+            language="json"
+            placeholder={STEPS_PLACEHOLDER}
+            onChange={(e) => { setSaveError(null); setStepsText(e.target.value); }}
+            padding={12}
+            data-color-mode="dark"
+            style={{ ...codeEditorStyle, minHeight: 220 }}
+          />
+        </div>
+
+        <div className="card space-y-4">
+          <h3 className="text-sm font-medium text-gray-300">Per-user runs</h3>
+          <label className="flex items-center gap-2 text-sm text-gray-300">
+            <input
+              type="checkbox"
+              checked={formData.per_user_enabled}
+              onChange={(e) => setFormData({ ...formData, per_user_enabled: e.target.checked })}
+            />
+            Fan out one run per connected user of a per-user-auth connector
+          </label>
+          {formData.per_user_enabled && (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Source connector (namespace/name)</label>
+                <input
+                  value={formData.per_user_connector}
+                  onChange={(e) => setFormData({ ...formData, per_user_connector: e.target.value })}
+                  className="input w-full font-mono"
+                  placeholder="google/gmail"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Skip user after N failures</label>
+                <input
+                  type="number"
+                  min={1}
+                  placeholder="off"
+                  value={formData.per_user_disable_after}
+                  onChange={(e) => setFormData({ ...formData, per_user_disable_after: e.target.value })}
+                  className="input w-full"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="card space-y-4">
+          <h3 className="text-sm font-medium text-gray-300">Agent tool exposure</h3>
+          <label className="flex items-center gap-2 text-sm text-gray-300">
+            <input
+              type="checkbox"
+              checked={formData.as_tool}
+              onChange={(e) => setFormData({ ...formData, as_tool: e.target.checked })}
+            />
+            Expose as an agent tool (requires an input schema and a description)
+          </label>
+          {formData.as_tool && (
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Tool description (defaults to description)</label>
+              <input
+                value={formData.tool_description}
+                onChange={(e) => setFormData({ ...formData, tool_description: e.target.value })}
+                className="input w-full"
+              />
+            </div>
+          )}
+          <JSONSchemaEditor
+            label="Input Schema"
+            description="Validates run input; becomes the tool parameters when exposed as a tool"
+            value={inputSchema}
+            onChange={setInputSchema}
+          />
+        </div>
+
+        <div className="card space-y-3">
+          <div>
+            <h3 className="text-sm font-medium text-gray-300">Output mapping (optional)</h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              {'{"output.$": "steps.act.output"}'} or a literal template; empty = last step's output.
+            </p>
+          </div>
+          <CodeEditor
+            value={outputMappingText}
+            language="json"
+            placeholder='{ "output.$": "steps.fetch.output.body" }'
+            onChange={(e) => { setSaveError(null); setOutputMappingText(e.target.value); }}
+            padding={12}
+            data-color-mode="dark"
+            style={{ ...codeEditorStyle, minHeight: 60 }}
+          />
+        </div>
+      </form>
+
+      {!isNew && (
+        <div className="card space-y-4">
+          <h3 className="text-sm font-medium text-gray-300">Run now</h3>
+          <div className="flex gap-3 items-start">
+            <div className="flex-1">
+              <CodeEditor
+                value={runInputText}
+                language="json"
+                onChange={(e) => setRunInputText(e.target.value)}
+                padding={10}
+                data-color-mode="dark"
+                style={{ ...codeEditorStyle, minHeight: 40 }}
+              />
+            </div>
+            <select value={runMode} onChange={(e) => setRunMode(e.target.value as any)} className="input">
+              <option value="sync">sync</option>
+              <option value="async">async</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => runMutation.mutate()}
+              disabled={runMutation.isPending}
+              className="btn btn-primary flex items-center"
+            >
+              <Play className="w-4 h-4 mr-2" />
+              {runMutation.isPending ? 'Running…' : 'Run'}
+            </button>
+          </div>
+          {runResult && (
+            <div className="text-sm space-y-1">
+              <div className="flex items-center gap-2">
+                {statusIcon(runResult.status)}
+                <span className="text-gray-300">{runResult.status}</span>
+                <span className="font-mono text-xs text-gray-500">{runResult.run_id}</span>
+                {runResult.duration_ms != null && (
+                  <span className="text-xs text-gray-500">{runResult.duration_ms} ms</span>
+                )}
+              </div>
+              {runResult.error && <p className="text-xs text-red-400 whitespace-pre-wrap">{runResult.error}</p>}
+              {runResult.output !== undefined && runResult.output !== null && (
+                <pre className="text-xs text-gray-400 bg-black/40 rounded p-2 overflow-auto max-h-64">
+                  {JSON.stringify(runResult.output, null, 2)}
+                </pre>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isNew && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-gray-300">
+            Recent runs {pipeline?.cursor_value && (
+              <span className="text-xs text-gray-500 font-normal ml-2">
+                cursor: <span className="font-mono">{pipeline.cursor_value}</span>
+              </span>
+            )}
+          </h3>
+          {!runs?.length ? (
+            <p className="text-sm text-gray-500">No runs yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {runs.map((run) => (
+                <RunRow key={run.run_id} run={run} onReplay={(id) => replayMutation.mutate(id)} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/src/pages/Pipelines.tsx
+++ b/console/src/pages/Pipelines.tsx
@@ -1,0 +1,138 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { Plus, Trash2, Workflow, ChevronRight, AlertTriangle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { Pipeline } from '../types';
+
+export function Pipelines() {
+  const queryClient = useQueryClient();
+
+  const { data: pipelines, isLoading } = useQuery({
+    queryKey: ['pipelines'],
+    queryFn: () => apiClient.listPipelines(),
+    retry: false,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ namespace, name }: { namespace: string; name: string }) =>
+      apiClient.deletePipeline(namespace, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pipelines'] });
+    },
+  });
+
+  const handleDelete = (pipeline: Pipeline) => {
+    if (confirm(`Delete pipeline "${pipeline.namespace}/${pipeline.name}"? Its run history and cursors are deleted too.`)) {
+      deleteMutation.mutate({ namespace: pipeline.namespace, name: pipeline.name });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-100">Pipelines</h1>
+          <p className="text-gray-400 mt-1">
+            Linear step sequences (connector → function → agent → query → load) fired by schedules, webhooks, CDC, or agents
+          </p>
+        </div>
+        <Link to="/pipelines/new/new" className="btn btn-primary flex items-center">
+          <Plus className="w-5 h-5 mr-2" />
+          New Pipeline
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="text-gray-400">Loading...</div>
+      ) : !pipelines?.length ? (
+        <div className="card text-center py-12">
+          <Workflow className="w-12 h-12 text-gray-600 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-gray-300">No pipelines yet</h3>
+          <p className="text-gray-500 mt-1">
+            Create a pipeline to chain connector calls, functions, agents, and database loads
+          </p>
+          <Link to="/pipelines/new/new" className="btn btn-primary mt-4 inline-flex items-center">
+            <Plus className="w-4 h-4 mr-2" />
+            Create Pipeline
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {pipelines.map((pipeline) => {
+            const stepCount = pipeline.steps?.length || 0;
+            const hasCursor = pipeline.steps?.some((s) => (s as any).cursor);
+            return (
+              <Link
+                key={pipeline.id}
+                to={`/pipelines/${pipeline.namespace}/${pipeline.name}`}
+                className="card flex items-center justify-between hover:border-white/[0.12] transition-colors group"
+              >
+                <div className="flex items-center gap-4 min-w-0">
+                  <Workflow className="w-5 h-5 text-primary-400 flex-shrink-0" />
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-3">
+                      <span className="font-mono text-sm text-gray-200">
+                        <span className="text-gray-500">{pipeline.namespace}/</span>
+                        {pipeline.name}
+                      </span>
+                      {pipeline.as_tool && (
+                        <span className="px-2 py-0.5 text-xs font-medium rounded bg-blue-900/30 text-blue-400">
+                          Tool
+                        </span>
+                      )}
+                      {pipeline.per_user && (
+                        <span className="px-2 py-0.5 text-xs font-medium rounded bg-purple-900/30 text-purple-400">
+                          Per-user
+                        </span>
+                      )}
+                      {hasCursor && (
+                        <span className="px-2 py-0.5 text-xs font-medium rounded bg-green-900/30 text-green-400">
+                          Cursor
+                        </span>
+                      )}
+                      {!pipeline.is_active && (
+                        <span className="px-2 py-0.5 text-xs font-medium rounded bg-red-900/30 text-red-400">
+                          Inactive
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 mt-0.5">
+                      <span className="text-xs text-gray-600">
+                        {stepCount} step{stepCount !== 1 ? 's' : ''}
+                        {' · '}
+                        {pipeline.steps?.map((s) => s.type).join(' → ') || 'empty'}
+                      </span>
+                    </div>
+                    {pipeline.description && (
+                      <p className="text-xs text-gray-500 mt-0.5 truncate">{pipeline.description}</p>
+                    )}
+                    {pipeline.error_message && (
+                      <p className="text-xs text-red-400 mt-0.5 truncate flex items-center gap-1">
+                        <AlertTriangle className="w-3 h-3 flex-shrink-0" />
+                        {pipeline.error_message}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleDelete(pipeline);
+                    }}
+                    className="p-1.5 text-gray-500 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100"
+                    title="Delete"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                  <ChevronRight className="w-4 h-4 text-gray-600" />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -1221,3 +1221,89 @@ export interface FileSearchResult {
   version: number;
   matches: FileSearchMatch[];
 }
+
+// Pipelines
+export interface PipelineStep {
+  name: string;
+  type: 'connector' | 'function' | 'agent' | 'query' | 'load';
+  [key: string]: any; // per-type fields + `.$` mapping keys, edited as JSON
+}
+
+export interface Pipeline {
+  id: string;
+  user_id: string;
+  namespace: string;
+  name: string;
+  description?: string | null;
+  input_schema: Record<string, any>;
+  steps: PipelineStep[];
+  per_user?: { connector: string; disableAfterFailures?: number } | null;
+  as_tool: boolean;
+  tool_description?: string | null;
+  sync_timeout_seconds: number;
+  concurrency?: 'single' | 'parallel' | null;
+  disable_after_failures?: number | null;
+  output_mapping?: Record<string, any> | null;
+  cursor_value?: string | null;
+  error_message?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface PipelineCreate {
+  namespace: string;
+  name: string;
+  description?: string | null;
+  input_schema?: Record<string, any> | null;
+  steps: PipelineStep[];
+  per_user?: { connector: string; disableAfterFailures?: number } | null;
+  as_tool?: boolean;
+  tool_description?: string | null;
+  sync_timeout_seconds?: number;
+  concurrency?: 'single' | 'parallel' | null;
+  disable_after_failures?: number | null;
+  output_mapping?: Record<string, any> | null;
+}
+
+export interface PipelineUpdate extends Partial<PipelineCreate> {
+  is_active?: boolean;
+}
+
+export interface PipelineRunStepSummary {
+  name: string;
+  type: string;
+  status: string;
+  startedAt?: string;
+  durationMs?: number;
+  executionId?: string;
+  chatId?: string;
+  error?: string;
+}
+
+export interface PipelineRun {
+  id: string;
+  run_id: string;
+  pipeline_id: string;
+  user_id: string;
+  trigger_type: string;
+  trigger_id?: string | null;
+  status: 'running' | 'succeeded' | 'failed' | 'timed_out' | string;
+  input?: Record<string, any> | null;
+  steps: PipelineRunStepSummary[];
+  error?: string | null;
+  cursor_before?: string | null;
+  cursor_after?: string | null;
+  started_at: string;
+  completed_at?: string | null;
+  duration_ms?: number | null;
+}
+
+export interface PipelineRunOutcome {
+  run_id: string;
+  status: string;
+  output?: any;
+  error?: string | null;
+  steps?: PipelineRunStepSummary[];
+  duration_ms?: number | null;
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -69,6 +69,14 @@ services:
     environment:
       FUNCTION_CONTAINER_IMAGE: sinas-executor
 
+  queue-pipeline:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    volumes:
+      - ./backend:/app
+      - file_storage:/var/sinas/files
+
   scheduler:
     build:
       context: ./backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,6 +265,38 @@ services:
     deploy:
       replicas: ${QUEUE_AGENT_SUB_REPLICAS:-2}
 
+  # Pipeline runner worker — own queue so long pipeline runs never starve
+  # function workers. Runs are await-heavy orchestration (high concurrency).
+  queue-pipeline:
+    image: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/backend:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    volumes:
+      - file_storage:/var/sinas/files
+    env_file:
+      - .env
+    environment:
+      DATABASE_USER: ${DATABASE_USER:-postgres}
+      DATABASE_HOST: pgbouncer
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: ${DATABASE_NAME:-sinas}
+      CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-clickhouse}
+      CLICKHOUSE_PORT: ${CLICKHOUSE_PORT:-8123}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+      CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-sinas}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set in .env file}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set in .env file}
+      DOCKER_NETWORK: ${DOCKER_NETWORK:-auto}
+    depends_on:
+      redis:
+        condition: service_healthy
+      pgbouncer:
+        condition: service_healthy
+    command: python -m arq app.queue.worker.PipelineWorkerSettings
+    deploy:
+      replicas: ${QUEUE_PIPELINE_REPLICAS:-1}
+
   scheduler:
     image: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/backend:${IMAGE_TAG:-latest}
     restart: unless-stopped

--- a/docs-mint/build-resources/pipelines.mdx
+++ b/docs-mint/build-resources/pipelines.mdx
@@ -115,6 +115,12 @@ Pipelines don't embed trigger config. Instead:
 
 - **Schedules**: `scheduleType: pipeline` + `pipelineName: ns/name` — the
   standard way to poll ("every 2 minutes, run the Gmail pipeline").
+- **Webhooks**: `targetType: pipeline` + `pipelineName` — the request payload
+  (merged over `defaultValues`) becomes the pipeline input, running as the
+  webhook's owner. `responseMode: sync` waits and returns
+  `{success, run_id, output}`; `async` returns `202 {run_id}`. `raw` stays
+  function-only. Webhook events are single occurrences, so perUser pipelines
+  do **not** fan out here — the event runs once, as the owner.
 - **Database triggers (CDC)**: `targetType: pipeline` + `pipelineName` — the
   changed rows become the pipeline input.
 - **Manual / API**:

--- a/docs-mint/build-resources/pipelines.mdx
+++ b/docs-mint/build-resources/pipelines.mdx
@@ -1,0 +1,156 @@
+---
+title: "Pipelines"
+description: "Linear typed step sequences: poll, transform, invoke agents, load data"
+---
+
+Pipelines are named, **linear** sequences of typed steps — deliberately not a DAG.
+They capture the recurring integration shape *poll or receive from a source →
+transform → optionally invoke an agent → act deterministically on its output*,
+as one declarative resource fired by the existing trigger resources (webhooks,
+schedules, database triggers) or invoked manually / as an agent tool.
+
+```yaml
+pipelines:
+  - namespace: gmail
+    name: inbox-triage
+    description: Poll Gmail history and triage new messages
+    perUser:
+      connector: google/gmail      # one run per connected user
+      disableAfterFailures: 5
+    steps:
+      - name: fetch
+        type: connector
+        connector: google/gmail
+        operation: list-history
+        input:
+          userId: me
+        cursor:
+          param: startHistoryId    # cursor injected here
+          path: body.historyId     # new high-water mark read here
+        retry: { maxAttempts: 3, backoff: exponential }
+
+      - name: extract
+        type: function
+        function: gmail/extract-messages
+        input.$: steps.fetch.output.body
+
+      - name: triage
+        type: agent
+        agent: gmail/triage
+        input.$: steps.extract.output
+
+      - name: land
+        type: load
+        connection: reporting
+        table: inbox_messages
+        primaryKey.$: item.id
+        items.$: steps.triage.output.messages
+```
+
+## Step types
+
+| Type | Executes | Output (in the run context) |
+|---|---|---|
+| `connector` | A connector operation in-process (auth incl. per-user OAuth, retries reused) | `{statusCode, body, elapsedMs}` — non-2xx fails the step unless listed in `allowStatuses` |
+| `function` | A function through the normal runtime | The function's return value |
+| `agent` | An agent with a fresh chat; the JSON reply is validated against the agent's `outputSchema` | Parsed structured output (or raw text without a schema) |
+| `query` | A saved query | `{rows, rowCount, affectedRows}` |
+| `load` | Idempotent JSONB upsert into a database connection | `{upserted, table}` |
+
+## Data mapping
+
+One convention everywhere, based on [JMESPath](https://jmespath.org):
+
+- `key: value` — literal, passed through.
+- `key.$: <expression>` — evaluated against the run context, bound to `key`.
+- A step's whole input can be one expression: `input.$: steps.fetch.output.body`.
+
+The run context:
+
+```json
+{
+  "input":  { },                        // trigger payload / tool args / run body
+  "steps":  { "fetch": { "output": … } },
+  "cursor": "…",                        // committed cursor for this run scope
+  "run":    { "id", "triggerType", "firedAt", "userId" }
+}
+```
+
+Missing paths resolve to `null`; invalid expressions are rejected when the
+pipeline is saved. The mapping layer is for projection and selection — real
+computation (format conversion, embeddings, MIME building) belongs in a
+`function` step.
+
+## Cursors and delivery semantics
+
+A step may declare `cursor: {param, path, initial?}`. The committed cursor is
+injected into the step's input and the new high-water mark is read from its
+output — but it **commits only when the whole run succeeds**. Failed runs hold
+the cursor, so the next firing re-reads from the same position: **at-least-once
+delivery**. This is safe because `load` steps are idempotent upserts; agent
+steps should tolerate occasional duplicate runs. An empty poll (cursor path
+resolves to `null`) leaves the bookmark unchanged.
+
+Runs are single-flight per pipeline (per user for `perUser` pipelines): a
+trigger firing during a run is coalesced into one follow-up run; manual sync
+runs return `409` instead of queueing. Cursor-less pipelines default to
+`concurrency: parallel`.
+
+## Per-user pipelines
+
+`perUser: {connector: ns/name}` fans a trigger firing out to **one run per
+connected user** — users with a stored OAuth token for the connector
+(`oauth2_authorization_code`), or a private Secret override for secret-based
+auth types. Each run executes as that user (their tokens, their permissions),
+with its own cursor and failure isolation: one user's revoked credential never
+blocks other users. With `disableAfterFailures: N`, a user is skipped after N
+consecutive failures until they reconnect or update their secret.
+
+`load` steps in perUser pipelines write a `user_id` column and upsert on
+`(user_id, pk)`, since source IDs are only unique per account.
+
+## Triggers and manual runs
+
+Pipelines don't embed trigger config. Instead:
+
+- **Schedules**: `scheduleType: pipeline` + `pipelineName: ns/name` — the
+  standard way to poll ("every 2 minutes, run the Gmail pipeline").
+- **Database triggers (CDC)**: `targetType: pipeline` + `pipelineName` — the
+  changed rows become the pipeline input.
+- **Manual / API**:
+
+```bash
+POST /pipelines/{ns}/{name}/run            # {"input": {...}, "mode": "sync"|"async"}
+GET  /pipelines/{ns}/{name}/runs           # run history (the dead-letter record)
+GET  /pipelines/runs/{run_id}
+POST /pipelines/runs/{run_id}/replay       # re-enqueue a failed run's stored input
+```
+
+Sync runs (and tool invocations) are bounded by `syncTimeoutSeconds` (default
+120). On timeout, completed steps have already had their side effects — the run
+record shows exactly which.
+
+## Pipelines as agent tools
+
+`asTool: true` (plus `inputSchema` and a description) exposes the pipeline as
+one semantic tool; agents opt in via `enabledPipelines: ["ns/name"]`. This
+replaces chains of individual tool calls — e.g. *embed the query text → run a
+vector query → shape the rows* becomes a single `pipeline_search__similar-docs`
+call. Keep agent steps out of `asTool` pipelines unless seconds-to-minutes of
+tool latency is acceptable.
+
+## Failure semantics
+
+- Per-step `retry: {maxAttempts, backoff}` (agent steps are never auto-retried).
+- The first step to exhaust retries fails the run; later steps are skipped and
+  the cursor is held.
+- The run record stores the input, per-step summaries (with linked execution or
+  chat IDs), and the error — replayable via the API.
+- `disableAfterFailures: N` at the pipeline level deactivates a persistently
+  failing shared pipeline; the perUser variant skips only the affected user.
+
+## Permissions
+
+`sinas.pipelines/{ns}/{name}` with actions `create/read/update/delete/run`.
+Users get `read:own` + `run:own` by default; creating and updating pipelines
+is admin-granted.

--- a/docs-mint/docs.json
+++ b/docs-mint/docs.json
@@ -38,6 +38,7 @@
               "build-resources/system-tools",
               "build-resources/functions",
               "build-resources/queries",
+              "build-resources/pipelines",
               "build-resources/connectors",
               "build-resources/skills",
               "build-resources/components",

--- a/docs-mint/triggers/database-triggers.mdx
+++ b/docs-mint/triggers/database-triggers.mdx
@@ -4,7 +4,7 @@ description: "Change data capture with polling"
 ---
 
 
-Database triggers watch external database tables for changes and automatically execute functions when new or updated rows are detected. This is poll-based Change Data Capture — no setup required on the source database.
+Database triggers watch external database tables for changes and automatically execute a function — or fire a pipeline — when new or updated rows are detected. This is poll-based Change Data Capture — no setup required on the source database.
 
 **How it works:**
 
@@ -23,7 +23,9 @@ Database triggers watch external database tables for changes and automatically e
 | `schema_name` | Database schema (default: `public`) |
 | `table_name` | Table to watch |
 | `operations` | `["INSERT"]`, `["UPDATE"]`, or both |
-| `function_namespace` / `function_name` | Function to execute when changes are detected |
+| `target_type` | `function` (default) or `pipeline` |
+| `function_namespace` / `function_name` | Function to execute (function targets) |
+| `pipeline_namespace` / `pipeline_name` | Pipeline to fire (pipeline targets) — the rows payload becomes the run input |
 | `poll_column` | Monotonically increasing column used as bookmark (e.g., `updated_at`, `id`) |
 | `poll_interval_seconds` | How often to poll (1–3600, default: `10`) |
 | `batch_size` | Max rows per poll (1–10000, default: `100`) |

--- a/docs-mint/triggers/schedules.mdx
+++ b/docs-mint/triggers/schedules.mdx
@@ -4,21 +4,23 @@ description: "Cron-based scheduled jobs"
 ---
 
 
-Schedules trigger functions or agents on a cron timer.
+Schedules trigger functions, agents, or pipelines on a cron timer.
 
 **Key properties:**
 
 | Property | Description |
 |---|---|
 | `name` | Unique name (per user) |
-| `schedule_type` | `function` or `agent` |
-| `target_namespace` / `target_name` | Function or agent to trigger |
+| `schedule_type` | `function`, `agent`, or `pipeline` |
+| `target_namespace` / `target_name` | Function, agent, or pipeline to trigger |
 | `cron_expression` | Standard cron expression (e.g., `0 9 * * MON-FRI`) |
 | `timezone` | Schedule timezone (default: `UTC`) |
 | `input_data` | Input passed to the function or agent |
 | `content` | Message content (agent schedules only) |
 
 For agent schedules, a new chat is created for each run with the schedule name and timestamp as the title.
+
+For pipeline schedules (`scheduleType: pipeline` + `pipelineName: ns/name` in YAML), the schedule fires the pipeline with `input_data` as the run input — the standard way to poll an external API on a cursor (see [Pipelines](/build-resources/pipelines)). A `perUser` pipeline fans out to one run per connected user.
 
 **Endpoints:**
 

--- a/docs-mint/triggers/webhooks.mdx
+++ b/docs-mint/triggers/webhooks.mdx
@@ -84,6 +84,25 @@ webhooks:
 
 Function-target webhooks in YAML are unchanged (`functionName: namespace/name`); `responseMode: raw` is available for them as well.
 
+## Pipeline targets
+
+A webhook can fire a [pipeline](/build-resources/pipelines): the request payload (merged over `defaultValues`) becomes the pipeline's run input, executed as the webhook's owner.
+
+- `sync` runs the pipeline inline (bounded by the pipeline's `syncTimeoutSeconds`) and returns `{"success": true, "run_id": ..., "output": ...}`; a failed run returns `500` with the `run_id` of the replayable run record
+- `async` returns `202` with `{"run_id": ...}` — use this for provider webhooks and slow pipelines (e.g. ones containing agent steps)
+- `raw` is not supported for pipeline targets
+- For authenticated webhooks the caller must own the webhook and hold `sinas.pipelines/{ns}/{name}.run`
+- A webhook event is a single occurrence, so `perUser` pipelines do **not** fan out here — that behavior belongs to schedules and manual `?allUsers=true` runs
+
+```yaml
+webhooks:
+  - path: crm/contact-updated
+    targetType: pipeline
+    pipelineName: crm/upsert-contact
+    responseMode: async
+    requiresAuth: false
+```
+
 **Example (function target):**
 
 ```bash


### PR DESCRIPTION
Implements the pipelines ADR (included: `backend/docs/adrs/2026-07-28-pipelines-triggers-and-linear-steps.md`): a new `pipelines` resource — a named **linear** sequence of typed steps (`connector` / `function` / `agent` / `query` / `load`), fired by the existing trigger resources, with platform-managed cursor state and optional exposure as an agent tool. Explicitly not a DAG; a `function` step is the escape hatch.

## Highlights

**One runner, two entry points.** `pipeline_runner.run_pipeline()` is awaited inline for tool-invoked and sync manual runs (bounded by `syncTimeoutSeconds`, default 120s), and wrapped in an arq job on a new dedicated queue `sinas:queue:pipelines` (own worker process + compose service, high concurrency since runs are await-heavy) for trigger-fired runs. Long pipeline runs can never starve function workers.

**Triggers stay separate resources.** Schedules (`scheduleType: pipeline`), webhooks (`targetType: pipeline` — composes with #111's agent targets; `sync`/`async`, `raw` stays function-only, no perUser fan-out from events), and CDC database triggers (`targetType: pipeline`) all fire the same pipeline. Manual runs / backfills via `POST /pipelines/{ns}/{name}/run` (+ runs list, run detail, `POST /pipelines/runs/{id}/replay`).

**Cursor = commit-on-success.** A step may declare `cursor: {param, path, initial}`; the new high-water mark commits only when the whole run succeeds — failed runs hold the bookmark (at-least-once, safe because `load` is an idempotent upsert). Deliberately different from CDC, which advances its bookmark at enqueue; documented in the ADR.

**Per-user runs.** `perUser: {connector: ns/name}` fans a trigger firing out to one run per connected user — enumerated from `connector_oauth_tokens` (authorization-code) or private Secret overrides (bearer/basic/api_key/client-credentials) — each executing as that user with their own cursor, single-flight lock, and failure counter in the new `pipeline_cursors` table. One user's revoked token never blocks others; `perUser.disableAfterFailures` skips a user until they re-credential (reset hooks wired into the OAuth callback and private-secret update).

**Failure semantics.** Per-step `retry: {maxAttempts, backoff}` (agent steps never auto-retried); first exhausted step fails the run, cursor held; `pipeline_runs` rows store input + per-step summaries + error and are the replayable dead-letter; optional `disableAfterFailures` auto-deactivates with `error_message` surfaced. Single-flight via Redis `SET NX` with coalesced fires (N fires during a run collapse to one follow-up); sync callers get 409.

**Data mapping.** JMESPath with AWS States-style `.$` keys (`startHistoryId.$: cursor`) used uniformly for step input, cursor path, load `items.$`/`primaryKey.$`, and final `output.$` shaping. Expressions compile at save/apply time. Steps are stored verbatim (camelCase, `.$` intact) — one representation across YAML/API/DB.

**Pipelines as tools.** `asTool: true` + `inputSchema` exposes a pipeline as one semantic tool (`enabledPipelines` on agents); agent steps inside tool-invoked pipelines are delegation-depth-checked, and function steps thread execution depth, so the #81/#90 deadlock and starvation protections apply unchanged.

**`load` sink.** Auto-created raw-JSONB table, transactional `INSERT ... ON CONFLICT DO UPDATE`; perUser pipelines write `user_id` with `PRIMARY KEY (user_id, pk)` (source IDs are only unique per account). Null PKs fail the step — rows are never silently dropped.

## Plumbing

- Migration `p1i2p3l4n5s6` (revises `w2a3b4t5g6t7`): `pipelines`, `pipeline_runs`, `pipeline_cursors`, `TriggerType.PIPELINE`, `agents.enabled_pipelines`, webhook + database-trigger pipeline target columns. Upgrade/downgrade/upgrade round-trip verified.
- Config round-trip: `PipelineConfig` (`output` / `output.$` via alias), apply (ordered after step-reference resources, before triggers), export/serializers, parser reference validation for schedule/webhook targets. Also fixes the parser's schedule validation, which previously required `functionName` on every schedule regardless of type.
- Permissions: `sinas.pipelines/...` with `create/read/update/delete/run`; default Users role gets `read:own` + `run:own`.
- Docs: `build-resources/pipelines.mdx`, schedules/webhooks/database-triggers pages, env vars (`QUEUE_PIPELINE_CONCURRENCY`, `PIPELINE_JOB_TIMEOUT`, `PIPELINE_RUN_RETENTION_DAYS` — retention janitor is a small follow-up).
- New dependency: `jmespath`.

## Verification

- 238 tests pass (39 pipeline-specific: mapping resolution, validation rules, cursor/injection helpers, model helpers, permission spellings, config round-trips incl. webhook target) against a from-scratch DB migrated through the full chain.
- Not yet done: live end-to-end run against a real provider (Gmail-shaped integration test is specced in the ADR), and the runner-latency measurement for the PR record — both flagged for follow-up.

## Deferred / follow-ups

- Pagination config on cursor steps (`paginate` is reserved and rejected at validation).
- `pipeline_runs` retention janitor; linking connector/query step outcomes as first-class execution rows.

- Parked from the superseded transforms brief (recorded in the ADR): connector-execute HTTP API escape hatch, JMESPath `outputFilter` on connector operations, embeddings API decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update:** console UI is now included (list, editor with JSON step editing, runs history with per-step summaries, manual run, replay).
