### PR TITLE
feat(auth): OIDC-compatible token verification — RS256, JWKS, userinfo

### DIFF
--- a/backend/alembic/versions/o1i2d3c4k5y6_jwt_signing_keys.py
+++ b/backend/alembic/versions/o1i2d3c4k5y6_jwt_signing_keys.py
@@ -1,0 +1,37 @@
+"""jwt_signing_keys table for RS256 auto-generated keypairs (#101)
+
+Revision ID: o1i2d3c4k5y6
+Revises: p1i2p3l4n5s6
+Create Date: 2026-08-10
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "o1i2d3c4k5y6"
+down_revision = "p1i2p3l4n5s6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jwt_signing_keys",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("purpose", sa.String(50), nullable=False, unique=True),
+        sa.Column("algorithm", sa.String(10), nullable=False),
+        sa.Column("kid", sa.String(100), nullable=False),
+        sa.Column("private_key_encrypted", sa.Text, nullable=False),
+        sa.Column("public_key_pem", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("jwt_signing_keys")

--- a/backend/app/api/runtime/__init__.py
+++ b/backend/app/api/runtime/__init__.py
@@ -1,7 +1,7 @@
 """Runtime API - Data Plane for execution, authentication, and runtime state."""
 from fastapi import APIRouter
 
-from app.api.runtime.endpoints import batches, manifests, authentication, chats, components, discovery, executions, files, functions, info, pipelines, queries, stores, templates, webhooks
+from app.api.runtime.endpoints import batches, manifests, authentication, chats, components, discovery, executions, files, functions, info, oidc, pipelines, queries, stores, templates, webhooks
 
 runtime_router = APIRouter()
 
@@ -11,6 +11,9 @@ runtime_router.include_router(info.router, tags=["runtime-info"])
 
 # Auth - OTP, tokens, API keys
 runtime_router.include_router(authentication.router, prefix="/auth", tags=["runtime-auth"])
+
+# OIDC-compatible verification - JWKS (root-level .well-known) + userinfo
+runtime_router.include_router(oidc.router, tags=["runtime-oidc"])
 
 # Chats - agent chat creation, message execution, and chat management
 runtime_router.include_router(chats.router, tags=["runtime-chats"])

--- a/backend/app/api/runtime/endpoints/components.py
+++ b/backend/app/api/runtime/endpoints/components.py
@@ -234,7 +234,7 @@ async def render_component(
         raise HTTPException(status_code=401, detail="Missing render token")
 
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid or expired render token")
 

--- a/backend/app/api/runtime/endpoints/files.py
+++ b/backend/app/api/runtime/endpoints/files.py
@@ -77,7 +77,7 @@ async def serve_file(
     The token contains the file_id, version, and expiry. No auth header needed.
     """
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid or expired file token")
 

--- a/backend/app/api/runtime/endpoints/oidc.py
+++ b/backend/app/api/runtime/endpoints/oidc.py
@@ -1,0 +1,81 @@
+"""OIDC-compatible verification endpoints: JWKS + userinfo (#101).
+
+Not a full OIDC IdP — no authorize/consent/client registration. Just enough
+for external resource servers to verify Sinas access tokens with standard
+JWT middleware: publish the RS256 public key set, and expose the user's
+claims under OIDC-standard names.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import set_permission_used, verify_jwt_or_api_key
+from app.core.database import get_db
+from app.core.token_signing import jwks
+from app.models import User
+from app.models.user import Role, UserRole
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/.well-known/jwks.json", include_in_schema=False)
+async def jwks_endpoint():
+    """Published signing keys (RFC 7517). Unauthenticated by design.
+
+    Only meaningful under JWT_ALGORITHM=RS256 — an HMAC secret must never be
+    published, so HS256 deployments get a 404 with a pointer instead of an
+    empty key set that standard libraries would treat as "no valid keys".
+    """
+    key_set = jwks()
+    if key_set is None:
+        raise HTTPException(
+            status_code=404,
+            detail="JWKS is only published when JWT_ALGORITHM=RS256",
+        )
+    return key_set
+
+
+async def _userinfo_claims(user_id: str, db: AsyncSession) -> dict:
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user or not user.is_active:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    roles_result = await db.execute(
+        select(Role.name)
+        .join(UserRole, UserRole.role_id == Role.id)
+        .where(UserRole.user_id == user.id, UserRole.active == True)
+    )
+
+    claims = {
+        "sub": str(user.id),
+        "email": user.email,
+        "roles": [r[0] for r in roles_result.all()],
+    }
+    # Org-specific profile data becomes plain claims, but must never shadow
+    # the standard ones — a custom field named "sub" would otherwise let a
+    # token-exchange partner rewrite the user's identity as seen downstream.
+    for key, value in (user.custom_fields or {}).items():
+        claims.setdefault(key, value)
+    return claims
+
+
+@router.get("/userinfo")
+@router.post("/userinfo")
+async def userinfo(
+    request: Request,
+    auth_data: tuple = Depends(verify_jwt_or_api_key),
+    db: AsyncSession = Depends(get_db),
+):
+    """OIDC-style userinfo: same data as /auth/me, standard claim names.
+
+    GET and POST both accepted per OIDC Core 5.3.1. Bearer token in the
+    Authorization header (API keys work too, like everywhere else).
+    """
+    user_id, _, _ = auth_data
+    set_permission_used(request, "sinas.users.read:own")
+    return await _userinfo_claims(user_id, db)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal, get_db
 from app.core.email import send_otp_email_async
+from app.core.token_signing import decode_access_token, get_signing_context
 from app.core.permissions import (
     DEFAULT_ROLE_PERMISSIONS,
     check_permission,
@@ -328,8 +329,17 @@ def create_access_token(
         # Absent on real user/app tokens (treated as top-level callers).
         to_encode["execution_depth"] = execution_depth
 
-    encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
-    return encoded_jwt
+    ctx = get_signing_context()
+    headers = None
+    if ctx.algorithm == "RS256":
+        # iss/aud only under RS256: adding them to HS256 tokens would break
+        # any existing consumer whose JWT library auto-verifies aud when the
+        # claim is present. kid lets JWKS verifiers pick the right key.
+        to_encode["iss"] = settings.token_issuer
+        to_encode["aud"] = settings.jwt_audience
+        headers = {"kid": ctx.kid}
+
+    return jwt.encode(to_encode, ctx.sign_key, algorithm=ctx.algorithm, headers=headers)
 
 
 def get_execution_depth_from_request(request) -> Optional[int]:
@@ -344,7 +354,7 @@ def get_execution_depth_from_request(request) -> Optional[int]:
         return None
     token = auth_header[7:].strip()
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        payload = decode_access_token(token)
     except Exception:
         return None
     depth = payload.get("execution_depth")
@@ -631,7 +641,7 @@ async def verify_jwt_or_api_key(
 
     # Try JWT first
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        payload = decode_access_token(token)
         user_id = payload.get("sub")
         email = payload.get("email")
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -45,7 +45,24 @@ class Settings(BaseSettings):
     # Application
     debug: bool = False
     secret_key: str = "your-secret-key-change-in-production"
+    # Deprecated: superseded by jwt_algorithm below. Kept so existing
+    # ALGORITHM=HS256 env entries don't fail settings validation; internal
+    # purpose tokens (file serve, component render) are pinned to HS256.
     algorithm: str = "HS256"
+    # Access-token signing (#101). Default HS256 keeps tokens verifiable
+    # exactly as before (shared secret_key). RS256 signs with an RSA keypair
+    # so external services can verify Sinas tokens offline with standard JWT
+    # middleware via GET /.well-known/jwks.json.
+    jwt_algorithm: str = "HS256"  # HS256 | RS256
+    # RS256 access tokens carry iss + aud claims. Issuer defaults to
+    # public_base_url (see token_issuer property).
+    jwt_issuer: str = ""
+    jwt_audience: str = "sinas"
+    # RS256 private key resolution order: JWT_PRIVATE_KEY (PEM content) →
+    # JWT_PRIVATE_KEY_FILE (path) → auto-generated and persisted encrypted in
+    # the database (shared by all processes).
+    jwt_private_key: str = ""
+    jwt_private_key_file: str = ""
     uvicorn_workers: int = 4  # Number of Uvicorn worker processes
     # JWT Token Configuration (Best Practice)
     access_token_expire_minutes: int = 15  # Short-lived access tokens
@@ -334,6 +351,11 @@ class Settings(BaseSettings):
         if not domain or domain.lower() in ("localhost", "127.0.0.1"):
             return f"http://localhost:{self.backend_port}"
         return f"https://{domain}"
+
+    @property
+    def token_issuer(self) -> str:
+        """`iss` claim on RS256 access tokens; what verifiers configure as issuer."""
+        return self.jwt_issuer.strip() or self.public_base_url
 
     # Component builder
     builder_url: str = "http://sinas-builder:3000"  # URL for esbuild compilation service

--- a/backend/app/core/token_signing.py
+++ b/backend/app/core/token_signing.py
@@ -1,0 +1,274 @@
+"""Access-token signing context: HS256 (default) or RS256 with published JWKS.
+
+HS256 keeps today's behavior byte-for-byte: tokens signed with the shared
+``secret_key``, no extra claims. RS256 (``JWT_ALGORITHM=RS256``) signs access
+tokens with an RSA keypair and adds ``iss``/``aud`` claims + a ``kid`` header,
+so any standard resource-server library can verify Sinas tokens offline via
+``GET /.well-known/jwks.json`` — no shared secret, no per-request introspection.
+
+Private key resolution order (RS256):
+  1. ``JWT_PRIVATE_KEY``       — PEM content in the environment
+  2. ``JWT_PRIVATE_KEY_FILE``  — path to a PEM file
+  3. auto-generated once and persisted (encrypted) in ``jwt_signing_keys`` so
+     every backend/worker/scheduler process signs and verifies with the same
+     key. Concurrent first boots race safely via ON CONFLICT DO NOTHING.
+
+Internal purpose tokens (file serve, component render, content refresh) are
+deliberately NOT part of this: they stay HS256 with ``secret_key`` — they are
+consumed only by Sinas itself and third parties should never verify them.
+"""
+
+import asyncio
+import base64
+import concurrent.futures
+import hashlib
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from jose import jwt
+from jose import jwk as jose_jwk
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Single row per purpose; today only access tokens have a managed keypair.
+_KEY_PURPOSE = "access-token"
+
+
+@dataclass(frozen=True)
+class SigningContext:
+    algorithm: str
+    sign_key: str  # HS256: shared secret; RS256: private PEM
+    verify_key: str  # HS256: shared secret; RS256: public PEM
+    kid: Optional[str] = None  # RS256 only
+    public_jwk: Optional[dict[str, Any]] = None  # RS256 only
+
+
+_context: Optional[SigningContext] = None
+_context_lock = threading.Lock()
+
+
+def reset_signing_context() -> None:
+    """Drop the cached context (tests / key rotation followed by restart)."""
+    global _context
+    with _context_lock:
+        _context = None
+
+
+def get_signing_context() -> SigningContext:
+    """Resolve (once per process) and return the signing context."""
+    global _context
+    if _context is not None:
+        return _context
+    with _context_lock:
+        if _context is None:
+            _context = _build_context()
+    return _context
+
+
+def decode_access_token(token: str) -> dict[str, Any]:
+    """Verify an access token with the configured algorithm.
+
+    Central choke point: under RS256 this also enforces ``aud`` and ``iss``,
+    which per-callsite ``jwt.decode`` calls would silently skip. Raises
+    ``jose.JWTError`` (or subclasses) on any failure, same contract callers
+    already handle.
+    """
+    ctx = get_signing_context()
+    if ctx.algorithm == "RS256":
+        return jwt.decode(
+            token,
+            ctx.verify_key,
+            algorithms=["RS256"],
+            audience=settings.jwt_audience,
+            issuer=settings.token_issuer,
+        )
+    return jwt.decode(token, ctx.verify_key, algorithms=[ctx.algorithm])
+
+
+def jwks() -> Optional[dict[str, Any]]:
+    """The published key set, or None when HS256 (nothing safe to publish)."""
+    ctx = get_signing_context()
+    if ctx.public_jwk is None:
+        return None
+    return {"keys": [ctx.public_jwk]}
+
+
+# ---------------------------------------------------------------------------
+# Context construction
+# ---------------------------------------------------------------------------
+
+
+def _build_context() -> SigningContext:
+    algorithm = settings.jwt_algorithm.strip().upper() or "HS256"
+
+    if algorithm == "HS256":
+        return SigningContext(
+            algorithm="HS256",
+            sign_key=settings.secret_key,
+            verify_key=settings.secret_key,
+        )
+
+    if algorithm != "RS256":
+        raise ValueError(
+            f"Unsupported JWT_ALGORITHM {algorithm!r} — use HS256 or RS256"
+        )
+
+    private_pem = _resolve_private_key()
+    public_pem = _public_pem_from_private(private_pem)
+    public_jwk = _public_jwk(public_pem)
+    kid = public_jwk["kid"]
+
+    logger.info(f"Access tokens signed with RS256 (kid={kid})")
+    return SigningContext(
+        algorithm="RS256",
+        sign_key=private_pem,
+        verify_key=public_pem,
+        kid=kid,
+        public_jwk=public_jwk,
+    )
+
+
+def _resolve_private_key() -> str:
+    if settings.jwt_private_key.strip():
+        # Env vars flatten newlines easily; accept literal "\n" sequences.
+        return settings.jwt_private_key.replace("\\n", "\n").strip() + "\n"
+
+    if settings.jwt_private_key_file.strip():
+        with open(settings.jwt_private_key_file.strip()) as f:
+            return f.read()
+
+    return _load_or_create_db_key_sync()
+
+
+def _generate_private_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+def _public_pem_from_private(private_pem: str) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    key = serialization.load_pem_private_key(private_pem.encode(), password=None)
+    return (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+
+def _public_jwk(public_pem: str) -> dict[str, Any]:
+    """Standard RSA JWK with an RFC 7638 thumbprint as the kid."""
+    jwk_dict = jose_jwk.construct(public_pem, "RS256").to_dict()
+    # RFC 7638: SHA-256 over the required members only, lexicographic order,
+    # no whitespace — gives a deterministic kid any tooling can reproduce.
+    canonical = json.dumps(
+        {"e": jwk_dict["e"], "kty": jwk_dict["kty"], "n": jwk_dict["n"]},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    thumbprint = base64.urlsafe_b64encode(
+        hashlib.sha256(canonical.encode()).digest()
+    ).rstrip(b"=").decode()
+    return {
+        "kty": jwk_dict["kty"],
+        "use": "sig",
+        "alg": "RS256",
+        "kid": thumbprint,
+        "n": jwk_dict["n"],
+        "e": jwk_dict["e"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# DB-persisted keypair (no env key provided)
+# ---------------------------------------------------------------------------
+
+
+def _load_or_create_db_key_sync() -> str:
+    """Run the async DB loader from sync code, whatever the calling context.
+
+    ``create_access_token`` is sync and called from inside running event loops
+    (request handlers, workers), where ``asyncio.run`` would fail — so the
+    loader always runs in a fresh loop on a dedicated thread. One-time cost
+    per process; the result is cached in the signing context.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(asyncio.run, _load_or_create_db_key()).result()
+
+
+async def _load_or_create_db_key() -> str:
+    import asyncpg
+
+    conn = await asyncpg.connect(
+        host=settings.database_host,
+        port=int(settings.database_port),
+        user=settings.database_user,
+        password=settings.database_password,
+        database=settings.database_name,
+    )
+    try:
+        return await load_or_create_db_key(conn)
+    finally:
+        await conn.close()
+
+
+async def load_or_create_db_key(conn) -> str:
+    """Load the persisted private key, generating it on first ever boot.
+
+    Takes an asyncpg connection so tests can supply their own. Concurrent
+    processes may both generate a candidate key; ON CONFLICT DO NOTHING +
+    re-select guarantees they all converge on whichever insert won.
+    """
+    import asyncpg
+
+    from app.core.encryption import encryption_service
+
+    try:
+        row = await conn.fetchrow(
+            "SELECT private_key_encrypted FROM jwt_signing_keys WHERE purpose = $1",
+            _KEY_PURPOSE,
+        )
+    except asyncpg.exceptions.UndefinedTableError:
+        raise RuntimeError(
+            "jwt_signing_keys table missing — run `alembic upgrade head` "
+            "before enabling JWT_ALGORITHM=RS256"
+        )
+
+    if row is None:
+        private_pem = _generate_private_pem()
+        public_pem = _public_pem_from_private(private_pem)
+        kid = _public_jwk(public_pem)["kid"]
+        await conn.execute(
+            """
+            INSERT INTO jwt_signing_keys
+                (purpose, algorithm, kid, private_key_encrypted, public_key_pem)
+            VALUES ($1, 'RS256', $2, $3, $4)
+            ON CONFLICT (purpose) DO NOTHING
+            """,
+            _KEY_PURPOSE,
+            kid,
+            encryption_service.encrypt(private_pem),
+            public_pem,
+        )
+        row = await conn.fetchrow(
+            "SELECT private_key_encrypted FROM jwt_signing_keys WHERE purpose = $1",
+            _KEY_PURPOSE,
+        )
+        logger.info("Generated and persisted RS256 signing keypair")
+
+    return encryption_service.decrypt(row["private_key_encrypted"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -23,6 +23,7 @@ from .pipeline import Pipeline, PipelineCursor, PipelineRun
 from .pending_delegation import PendingDelegation
 from .schedule import ScheduledJob
 from .secret import Secret
+from .signing_key import JWTSigningKey
 from .skill import Skill
 from .state import State
 from .store import Store
@@ -89,4 +90,5 @@ __all__ = [
     "ContentFilterEvaluation",
     "TableAnnotation",
     "ToolCallResult",
+    "JWTSigningKey",
 ]

--- a/backend/app/models/signing_key.py
+++ b/backend/app/models/signing_key.py
@@ -1,0 +1,27 @@
+"""Persisted JWT signing keypairs (RS256 auto-generated mode).
+
+One row per purpose; today only "access-token". Written once on first boot
+when JWT_ALGORITHM=RS256 and no key is supplied via env/file, then read by
+every process so they all sign and verify with the same key. Access happens
+via raw asyncpg in app.core.token_signing (sync-context loading); this model
+exists for schema completeness and admin introspection.
+"""
+from typing import Optional
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base, created_at, uuid_pk
+
+
+class JWTSigningKey(Base):
+    __tablename__ = "jwt_signing_keys"
+
+    id: Mapped[uuid_pk]
+    purpose: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    algorithm: Mapped[str] = mapped_column(String(10), nullable=False)
+    kid: Mapped[str] = mapped_column(String(100), nullable=False)
+    # PEM, encrypted with the platform ENCRYPTION_KEY (same as secrets)
+    private_key_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    public_key_pem: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[created_at]

--- a/backend/app/services/content_tokens.py
+++ b/backend/app/services/content_tokens.py
@@ -24,7 +24,9 @@ def generate_component_render_token(
         "purpose": "component_render",
         "exp": int((datetime.now(UTC) + timedelta(seconds=expires_in)).timestamp()),
     }
-    return jose_jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+    # Internal purpose tokens are pinned to HS256 regardless of JWT_ALGORITHM:
+    # only Sinas itself verifies them, so asymmetric signing buys nothing.
+    return jose_jwt.encode(payload, settings.secret_key, algorithm="HS256")
 
 
 def _refresh_file_serve_url(url: str) -> str | None:
@@ -37,7 +39,7 @@ def _refresh_file_serve_url(url: str) -> str | None:
         payload = jose_jwt.decode(
             token,
             settings.secret_key,
-            algorithms=[settings.algorithm],
+            algorithms=["HS256"],
             options={"verify_exp": False},
         )
         file_id = payload.get("file_id")
@@ -125,7 +127,7 @@ def refresh_component_render_tokens(
             payload = jose_jwt.decode(
                 token,
                 settings.secret_key,
-                algorithms=[settings.algorithm],
+                algorithms=["HS256"],
                 options={"verify_exp": False},
             )
             namespace = payload.get("namespace")

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -216,7 +216,7 @@ def generate_file_url(file_id: str, version: int, expires_in: int = 3600) -> str
         "purpose": "file_serve",
         "exp": int(expire.timestamp()),
     }
-    token = jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+    token = jwt.encode(payload, settings.secret_key, algorithm="HS256")
 
     domain = settings.domain
     if not domain or domain.lower() in ("localhost", "127.0.0.1"):

--- a/backend/tests/unit/test_oidc.py
+++ b/backend/tests/unit/test_oidc.py
@@ -1,0 +1,296 @@
+"""OIDC-compatible token verification (#101): RS256 signing, JWKS, userinfo.
+
+The signing context is cached per process, so every test that flips
+JWT_ALGORITHM goes through the `rs256` / `hs256` fixtures, which reset the
+cache on both entry and exit.
+"""
+
+import os
+import uuid
+
+import pytest
+from jose import jwt as jose_jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.token_signing import (
+    _generate_private_pem,
+    _public_jwk,
+    _public_pem_from_private,
+    decode_access_token,
+    get_signing_context,
+    jwks,
+    load_or_create_db_key,
+    reset_signing_context,
+)
+from tests.conftest import auth_headers, make_token
+
+# One keypair for the whole module — RSA generation is the slow part.
+_PRIVATE_PEM = _generate_private_pem()
+_PUBLIC_PEM = _public_pem_from_private(_PRIVATE_PEM)
+
+
+@pytest.fixture
+def rs256(monkeypatch):
+    monkeypatch.setattr(settings, "jwt_algorithm", "RS256")
+    monkeypatch.setattr(settings, "jwt_private_key", _PRIVATE_PEM)
+    reset_signing_context()
+    yield
+    reset_signing_context()
+
+
+@pytest.fixture
+def hs256():
+    reset_signing_context()
+    yield
+    reset_signing_context()
+
+
+# ---------------------------------------------------------------------------
+# HS256 default: byte-for-byte today's behavior
+# ---------------------------------------------------------------------------
+
+
+class TestHS256Default:
+    def test_token_has_no_oidc_claims(self, hs256):
+        """Adding aud to HS256 tokens would break existing consumers whose
+        JWT library auto-verifies aud whenever the claim is present."""
+        from app.core.auth import create_access_token
+
+        token = create_access_token(str(uuid.uuid4()), "u@example.com")
+        payload = decode_access_token(token)
+        assert "aud" not in payload
+        assert "iss" not in payload
+        assert jose_jwt.get_unverified_header(token) == {"alg": "HS256", "typ": "JWT"}
+
+    def test_jwks_is_none(self, hs256):
+        assert jwks() is None
+
+    async def test_jwks_endpoint_404(self, hs256, client):
+        resp = await client.get("/.well-known/jwks.json")
+        assert resp.status_code == 404
+        assert "RS256" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# RS256: mint, publish, verify offline
+# ---------------------------------------------------------------------------
+
+
+class TestRS256:
+    def test_token_carries_iss_aud_kid(self, rs256):
+        from app.core.auth import create_access_token
+
+        token = create_access_token(str(uuid.uuid4()), "u@example.com")
+        header = jose_jwt.get_unverified_header(token)
+        assert header["alg"] == "RS256"
+        assert header["kid"] == get_signing_context().kid
+
+        payload = decode_access_token(token)
+        assert payload["iss"] == settings.token_issuer
+        assert payload["aud"] == settings.jwt_audience
+
+    def test_third_party_verifies_with_jwks_only(self, rs256):
+        """The whole point: verification using nothing but the published JWK."""
+        from app.core.auth import create_access_token
+
+        user_id = str(uuid.uuid4())
+        token = create_access_token(user_id, "u@example.com")
+
+        key_set = jwks()
+        assert len(key_set["keys"]) == 1
+        payload = jose_jwt.decode(
+            token,
+            key_set["keys"][0],
+            algorithms=["RS256"],
+            audience=settings.jwt_audience,
+            issuer=settings.token_issuer,
+        )
+        assert payload["sub"] == user_id
+
+    def test_wrong_audience_rejected(self, rs256):
+        from app.core.auth import create_access_token
+
+        token = create_access_token(str(uuid.uuid4()), "u@example.com")
+        with pytest.raises(jose_jwt.JWTError):
+            jose_jwt.decode(
+                token,
+                jwks()["keys"][0],
+                algorithms=["RS256"],
+                audience="someone-else",
+                issuer=settings.token_issuer,
+            )
+
+    def test_hs256_token_rejected_under_rs256(self, rs256):
+        """A token forged with the (compromised or guessed) HMAC secret must
+        not pass once the deployment runs RS256 — no algorithm-confusion."""
+        forged = jose_jwt.encode(
+            {"sub": str(uuid.uuid4()), "email": "x@example.com"},
+            settings.secret_key,
+            algorithm="HS256",
+        )
+        with pytest.raises(jose_jwt.JWTError):
+            decode_access_token(forged)
+
+    def test_kid_is_rfc7638_thumbprint(self, rs256):
+        """Deterministic: same key → same kid, independently reproducible."""
+        import base64
+        import hashlib
+        import json
+
+        jwk_dict = _public_jwk(_PUBLIC_PEM)
+        canonical = json.dumps(
+            {"e": jwk_dict["e"], "kty": "RSA", "n": jwk_dict["n"]},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(canonical.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        assert jwk_dict["kid"] == expected
+
+    async def test_full_auth_path_accepts_rs256_token(self, rs256, client, test_user):
+        """verify_jwt_or_api_key (used by every endpoint) round-trips RS256."""
+        resp = await client.get("/auth/me", headers=auth_headers(test_user))
+        assert resp.status_code == 200
+        assert resp.json()["email"] == test_user.email
+
+    async def test_jwks_endpoint_serves_key(self, rs256, client):
+        resp = await client.get("/.well-known/jwks.json")
+        assert resp.status_code == 200
+        keys = resp.json()["keys"]
+        assert len(keys) == 1
+        assert keys[0]["kty"] == "RSA"
+        assert keys[0]["use"] == "sig"
+        assert set(keys[0]) >= {"kid", "n", "e", "alg"}
+
+    def test_private_key_file_source(self, tmp_path, monkeypatch):
+        keyfile = tmp_path / "jwt.pem"
+        keyfile.write_text(_PRIVATE_PEM)
+        monkeypatch.setattr(settings, "jwt_algorithm", "RS256")
+        monkeypatch.setattr(settings, "jwt_private_key", "")
+        monkeypatch.setattr(settings, "jwt_private_key_file", str(keyfile))
+        reset_signing_context()
+        try:
+            ctx = get_signing_context()
+            assert ctx.algorithm == "RS256"
+            assert ctx.kid == _public_jwk(_PUBLIC_PEM)["kid"]
+        finally:
+            reset_signing_context()
+
+    def test_unsupported_algorithm_rejected(self, monkeypatch):
+        monkeypatch.setattr(settings, "jwt_algorithm", "ES512")
+        reset_signing_context()
+        try:
+            with pytest.raises(ValueError, match="ES512"):
+                get_signing_context()
+        finally:
+            reset_signing_context()
+
+
+# ---------------------------------------------------------------------------
+# userinfo endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestUserinfo:
+    async def test_get_and_post_return_oidc_claims(self, client, db, test_user):
+        test_user.custom_fields = {"department": "engineering", "employee_id": 42}
+        await db.flush()
+
+        for method in ("get", "post"):
+            resp = await getattr(client, method)(
+                "/userinfo", headers=auth_headers(test_user)
+            )
+            assert resp.status_code == 200, resp.text
+            claims = resp.json()
+            assert claims["sub"] == str(test_user.id)
+            assert claims["email"] == test_user.email
+            assert isinstance(claims["roles"], list) and claims["roles"]
+            assert claims["department"] == "engineering"
+            assert claims["employee_id"] == 42
+
+    async def test_custom_fields_cannot_shadow_standard_claims(
+        self, client, db, test_user
+    ):
+        """A token-exchange partner writes custom_fields; a field named "sub"
+        must not let it rewrite the identity seen by downstream services."""
+        test_user.custom_fields = {"sub": "spoofed", "email": "spoofed@evil"}
+        await db.flush()
+
+        resp = await client.get("/userinfo", headers=auth_headers(test_user))
+        claims = resp.json()
+        assert claims["sub"] == str(test_user.id)
+        assert claims["email"] == test_user.email
+
+    async def test_requires_auth(self, client):
+        resp = await client.get("/userinfo")
+        assert resp.status_code in (401, 403)
+
+    async def test_works_under_rs256(self, rs256, client, test_user):
+        resp = await client.get("/userinfo", headers=auth_headers(test_user))
+        assert resp.status_code == 200
+        assert resp.json()["sub"] == str(test_user.id)
+
+
+# ---------------------------------------------------------------------------
+# DB-persisted keypair (no env key): load-or-create against the real table
+# ---------------------------------------------------------------------------
+
+
+class TestDBKeyPersistence:
+    @pytest.fixture
+    async def pg(self):
+        import asyncpg
+
+        conn = await asyncpg.connect(
+            host="localhost",
+            port=int(os.environ.get("TEST_DATABASE_PORT", "5433")),
+            user=settings.database_user,
+            password=settings.database_password,
+            database=settings.database_name,
+        )
+        # Isolate from any real persisted key, and clean up after ourselves.
+        await conn.execute("DELETE FROM jwt_signing_keys WHERE purpose = 'access-token'")
+        yield conn
+        await conn.execute("DELETE FROM jwt_signing_keys WHERE purpose = 'access-token'")
+        await conn.close()
+
+    async def test_first_boot_generates_then_reuses(self, pg):
+        pem1 = await load_or_create_db_key(pg)
+        pem2 = await load_or_create_db_key(pg)
+        assert pem1 == pem2
+        assert "PRIVATE KEY" in pem1
+
+        row = await pg.fetchrow(
+            "SELECT algorithm, kid, public_key_pem, private_key_encrypted "
+            "FROM jwt_signing_keys WHERE purpose = 'access-token'"
+        )
+        assert row["algorithm"] == "RS256"
+        assert row["kid"] == _public_jwk(row["public_key_pem"])["kid"]
+        # Never stored in the clear
+        assert "PRIVATE KEY" not in row["private_key_encrypted"]
+
+    async def test_concurrent_generation_converges(self, pg):
+        """Two processes racing on first boot must end up with the same key
+        (ON CONFLICT DO NOTHING + re-select)."""
+        import asyncpg
+
+        conn2 = await asyncpg.connect(
+            host="localhost",
+            port=int(os.environ.get("TEST_DATABASE_PORT", "5433")),
+            user=settings.database_user,
+            password=settings.database_password,
+            database=settings.database_name,
+        )
+        try:
+            import asyncio
+
+            pem_a, pem_b = await asyncio.gather(
+                load_or_create_db_key(pg), load_or_create_db_key(conn2)
+            )
+            assert pem_a == pem_b
+        finally:
+            await conn2.close()

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -123,6 +123,25 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
   value: {{ .Values.features.codeExecution | quote }}
 - name: BUILTIN_DATABASE_ENABLED
   value: {{ .Values.features.builtinDatabase | quote }}
+{{- with (.Values.jwt).algorithm }}
+- name: JWT_ALGORITHM
+  value: {{ . | quote }}
+{{- end }}
+{{- with (.Values.jwt).issuer }}
+- name: JWT_ISSUER
+  value: {{ . | quote }}
+{{- end }}
+{{- with (.Values.jwt).audience }}
+- name: JWT_AUDIENCE
+  value: {{ . | quote }}
+{{- end }}
+{{- if (.Values.jwt).existingSecret }}
+- name: JWT_PRIVATE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.jwt.existingSecret }}
+      key: {{ .Values.jwt.existingSecretKey | default "jwt-private-key" }}
+{{- end }}
 - name: BACKEND_PORT
   value: "8000"
 {{- with .Values.extraEnv }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -200,6 +200,22 @@ features:
   ## record untouched.
   builtinDatabase: true
 
+## Access-token signing (OIDC-compatible verification).
+## algorithm "RS256" signs access tokens with an RSA keypair and publishes the
+## public key at /.well-known/jwks.json so external services can verify Sinas
+## tokens offline with standard JWT middleware. Default "" keeps HS256.
+jwt:
+  algorithm: ""
+  ## Optional: bring your own RS256 private key via an existing Secret.
+  ## When unset, Sinas auto-generates a keypair on first boot and stores it
+  ## encrypted in the database (shared by all processes) — no key management
+  ## needed.
+  existingSecret: ""
+  existingSecretKey: "jwt-private-key"
+  ## iss / aud claims on RS256 tokens; issuer defaults to the instance URL.
+  issuer: ""
+  audience: ""
+
 ## Extra environment variables appended to every sinas service (backend,
 ## queue workers, scheduler, cdc-worker). Any backend Settings knob
 ## (app/core/config.py) can be set here without a chart change, e.g.:

--- a/docs-mint/docs.json
+++ b/docs-mint/docs.json
@@ -27,6 +27,7 @@
             "group": "Platform",
             "pages": [
               "platform/authentication",
+              "platform/verifying-tokens",
               "platform/rbac",
               "platform/api-overview",
               "platform/async-jobs"

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -22,6 +22,11 @@ description: "All configuration options"
 | `SUPERADMIN_PASSWORD` | _(none)_ | Seed password for the superadmin. Only used when `AUTH_MODE` includes `password`. Setting this and restarting acts as a password-reset escape hatch. |
 | `TOKEN_EXCHANGE_DEFAULT_ROLE` | `GuestUsers` | Role assigned to users auto-provisioned via `POST /auth/token/exchange`. See [Token Exchange](/platform/authentication#token-exchange-bring-your-own-auth). |
 | `OAUTH_BIND_BROWSER_SESSION` | `true` | Bind connector OAuth (authorization-code) flows to the browser that started them via an HttpOnly nonce cookie — prevents account-linking CSRF. Set `false` only for split-origin local dev (console and API on different ports); keep `true` in production. |
+| `JWT_ALGORITHM` | `HS256` | Access-token signing. `RS256` signs with an RSA keypair and publishes it at `/.well-known/jwks.json` so external services can verify tokens offline. See [Verifying Sinas Tokens](/platform/verifying-tokens). |
+| `JWT_ISSUER` | instance URL | `iss` claim on RS256 access tokens. |
+| `JWT_AUDIENCE` | `sinas` | `aud` claim on RS256 access tokens. |
+| `JWT_PRIVATE_KEY` | _(none)_ | RS256 private key as PEM content. When neither this nor `JWT_PRIVATE_KEY_FILE` is set, a keypair is auto-generated and stored encrypted in the database. |
+| `JWT_PRIVATE_KEY_FILE` | _(none)_ | RS256 private key as a file path. |
 
 ## SMTP
 

--- a/docs-mint/platform/authentication.mdx
+++ b/docs-mint/platform/authentication.mdx
@@ -109,4 +109,8 @@ Behavior details:
 
 The exchange endpoint trusts the caller to assert identities — treat keys with `sinas.auth.exchange:all` like any other admin credential.
 
+## Verifying Tokens From Your Own Services
+
+The reverse direction — your services validating Sinas tokens — works with standard JWT middleware once `JWT_ALGORITHM=RS256` is set: public keys at `/.well-known/jwks.json`, profile claims at `/userinfo`. See [Verifying Sinas Tokens](/platform/verifying-tokens).
+
 ---

--- a/docs-mint/platform/verifying-tokens.mdx
+++ b/docs-mint/platform/verifying-tokens.mdx
@@ -1,0 +1,140 @@
+---
+title: "Verifying Sinas Tokens"
+description: "Let your own services verify Sinas access tokens offline with standard JWT middleware"
+---
+
+When you build services next to Sinas — an internal API, a partner backend, a gateway — those services often receive Sinas access tokens and need to answer one question: *is this token valid, and who is it for?*
+
+By default Sinas signs access tokens with a symmetric secret (`HS256`), which only Sinas itself can verify. Switch to asymmetric signing and any standard JWT library can verify tokens offline — no shared secret, no per-request call back to Sinas:
+
+```bash
+JWT_ALGORITHM=RS256
+```
+
+That's the only required change. On first boot Sinas generates an RSA keypair and persists it (encrypted) in its database, so every backend, worker, and scheduler process signs with the same key. To bring your own key instead:
+
+```bash
+JWT_PRIVATE_KEY_FILE=/etc/sinas/jwt-private.pem   # path to a PKCS8 PEM
+# or inline:
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n..."
+```
+
+Generate one with `openssl genpkey -algorithm RSA -pkcs8 -out jwt-private.pem`.
+
+<Warning>
+Switching the algorithm invalidates in-flight access tokens. They live 15 minutes by default, and clients refresh automatically — logged-in users won't notice beyond one transparent refresh.
+</Warning>
+
+## What changes with RS256
+
+Access tokens gain the standard verification claims plus a key id header:
+
+| | HS256 (default) | RS256 |
+|---|---|---|
+| Signature | `SECRET_KEY` (symmetric) | RSA private key |
+| `iss` claim | — | `JWT_ISSUER` (defaults to your instance URL) |
+| `aud` claim | — | `JWT_AUDIENCE` (defaults to `sinas`) |
+| Public keys | not published | `GET /.well-known/jwks.json` |
+
+The JWKS endpoint is unauthenticated (public keys are public) and the `kid` in each token's header matches the published key, so libraries pick the right key automatically.
+
+## Verifying from your service
+
+Point your JWT middleware at the JWKS URL and check issuer + audience. No Sinas SDK needed.
+
+### FastAPI / Python
+
+```python
+import jwt  # PyJWT
+from jwt import PyJWKClient
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+SINAS_URL = "https://sinas.your-org.com"
+jwks_client = PyJWKClient(f"{SINAS_URL}/.well-known/jwks.json")
+
+app = FastAPI()
+bearer = HTTPBearer()
+
+def current_user(creds: HTTPAuthorizationCredentials = Depends(bearer)) -> dict:
+    try:
+        key = jwks_client.get_signing_key_from_jwt(creds.credentials)
+        return jwt.decode(
+            creds.credentials,
+            key.key,
+            algorithms=["RS256"],
+            audience="sinas",
+            issuer=SINAS_URL,
+        )
+    except jwt.PyJWTError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+@app.get("/reports")
+def reports(user: dict = Depends(current_user)):
+    return {"for_user": user["sub"], "email": user["email"]}
+```
+
+### Express / Node
+
+```javascript
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const SINAS_URL = "https://sinas.your-org.com";
+const jwks = createRemoteJWKSet(new URL(`${SINAS_URL}/.well-known/jwks.json`));
+
+async function requireUser(req, res, next) {
+  const token = (req.headers.authorization ?? "").replace(/^Bearer /, "");
+  try {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: SINAS_URL,
+      audience: "sinas",
+    });
+    req.user = payload; // { sub, email, iss, aud, exp, ... }
+    next();
+  } catch {
+    res.status(401).json({ error: "invalid token" });
+  }
+}
+
+app.get("/reports", requireUser, (req, res) => {
+  res.json({ forUser: req.user.sub, email: req.user.email });
+});
+```
+
+Both libraries cache the JWKS response, so verification is a local signature check on the hot path.
+
+## Getting user profile data
+
+The token proves identity; for profile data there's an OIDC-style userinfo endpoint (works under both algorithms):
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" https://sinas.your-org.com/userinfo
+```
+
+```json
+{
+  "sub": "7c9e6679-7425-40de-963d-02d1102e0d13",
+  "email": "jane@acme.com",
+  "roles": ["Users"],
+  "department": "engineering",
+  "plan": "enterprise"
+}
+```
+
+`sub`, `email`, and `roles` are always present. Every entry in the user's [custom fields](/admin/users-roles) appears as a plain claim — set by admins or by your backend during [token exchange](/platform/authentication#token-exchange-bring-your-own-auth) — so downstream services can authorize on org-specific attributes without extra lookups. Custom fields can never shadow the standard claims.
+
+## Configuration reference
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `JWT_ALGORITHM` | `HS256` | `RS256` enables asymmetric signing + JWKS |
+| `JWT_ISSUER` | instance URL | `iss` claim on RS256 tokens |
+| `JWT_AUDIENCE` | `sinas` | `aud` claim on RS256 tokens |
+| `JWT_PRIVATE_KEY` | — | RS256 private key as PEM content |
+| `JWT_PRIVATE_KEY_FILE` | — | RS256 private key as a file path |
+
+Key resolution order: `JWT_PRIVATE_KEY` → `JWT_PRIVATE_KEY_FILE` → auto-generated and stored encrypted in the database.
+
+## What this is not
+
+Sinas is not a full OIDC identity provider — there is no `/authorize`, consent, or dynamic client registration. If your organization runs Keycloak, Authentik, or another IdP, keep it as the source of truth and use [token exchange](/platform/authentication#token-exchange-bring-your-own-auth) to bring those users into Sinas instead.


### PR DESCRIPTION
Closes #101.

External services can verify Sinas access tokens with standard OIDC/JWT tooling — no shared HS256 secret, no per-request `/auth/me` introspection.

## What's in

**RS256 signing option** — `JWT_ALGORITHM=RS256` (default stays `HS256`, byte-for-byte today's tokens). RS256 access tokens gain `iss` (instance URL, overridable via `JWT_ISSUER`), `aud` (`JWT_AUDIENCE`, default `sinas`), and a `kid` header. HS256 tokens deliberately gain **no** new claims: adding `aud` would break any existing consumer whose JWT library auto-verifies it when the claim is present.

**Key management** — resolution order: `JWT_PRIVATE_KEY` (PEM) → `JWT_PRIVATE_KEY_FILE` → auto-generated on first boot and persisted **encrypted** in a new `jwt_signing_keys` table, so backend/workers/scheduler all sign with the same key. Concurrent first boots converge via `ON CONFLICT DO NOTHING` + re-select. The one-time DB load runs on a dedicated thread so sync `create_access_token` callers inside running event loops don't need signature changes. `kid` is the RFC 7638 thumbprint (independently reproducible).

**`GET /.well-known/jwks.json`** — unauthenticated, root level. 404 under HS256: an HMAC secret must never be published, and an empty key set would read as "no valid keys" to standard libraries.

**`GET|POST /userinfo`** — OIDC-standard claims (`sub`, `email`, `roles`, custom fields as plain claims), same data as `/auth/me`. Custom fields can never shadow the standard claims — a token-exchange partner writing `custom_fields: {"sub": ...}` must not rewrite the identity seen downstream.

**Hardening along the way**
- `decode_access_token()` is now the single verify choke point: under RS256 it enforces `aud`+`iss` (per-callsite `jwt.decode` calls silently skip both) and rejects HS256-signed tokens → no algorithm-confusion path via a leaked/guessed `SECRET_KEY`.
- Internal purpose tokens (file serve, component render, content refresh) pinned to HS256 — only Sinas verifies them, and they keep working regardless of `JWT_ALGORITHM` (previously `ALGORITHM=RS256` would have broken file serving).

**Helm** — `jwt.algorithm`, `jwt.existingSecret`/`existingSecretKey`, `jwt.issuer`, `jwt.audience` (default render unchanged).

**Docs** — new [Verifying Sinas Tokens] page with PyJWT/FastAPI and jose/Express examples, env-var reference, and a note in the auth page.

## Not in (per issue non-goals)
No `/authorize`, consent, or client registration — Keycloak/Authentik shops keep their IdP and use token exchange (#93).

## Tests
`tests/unit/test_oidc.py` (18): HS256 default unchanged (no aud/iss, jwks 404) · RS256 mint→verify offline with published JWK only · wrong-audience rejected · HS256-forged token rejected under RS256 · kid = RFC 7638 thumbprint · full auth path (`/auth/me`) with RS256 token · JWKS endpoint shape · key-from-file · unsupported algorithm rejected · userinfo GET+POST claims incl. custom fields · claim-shadowing blocked · unauthenticated 401 · DB persistence: generate-then-reuse, encrypted at rest, concurrent generation converges.

Full unit suite: 274 passed, 7 pre-existing failures (`test_auth.py` Redis connection errors — fail identically on clean dev, local-env only).

## Ops notes
- Migration `o1i2d3c4k5y6` (new table only, no data changes).
- Switching algorithms invalidates in-flight access tokens (≤15 min, clients auto-refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)