### PR TITLE
feat(ops): operations metering — counted ops, durable snapshots, cumulative push

### DIFF
--- a/backend/alembic/versions/u1s2a3g4e5p6_usage_periods.py
+++ b/backend/alembic/versions/u1s2a3g4e5p6_usage_periods.py
@@ -1,0 +1,44 @@
+"""usage_periods table for operations metering
+
+Revision ID: u1s2a3g4e5p6
+Revises: o1i2d3c4k5y6
+Create Date: 2026-08-10
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "u1s2a3g4e5p6"
+down_revision = "o1i2d3c4k5y6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "usage_periods",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("instance_id", sa.String(255), nullable=False),
+        sa.Column("period_id", sa.String(20), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("total", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("by_kind", sa.JSON, nullable=False, server_default="{}"),
+        sa.Column("last_op_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("snapshot_seq", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("reported_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "uq_usage_periods_instance_period",
+        "usage_periods",
+        ["instance_id", "period_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_usage_periods_instance_period", table_name="usage_periods")
+    op.drop_table("usage_periods")

--- a/backend/app/api/runtime/endpoints/files.py
+++ b/backend/app/api/runtime/endpoints/files.py
@@ -246,6 +246,11 @@ async def upload_file(
         raise HTTPException(status_code=403, detail="Not authorized to upload files to this collection")
     set_permission_used(http_request, perm)
 
+    # Metering leaf: one op per authorized file upload
+    from app.services import metering
+
+    await metering.record(metering.OperationKind.UPLOAD)
+
     # Get or create collection
     coll = await Collection.get_by_name(db, namespace, collection)
     if not coll:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -114,7 +114,12 @@ class Settings(BaseSettings):
     #     "disabled"         — sandbox features rejected; deploy is trusted-only
     # - trusted_executor: backend for admin-approved code (Function.shared_pool=True).
     #     "docker_shared" — dedicated long-lived Docker workers (current default)
-    #     "inprocess"     — run inside the calling process; no Docker socket needed
+    #     "k8s_shared"    — dedicated long-lived k8s pods (for k8s deploys;
+    #                       credential-free, meter-integrity safe)
+    #     "inprocess"     — run inside the calling process; no Docker socket
+    #                       needed. NOT meter-integrity safe: trusted code runs
+    #                       in a credential-bearing process.
+    #     "disabled"      — shared_pool executions rejected with a clear error
     sandbox_executor: str = "docker_pool"
     trusted_executor: str = "docker_shared"
 
@@ -147,6 +152,8 @@ class Settings(BaseSettings):
     # All empty/no-op by default — matches today's behavior on generic
     # clusters with no per-client scheduling policy.
     k8s_release_name: str = ""
+    # k8s_shared trusted executor: number of warm trusted worker pods.
+    k8s_trusted_workers: int = 2
     k8s_sandbox_node_selector: str = "{}"  # JSON object, e.g. {"role": "shared"}
     k8s_sandbox_tolerations: str = "[]"  # JSON list of Toleration dicts
     k8s_sandbox_affinity: str = "{}"  # JSON k8s Affinity object (podAffinity/podAntiAffinity/nodeAffinity)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -357,6 +357,19 @@ class Settings(BaseSettings):
         """`iss` claim on RS256 access tokens; what verifiers configure as issuer."""
         return self.jwt_issuer.strip() or self.public_base_url
 
+    # Operations metering (managed SaaS). Default-off; when enabled, every
+    # operation (function/code/query/agent/upload/tool) increments a Redis
+    # counter, the scheduler snapshots it to usage_periods, and a heartbeat
+    # pushes the CUMULATIVE period total to metering_endpoint. Pure emission:
+    # nothing is enforced on the instance and nothing is pulled down. A dead
+    # endpoint or Redis blip never affects platform behavior.
+    metering_enabled: bool = False
+    metering_endpoint: str = ""  # e.g. https://ops.example.com/v1/usage
+    metering_api_key: str = ""  # sent as Authorization: Bearer <key>
+    metering_instance_id: str = ""  # defaults to `domain`; set explicitly in SaaS
+    metering_snapshot_minutes: int = 5  # Redis -> usage_periods cadence
+    metering_push_minutes: int = 15  # heartbeat cadence (jittered per instance)
+
     # Component builder
     builder_url: str = "http://sinas-builder:3000"  # URL for esbuild compilation service
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -30,6 +30,7 @@ from .store import Store
 from .table_annotation import TableAnnotation
 from .template import Template
 from .tool_call_result import ToolCallResult
+from .usage import UsagePeriod
 from .user import (
     APIKey,
     OTPSession,
@@ -91,4 +92,5 @@ __all__ = [
     "TableAnnotation",
     "ToolCallResult",
     "JWTSigningKey",
+    "UsagePeriod",
 ]

--- a/backend/app/models/usage.py
+++ b/backend/app/models/usage.py
@@ -1,0 +1,40 @@
+"""Durable usage snapshots for operations metering.
+
+One row per (instance_id, period_id), upserted by the scheduler snapshot job
+from the live Redis counters. Redis is the authoritative live counter; this
+row is the crash-recovery record (Redis is re-seeded from it on startup) and
+the source for the cumulative heartbeat pushed to the platform.
+"""
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import JSON, BigInteger, DateTime, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base, created_at, updated_at, uuid_pk
+
+
+class UsagePeriod(Base):
+    __tablename__ = "usage_periods"
+
+    id: Mapped[uuid_pk]
+    instance_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    period_id: Mapped[str] = mapped_column(String(20), nullable=False)  # e.g. "2026-08"
+    period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    total: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    by_kind: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    last_op_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Incremented per push; part of the Idempotency-Key and the platform's
+    # monotonicity backstop (a decreasing seq or total flags tampering).
+    snapshot_seq: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    reported_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    created_at: Mapped[created_at]
+    updated_at: Mapped[updated_at]
+
+    __table_args__ = (
+        Index("uq_usage_periods_instance_period", "instance_id", "period_id", unique=True),
+    )

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -284,6 +284,14 @@ async def main() -> None:
         # --- Shared containers ---
         if settings.trusted_executor == "docker_shared":
             await shared_worker_manager.initialize()
+        elif settings.trusted_executor == "k8s_shared":
+            # Pre-warm the trusted worker pods so the first shared-pool
+            # execution doesn't pay a pod cold-start (dispatch self-heals
+            # missing pods, so this is latency, not correctness).
+            from app.services.executor.k8s_shared_trusted import ensure_trusted_pool
+
+            async with AsyncSessionLocal() as db:
+                await ensure_trusted_pool(db)
 
     # --- APScheduler ---
     await scheduler.start()

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -312,6 +312,65 @@ async def main() -> None:
     )
     logger.info("Registered system job: maintain_tool_result_partitions (every 24h)")
 
+    # --- Operations metering (managed SaaS, default-off) ---
+    if settings.metering_enabled:
+        from datetime import UTC as _UTC
+        from datetime import datetime as _dt
+        from datetime import timedelta as _td
+
+        from app.services import metering
+        from app.services.metering import (
+            push_jitter_seconds,
+            run_push_cycle,
+            run_snapshot_cycle,
+            seed_redis_from_db,
+        )
+
+        if settings.trusted_executor == "inprocess":
+            # §6 invariant: no process that runs client code may hold meter
+            # write access. inprocess runs trusted functions inside THIS
+            # credential-bearing process, so the count is forgeable. Managed
+            # instances must use docker_shared.
+            logger.warning(
+                "METERING_ENABLED with TRUSTED_EXECUTOR=inprocess: trusted "
+                "functions run inside a credential-bearing process, so the "
+                "meter is NOT tamper-resistant. Use docker_shared for "
+                "billable instances."
+            )
+
+        # Restore the live counter after a Redis restart (max of both sides)
+        async with AsyncSessionLocal() as db:
+            await seed_redis_from_db(db)
+
+        snap_min = max(1, settings.metering_snapshot_minutes)
+        scheduler.scheduler.add_job(
+            func=run_snapshot_cycle,
+            trigger="interval",
+            minutes=snap_min,
+            id="system:metering_snapshot",
+            name="Snapshot usage counters",
+            replace_existing=True,
+        )
+
+        # Per-instance start offset + trigger jitter so a fleet of instances
+        # never pushes in sync (design doc §5a).
+        push_min = max(1, settings.metering_push_minutes)
+        offset = push_jitter_seconds(push_min)
+        scheduler.scheduler.add_job(
+            func=run_push_cycle,
+            trigger="interval",
+            minutes=push_min,
+            jitter=30,
+            start_date=_dt.now(_UTC) + _td(seconds=offset),
+            id="system:metering_push",
+            name="Push usage heartbeat",
+            replace_existing=True,
+        )
+        logger.info(
+            f"Registered metering jobs: snapshot every {snap_min}m, push every "
+            f"{push_min}m (start offset {offset}s, instance={metering.instance_id()})"
+        )
+
     # --- Pub/sub listener for live job changes ---
     stop_event = asyncio.Event()
     listener_task = asyncio.create_task(_listen_for_job_changes(stop_event))

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -99,6 +99,11 @@ async def execute(
     effective_timeout = timeout or settings.code_execution_timeout
     execution_id = str(uuid.uuid4())
 
+    # Metering leaf: one op per codeExecution tool call
+    from app.services import metering
+
+    await metering.record(metering.OperationKind.CODE)
+
     if not settings.code_execution_enabled:
         # Belt and braces: the tool isn't advertised when disabled, but a model
         # can still emit a call for a tool it saw earlier in the conversation.

--- a/backend/app/services/database_pool.py
+++ b/backend/app/services/database_pool.py
@@ -129,6 +129,11 @@ class DatabasePoolManager:
 
         Converts :param_name syntax to $N positional params for asyncpg.
         """
+        # Metering leaf: the single path for agent-tool AND runtime-API queries
+        from app.services import metering
+
+        await metering.record(metering.OperationKind.QUERY)
+
         pool = await self.get_pool(db, connection_id)
 
         # Convert :param_name to $N positional params

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -111,12 +111,13 @@ class FunctionExecutor:
         # Executor selection is delegated to `app.services.executor.factory`,
         # which resolves the configured impls from settings. We cache the
         # resolved handles per-instance to avoid the factory call per
-        # execution. The sandbox handle is `None` when sandbox execution is
-        # disabled in this deployment; trusted is always required (it backs
-        # the admin-approved Function.shared_pool path).
+        # execution. Either handle is `None` when that execution class is
+        # disabled in this deployment (sandbox_executor / trusted_executor
+        # = "disabled").
         self._sandbox_executor = None
         self._sandbox_executor_resolved = False
         self._trusted_executor = None
+        self._trusted_executor_resolved = False
 
     @property
     def sandbox_executor(self):
@@ -135,11 +136,13 @@ class FunctionExecutor:
 
     @property
     def trusted_executor(self):
-        """Resolved TrustedExecutor for admin-approved `Function.shared_pool` code."""
-        if self._trusted_executor is None:
+        """Resolved TrustedExecutor for admin-approved `Function.shared_pool`
+        code (or None if disabled — callers must surface a clear error)."""
+        if not self._trusted_executor_resolved:
             from app.services.executor import get_trusted_executor
 
             self._trusted_executor = get_trusted_executor()
+            self._trusted_executor_resolved = True
         return self._trusted_executor
 
     async def validate_schema(self, data: Any, schema: dict[str, Any]) -> Any:
@@ -177,6 +180,13 @@ class FunctionExecutor:
         Workers are separate containers from backend but shared across users.
         No per-user isolation - functions must be trusted.
         """
+        if self.trusted_executor is None:
+            raise FunctionExecutionError(
+                f"Trusted (shared-pool) execution is disabled on this deployment "
+                f"(trusted_executor='disabled'); cannot run "
+                f"{function.namespace}/{function.name}. Either enable a trusted "
+                f"executor or clear the function's shared_pool flag."
+            )
         exec_result = await self.trusted_executor.execute(
             user_id=user_id,
             user_email=user_email,
@@ -542,7 +552,10 @@ class FunctionExecutor:
             executor = self.sandbox_executor if role == "sandbox" else self.trusted_executor
             if executor is None:
                 execution.status = ExecutionStatus.FAILED
-                execution.error = "Sandbox execution is disabled; cannot resume this execution."
+                execution.error = (
+                    f"{role.capitalize()} execution is disabled; "
+                    f"cannot resume this execution."
+                )
                 execution.completed_at = datetime.utcnow()
                 await db.commit()
                 raise FunctionExecutionError(execution.error)

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -256,6 +256,10 @@ class FunctionExecutor:
                 "Function execution is disabled on this deployment "
                 "(CODE_EXECUTION_ENABLED=false)."
             )
+        # Metering leaf: one op per function execution, whatever triggered it
+        from app.services import metering
+
+        await metering.record(metering.OperationKind.FUNCTION)
         async with AsyncSessionLocal() as db:
             # Get user info for context
             from app.core.auth import create_access_token

--- a/backend/app/services/executor/factory.py
+++ b/backend/app/services/executor/factory.py
@@ -52,8 +52,14 @@ def get_sandbox_executor() -> SandboxExecutor | None:
 
 
 @lru_cache(maxsize=1)
-def get_trusted_executor() -> TrustedExecutor:
-    """Return the configured trusted executor."""
+def get_trusted_executor() -> TrustedExecutor | None:
+    """Return the configured trusted executor, or None when disabled.
+
+    When `None` is returned, callers must reject `Function.shared_pool`
+    executions with a clear error — no silent fallback to the sandbox
+    (sandbox pods are network-isolated, so trusted functions would break
+    there in confusing ways rather than obviously).
+    """
     mode = settings.trusted_executor
 
     if mode == "docker_shared":
@@ -63,10 +69,18 @@ def get_trusted_executor() -> TrustedExecutor:
 
         return DockerSharedTrustedExecutor()
 
+    if mode == "k8s_shared":
+        from app.services.executor.k8s_shared_trusted import K8sSharedTrustedExecutor
+
+        return K8sSharedTrustedExecutor()
+
     if mode == "inprocess":
         from app.services.executor.inprocess_trusted import InProcessTrustedExecutor
 
         return InProcessTrustedExecutor()
+
+    if mode == "disabled":
+        return None
 
     raise ValueError(f"Unknown trusted_executor mode: {mode!r}")
 

--- a/backend/app/services/executor/k8s_shared_trusted.py
+++ b/backend/app/services/executor/k8s_shared_trusted.py
@@ -1,0 +1,390 @@
+"""TrustedExecutor: warm, long-lived Kubernetes pods for shared-pool code.
+
+The k8s-native sibling of `DockerSharedTrustedExecutor`. Trusted
+(admin-approved, `Function.shared_pool=True`) code runs in a small fleet of
+persistent pods created from the executor image in shared-worker mode, and
+work is dispatched over the same request/trigger/result-file exec IPC the
+k8s sandbox pods use — so per-call latency is an exec round-trip against a
+warm pod, not a pod cold-start.
+
+Meter integrity: these pods receive no environment beyond WORKER_MODE /
+WORKER_ID (no REDIS_URL, no DATABASE_URL, no ENCRYPTION_KEY), and
+`automountServiceAccountToken: false`, so trusted code cannot reach the
+usage meter — the property `TRUSTED_EXECUTOR=inprocess` cannot provide.
+The chart pairs this with a NetworkPolicy (label
+`sinas.type=trusted-executor`) allowing egress to the internet and the
+backend API but not to Postgres/Redis/ClickHouse.
+
+Pods have deterministic names ({prefix}-trusted-worker-N), so every platform
+process can dispatch without shared discovery state, and a missing or dead
+pod is recreated on demand by whoever notices first (create conflicts are
+benign). The scheduler pre-warms the fleet at startup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import replace
+from itertools import count
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.services.executor.base import ExecutionResult, ResultStatus
+
+logger = logging.getLogger(__name__)
+
+_POD_LABELS = {"sinas.type": "trusted-executor"}
+_DEPS_INSTALL_TIMEOUT = 300
+
+# Process-wide round-robin cursor; purely a load-spreading hint.
+_rr = count()
+
+
+def _pod_names() -> list[str]:
+    prefix = settings.k8s_release_name or "sinas"
+    n = max(1, settings.k8s_trusted_workers)
+    return [f"{prefix}-trusted-worker-{i}" for i in range(n)]
+
+
+def _manifest(name: str, image: str, worker_id: str) -> dict[str, Any]:
+    """Long-lived trusted worker pod.
+
+    Same hardening as the sandbox manifest (non-root-ish, caps dropped,
+    seccomp, no SA token) minus the parts that only make sense for
+    single-use pods (activeDeadlineSeconds, restartPolicy=Never). Resources
+    mirror the Docker shared workers (1Gi / 1 CPU).
+    """
+    from app.services.executor._k8s_runtime import _k8s_quantity
+
+    spec: dict[str, Any] = {
+        "restartPolicy": "Always",
+        "automountServiceAccountToken": False,
+        "containers": [
+            {
+                "name": "executor",
+                "image": image,
+                "imagePullPolicy": "IfNotPresent",
+                "env": [
+                    {"name": "PYTHONUNBUFFERED", "value": "1"},
+                    {"name": "WORKER_MODE", "value": "true"},
+                    {"name": "WORKER_ID", "value": worker_id},
+                    {"name": "SINAS_CONTAINER_MODE", "value": "shared"},
+                ],
+                "resources": {
+                    "requests": {"memory": "512Mi", "cpu": "250m"},
+                    "limits": {
+                        "memory": "1Gi",
+                        "cpu": "1",
+                        "ephemeral-storage": _k8s_quantity(
+                            settings.max_function_storage
+                        ),
+                    },
+                },
+                "securityContext": {
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {
+                        "drop": ["ALL"],
+                        "add": ["CHOWN", "SETUID", "SETGID"],
+                    },
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+                "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
+            }
+        ],
+        "volumes": [
+            {"name": "tmp", "emptyDir": {"medium": "Memory", "sizeLimit": "100Mi"}}
+        ],
+    }
+    if settings.k8s_sandbox_service_account:
+        # The credential-less sandbox SA; automount is off regardless.
+        spec["serviceAccountName"] = settings.k8s_sandbox_service_account
+
+    labels = dict(_POD_LABELS)
+    if settings.k8s_release_name:
+        labels["app.kubernetes.io/instance"] = settings.k8s_release_name
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": name, "labels": labels},
+        "spec": spec,
+    }
+
+
+def _pod_ready_blocking(name: str, namespace: str) -> bool:
+    from kubernetes.client.exceptions import ApiException
+
+    from app.services.executor._k8s_runtime import _get_clients
+
+    api, _ = _get_clients()
+    try:
+        pod = api.read_namespaced_pod(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status == 404:
+            return False
+        raise
+    statuses = pod.status.container_statuses or []
+    return pod.status.phase == "Running" and bool(statuses) and statuses[0].ready
+
+
+async def _ensure_pod(db: AsyncSession | None, name: str, namespace: str) -> None:
+    """Create (or replace a dead) trusted worker pod and wait until ready."""
+    from kubernetes.client.exceptions import ApiException
+
+    from app.services.executor._k8s_runtime import (
+        _exec_blocking,
+        _get_clients,
+        _wait_ready_blocking,
+    )
+
+    api, _ = _get_clients()
+    image = settings.k8s_sandbox_image or settings.function_container_image
+    worker_id = name.rsplit("-", 1)[-1]
+    manifest = _manifest(name, image, worker_id)
+
+    def _create() -> bool:
+        """Returns True if we created the pod (vs. found a live one)."""
+        try:
+            pod = api.read_namespaced_pod(name=name, namespace=namespace)
+            if pod.status.phase in ("Failed", "Succeeded"):
+                api.delete_namespaced_pod(
+                    name=name, namespace=namespace, grace_period_seconds=0
+                )
+                for _ in range(40):
+                    try:
+                        api.read_namespaced_pod(name=name, namespace=namespace)
+                        time.sleep(0.25)
+                    except ApiException as e:
+                        if e.status == 404:
+                            break
+                        raise
+            else:
+                return False  # exists and is pending/running
+        except ApiException as e:
+            if e.status != 404:
+                raise
+
+        try:
+            api.create_namespaced_pod(namespace=namespace, body=manifest)
+            return True
+        except ApiException as e:
+            if e.status == 409:
+                return False  # another process won the race — fine
+            raise
+
+    created = await asyncio.to_thread(_create)
+    await asyncio.to_thread(
+        _wait_ready_blocking, name, namespace, settings.k8s_sandbox_pod_ready_timeout
+    )
+
+    if created and settings.k8s_sandbox_install_dependencies and db is not None:
+        from app.services.sandbox_image import _dependency_specs
+
+        specs = await _dependency_specs(db)
+        if specs:
+            stdout, stderr, rc = await asyncio.to_thread(
+                _exec_blocking,
+                name,
+                namespace,
+                ["pip", "install", "--no-cache-dir", *specs],
+                timeout=_DEPS_INSTALL_TIMEOUT,
+            )
+            if rc != 0:
+                logger.warning(
+                    "Dependency install failed in trusted pod %s: %s",
+                    name,
+                    (stderr or stdout)[-1000:],
+                )
+    if created:
+        logger.info("Created trusted worker pod %s", name)
+
+
+async def ensure_trusted_pool(db: AsyncSession | None = None) -> None:
+    """Pre-warm the whole fleet. Called from the scheduler at startup;
+    dispatch also calls _ensure_pod lazily for self-healing."""
+    from app.services.executor._k8s_runtime import resolve_namespace
+
+    namespace = resolve_namespace()
+    for name in _pod_names():
+        try:
+            await _ensure_pod(db, name, namespace)
+        except Exception as e:
+            logger.error("Failed to ensure trusted worker pod %s: %s", name, e)
+
+
+class K8sSharedTrustedExecutor:
+    """Warm shared k8s pods. Implements TrustedExecutor."""
+
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        user_email: str,
+        access_token: str,
+        function_namespace: str,
+        function_name: str,
+        input_data: dict[str, Any],
+        execution_id: str,
+        trigger_type: str,
+        chat_id: str | None,
+        user_custom_fields: dict[str, Any] | None = None,
+        db: AsyncSession,
+        timeout: int,
+    ) -> ExecutionResult:
+        from app.models.function import Function
+        from app.services.executor._k8s_runtime import (
+            resolve_namespace,
+            run_payload_in_pod,
+        )
+        from app.services.shared_worker_manager import shared_worker_manager
+
+        result = await db.execute(
+            select(Function).where(
+                Function.namespace == function_namespace,
+                Function.name == function_name,
+                Function.is_active == True,
+                Function.shared_pool == True,
+            )
+        )
+        function = result.scalar_one_or_none()
+        if not function:
+            return ExecutionResult.failed(
+                f"Function {function_namespace}/{function_name} not found "
+                f"or not marked as shared_pool"
+            )
+
+        effective_timeout = timeout or settings.function_timeout
+        payload = {
+            "action": "execute_inline",
+            "function_code": function.code,
+            "execution_id": execution_id,
+            "function_namespace": function_namespace,
+            "function_name": function_name,
+            "timeout": effective_timeout,
+            "input_data": input_data,
+            "context": {
+                "user_id": user_id,
+                "user_email": user_email,
+                "user_custom_fields": user_custom_fields or {},
+                "access_token": access_token,
+                "execution_id": execution_id,
+                "trigger_type": trigger_type,
+                "chat_id": chat_id,
+                # Same trusted-context secrets the Docker shared workers get
+                "secrets": await shared_worker_manager._load_secrets(db, user_id),
+            },
+        }
+
+        namespace = resolve_namespace()
+        names = _pod_names()
+        start = next(_rr)
+        last_error: Exception | None = None
+        for i in range(len(names)):
+            name = names[(start + i) % len(names)]
+            try:
+                if not await asyncio.to_thread(_pod_ready_blocking, name, namespace):
+                    await _ensure_pod(db, name, namespace)
+                wire = await run_payload_in_pod(
+                    name, namespace, payload, effective_timeout
+                )
+                res = ExecutionResult.from_wire(wire)
+                if res.status is ResultStatus.AWAITING_INPUT and not res.handle:
+                    # The pod doesn't know its own name; stamp the handle so
+                    # resume can find the same pod.
+                    res = replace(res, handle=name)
+                return res
+            except Exception as e:
+                # Infra failure on this pod (exec error, recreate failed) —
+                # try the next one before giving up.
+                last_error = e
+                logger.warning(
+                    "Trusted execution %s failed on pod %s: %s",
+                    execution_id,
+                    name,
+                    e,
+                )
+        return ExecutionResult.failed(
+            f"All trusted worker pods failed: {last_error}"
+        )
+
+    async def resume(
+        self,
+        *,
+        handle: str,
+        resume_value: Any,
+        execution_id: str,
+        timeout: int,
+    ) -> ExecutionResult:
+        """Resume a function parked on input() in trusted pod `handle`.
+
+        k8s twin of `_docker_resume.docker_resume`: write the resume value
+        into the pod, then poll for the result the parked thread produces.
+        """
+        from app.services.executor._k8s_runtime import (
+            _STDIN_WRITER,
+            _exec_blocking,
+            resolve_namespace,
+        )
+
+        namespace = resolve_namespace()
+        if not await asyncio.to_thread(_pod_ready_blocking, handle, namespace):
+            # The parked interpreter state died with the pod.
+            return ExecutionResult.failed(
+                f"Trusted worker pod {handle} no longer available (restarted?)"
+            )
+
+        resume_file = f"/tmp/exec_resume_{execution_id}.json"
+        result_file = f"/tmp/exec_result_{execution_id}.json"
+        resume_json = json.dumps({"value": resume_value})
+
+        writer = _STDIN_WRITER.format(path=resume_file)
+        stdout, stderr, rc = await asyncio.to_thread(
+            _exec_blocking,
+            handle,
+            namespace,
+            ["python3", "-c", writer],
+            stdin_payload=resume_json,
+            timeout=60,
+        )
+        expected = f"WROTE {len(resume_json.encode('utf-8'))}"
+        if expected not in stdout:
+            return ExecutionResult.failed(
+                f"Failed to write resume value into pod {handle}: "
+                f"rc={rc} stderr={stderr[-500:]!r}"
+            )
+
+        poll_script = f"""
+import sys, json, time, os
+max_wait = {timeout}
+start = time.time()
+while time.time() - start < max_wait:
+    if os.path.exists("{result_file}"):
+        with open("{result_file}", "r") as f:
+            data = json.load(f)
+        print(json.dumps(data))
+        sys.exit(0)
+    time.sleep(0.1)
+print(json.dumps({{"status": "failed", "error": "Resume timeout after {timeout}s"}}))
+sys.exit(1)
+"""
+        stdout, stderr, rc = await asyncio.to_thread(
+            _exec_blocking,
+            handle,
+            namespace,
+            ["python3", "-c", poll_script],
+            timeout=timeout + 30,
+        )
+        if not stdout.strip():
+            return ExecutionResult.failed(
+                f"No resume result from pod {handle}: rc={rc} stderr={stderr[-500:]!r}"
+            )
+        res = ExecutionResult.from_wire(json.loads(stdout.strip()))
+        if res.status is ResultStatus.AWAITING_INPUT and not res.handle:
+            res = replace(res, handle=handle)
+        return res

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -384,6 +384,11 @@ class MessageService:
         if prep.get("blocked"):
             return prep["block_message"]
 
+        # Metering leaf: one agent invocation per (unblocked) user message
+        from app.services import metering
+
+        await metering.record(metering.OperationKind.AGENT)
+
         agent_label = prep.get("agent_label")
         _labels = json.dumps([f"agent:{agent_label}"]) if agent_label else "[]"
         _llm_span = _tracer.start_span("llm.call", attributes={
@@ -541,6 +546,11 @@ class MessageService:
             yield {"type": "message", "content": prep["block_message"].content}
             yield {"type": "done", "status": "blocked"}
             return
+
+        # Metering leaf: one agent invocation per (unblocked) user message
+        from app.services import metering
+
+        await metering.record(metering.OperationKind.AGENT)
 
         agent_label = prep.get("agent_label")
         _labels = json.dumps([f"agent:{agent_label}"]) if agent_label else "[]"

--- a/backend/app/services/metering.py
+++ b/backend/app/services/metering.py
@@ -1,0 +1,367 @@
+"""Operations metering: count operations, snapshot durably, push cumulative
+usage to the central platform. Pure emission — nothing is enforced on the
+instance, no limits or status are pulled down, and the heartbeat response
+body is ignored (2xx = ack).
+
+Design (Confluence: "Operations metering & usage-based billing — design"):
+
+  hot path   metering.record(kind) → atomic Redis INCRBY, fire-and-forget
+  durability scheduler snapshot job → usage_periods row per period (upsert);
+             Redis is re-seeded from it on startup so restarts don't lose
+             the running count
+  emission   scheduler push job → POST the CUMULATIVE period-to-date total
+             (never deltas). A missed beat needs no catch-up: the next push
+             carries the current total and the platform takes max(total) per
+             (instance_id, period_id). Idempotency-Key dedupes retries.
+             Per-instance jitter keeps a fleet from pushing in sync.
+
+Meter integrity (§6): no process that executes client-supplied code may hold
+write access to the meter. Sandbox and shared executor containers receive no
+Redis/DB credentials (verified: shared_worker_manager passes only
+WORKER_MODE/WORKER_ID), so record() only ever runs in platform code.
+TRUSTED_EXECUTOR=inprocess runs client code inside a credential-bearing
+process — the invariant is unenforceable there, and enabling metering in
+that mode logs a loud warning at scheduler startup. The platform-side
+backstop is in the contract: totals are cumulative and snapshot_seq is
+monotonic, so the receiver flags any decrease as tampering.
+"""
+
+import enum
+import hashlib
+import logging
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app._version import __version__
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = "sinas.metering/v1"
+
+# Old-period Redis keys are kept briefly after their final push, then expire.
+_ROLLED_OVER_KEY_TTL = int(timedelta(days=7).total_seconds())
+
+_PUSH_ATTEMPTS = 3
+
+
+class OperationKind(str, enum.Enum):
+    FUNCTION = "function"  # function execution (any trigger)
+    CODE = "code"  # agent codeExecution tool
+    QUERY = "query"  # query execution (agent tool or runtime API)
+    AGENT = "agent"  # agent invocation (one LLM turn)
+    UPLOAD = "upload"  # file upload
+    TOOL = "tool"  # other tool calls (skill/state/component/connector/...)
+
+
+def instance_id() -> str:
+    return (
+        settings.metering_instance_id.strip()
+        or (settings.domain or "").strip()
+        or "unknown"
+    )
+
+
+def period_id(now: Optional[datetime] = None) -> str:
+    """Monthly period, UTC. Fallback until the platform supplies
+    subscription-anchored periods — same field, so that slots in later."""
+    now = now or datetime.now(UTC)
+    return f"{now.year:04d}-{now.month:02d}"
+
+
+def period_bounds(pid: str) -> tuple[datetime, datetime]:
+    year, month = int(pid[:4]), int(pid[5:7])
+    start = datetime(year, month, 1, tzinfo=UTC)
+    end = datetime(year + 1, 1, 1, tzinfo=UTC) if month == 12 else datetime(year, month + 1, 1, tzinfo=UTC)
+    return start, end
+
+
+def _previous_period_id(pid: str) -> str:
+    start, _ = period_bounds(pid)
+    prev_last_day = start - timedelta(days=1)
+    return f"{prev_last_day.year:04d}-{prev_last_day.month:02d}"
+
+
+def _key(pid: str, suffix: str) -> str:
+    return f"usage:{instance_id()}:{pid}:{suffix}"
+
+
+def push_jitter_seconds(interval_minutes: int) -> int:
+    """Deterministic per-instance offset so fleet pushes spread across the
+    window instead of aligning to the wall clock."""
+    digest = hashlib.sha256(instance_id().encode()).digest()
+    return int.from_bytes(digest[:4], "big") % max(1, interval_minutes * 60)
+
+
+# ---------------------------------------------------------------------------
+# Hot path
+# ---------------------------------------------------------------------------
+
+
+async def record(kind: OperationKind, n: int = 1) -> None:
+    """Count an operation. Fire-and-forget: never raises, never blocks the
+    request on metering problems (posture matches the ClickHouse logging)."""
+    if not settings.metering_enabled:
+        return
+    try:
+        from app.core.redis import get_redis
+
+        redis = await get_redis()
+        pid = period_id()
+        pipe = redis.pipeline(transaction=False)
+        pipe.incrby(_key(pid, "total"), n)
+        pipe.incrby(_key(pid, f"kind:{kind.value}"), n)
+        pipe.set(f"usage:{instance_id()}:last_op_at", datetime.now(UTC).isoformat())
+        await pipe.execute()
+    except Exception as e:
+        # Under-counting during a Redis blip is acceptable; failing the
+        # customer's request is not.
+        logger.warning(f"metering.record failed (op not counted): {e}")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot: Redis -> usage_periods (durable record of record)
+# ---------------------------------------------------------------------------
+
+
+async def _read_redis_counters(redis, pid: str) -> Optional[dict[str, Any]]:
+    total = await redis.get(_key(pid, "total"))
+    if total is None:
+        return None
+    by_kind: dict[str, int] = {}
+    for kind in OperationKind:
+        v = await redis.get(_key(pid, f"kind:{kind.value}"))
+        if v is not None:
+            by_kind[kind.value] = int(v)
+    last_op = await redis.get(f"usage:{instance_id()}:last_op_at")
+    if isinstance(last_op, bytes):
+        last_op = last_op.decode()
+    return {"total": int(total), "by_kind": by_kind, "last_op_at": last_op}
+
+
+async def snapshot(db: AsyncSession) -> None:
+    """Upsert usage_periods from Redis for the current period — and for the
+    previous one while its keys still exist, which is what finalizes a period
+    after rollover without a special case."""
+    from app.core.redis import get_redis
+    from app.models import UsagePeriod
+
+    redis = await get_redis()
+    current = period_id()
+
+    for pid in (current, _previous_period_id(current)):
+        counters = await _read_redis_counters(redis, pid)
+        if counters is None:
+            continue
+
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(
+                    UsagePeriod.instance_id == instance_id(),
+                    UsagePeriod.period_id == pid,
+                )
+            )
+        ).scalar_one_or_none()
+
+        if row is None:
+            start, end = period_bounds(pid)
+            row = UsagePeriod(
+                instance_id=instance_id(),
+                period_id=pid,
+                period_start=start,
+                period_end=end,
+            )
+            db.add(row)
+
+        # The count only ever moves up; never let a stale Redis (e.g. one
+        # restarted mid-seed) regress the durable row.
+        row.total = max(row.total or 0, counters["total"])
+        merged = dict(row.by_kind or {})
+        for k, v in counters["by_kind"].items():
+            merged[k] = max(merged.get(k, 0), v)
+        row.by_kind = merged
+        if counters["last_op_at"]:
+            row.last_op_at = datetime.fromisoformat(counters["last_op_at"])
+
+    await db.commit()
+
+
+async def seed_redis_from_db(db: AsyncSession) -> None:
+    """On startup: restore the current period's count into Redis, taking the
+    max of both sides so neither a Redis restart nor a stale snapshot can
+    move the count backwards."""
+    from app.core.redis import get_redis
+    from app.models import UsagePeriod
+
+    row = (
+        await db.execute(
+            select(UsagePeriod).where(
+                UsagePeriod.instance_id == instance_id(),
+                UsagePeriod.period_id == period_id(),
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return
+
+    redis = await get_redis()
+    current_total = await redis.get(_key(row.period_id, "total"))
+    if current_total is None or int(current_total) < (row.total or 0):
+        await redis.set(_key(row.period_id, "total"), row.total or 0)
+        for kind, value in (row.by_kind or {}).items():
+            existing = await redis.get(_key(row.period_id, f"kind:{kind}"))
+            if existing is None or int(existing) < value:
+                await redis.set(_key(row.period_id, f"kind:{kind}"), value)
+        logger.info(
+            f"Metering: re-seeded Redis for period {row.period_id} "
+            f"from durable snapshot (total={row.total})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Push: cumulative heartbeat to the platform
+# ---------------------------------------------------------------------------
+
+
+def _build_payload(row) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "instance_id": row.instance_id,
+        "platform_version": __version__,
+        "period_id": row.period_id,
+        "period_start": row.period_start.isoformat(),
+        "period_end": row.period_end.isoformat(),
+        # Cumulative period-to-date — never a delta. The platform takes
+        # max(total) per (instance_id, period_id); a missed or duplicated
+        # beat self-heals.
+        "total": row.total,
+        "by_kind": row.by_kind or {},
+        "last_op_at": row.last_op_at.isoformat() if row.last_op_at else None,
+        "snapshot_seq": row.snapshot_seq,
+        "sent_at": datetime.now(UTC).isoformat(),
+    }
+
+
+async def push(db: AsyncSession) -> int:
+    """POST every period row with unreported progress. Returns rows pushed.
+
+    Failures are logged and abandoned until the next cycle — cumulative
+    totals mean there is nothing to replay.
+    """
+    from app.core.redis import get_redis
+    from app.models import UsagePeriod
+
+    endpoint = settings.metering_endpoint.strip()
+    if not endpoint:
+        logger.warning("METERING_ENABLED but METERING_ENDPOINT is empty — nothing sent")
+        return 0
+
+    rows = (
+        (
+            await db.execute(
+                select(UsagePeriod)
+                .where(UsagePeriod.instance_id == instance_id())
+                .order_by(UsagePeriod.period_start)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    to_send = [
+        r for r in rows if r.reported_at is None or r.updated_at > r.reported_at
+    ]
+    if not to_send:
+        return 0
+
+    headers = {}
+    if settings.metering_api_key:
+        headers["Authorization"] = f"Bearer {settings.metering_api_key}"
+
+    pushed = 0
+    current = period_id()
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        for row in to_send:
+            row.snapshot_seq += 1
+            payload = _build_payload(row)
+            key = f"{row.instance_id}:{row.period_id}:{row.snapshot_seq}"
+
+            ok = False
+            for attempt in range(_PUSH_ATTEMPTS):
+                try:
+                    resp = await client.post(
+                        endpoint,
+                        json=payload,
+                        headers={**headers, "Idempotency-Key": key},
+                    )
+                    if 200 <= resp.status_code < 300:
+                        ok = True
+                        break
+                    logger.warning(
+                        f"Metering push {key}: HTTP {resp.status_code} "
+                        f"(attempt {attempt + 1}/{_PUSH_ATTEMPTS})"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Metering push {key} failed "
+                        f"(attempt {attempt + 1}/{_PUSH_ATTEMPTS}): {e}"
+                    )
+                if attempt < _PUSH_ATTEMPTS - 1:
+                    import asyncio
+
+                    # Backoff with jitter so a fleet retries out of phase
+                    await asyncio.sleep((2**attempt) + random.uniform(0, 1))
+
+            if ok:
+                row.reported_at = datetime.now(UTC)
+                pushed += 1
+                if row.period_id != current:
+                    # Rolled-over period got its final push; let its Redis
+                    # keys age out instead of lingering forever.
+                    try:
+                        redis = await get_redis()
+                        for kind in OperationKind:
+                            await redis.expire(
+                                _key(row.period_id, f"kind:{kind.value}"),
+                                _ROLLED_OVER_KEY_TTL,
+                            )
+                        await redis.expire(
+                            _key(row.period_id, "total"), _ROLLED_OVER_KEY_TTL
+                        )
+                    except Exception:
+                        pass
+            await db.commit()
+
+    if pushed:
+        logger.info(f"Metering: pushed {pushed} period report(s)")
+    return pushed
+
+
+# ---------------------------------------------------------------------------
+# Scheduler entrypoints
+# ---------------------------------------------------------------------------
+
+
+async def run_snapshot_cycle() -> None:
+    from app.core.database import AsyncSessionLocal
+
+    try:
+        async with AsyncSessionLocal() as db:
+            await snapshot(db)
+    except Exception:
+        logger.exception("Metering snapshot cycle failed")
+
+
+async def run_push_cycle() -> None:
+    from app.core.database import AsyncSessionLocal
+
+    try:
+        async with AsyncSessionLocal() as db:
+            await snapshot(db)  # push fresh numbers, not last cycle's
+            await push(db)
+    except Exception:
+        logger.exception("Metering push cycle failed")

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -640,6 +640,13 @@ async def execute_single_tool(
                     tool_found_in_list = True
                     break
 
+            # Metering (§2a leaf-only rule): branches that recurse into a leaf
+            # chokepoint — code-exec, sub-agent, pipeline, query, function —
+            # are counted there; every other branch counts as one TOOL op
+            # after dispatch. This keeps "agent turn calling 3 functions" =
+            # 1 agent + 3 function, never double-counted.
+            counted_at_leaf = False
+
             # Built-in tools (no metadata needed)
             if tool_name in ("save_state", "retrieve_state", "update_state", "delete_state", "list_state_keys"):
                 result = await StateTools.execute_tool(
@@ -691,6 +698,7 @@ async def execute_single_tool(
                     resume_value=arguments["input"],
                 )
             elif tool_name == "execute_code":
+                counted_at_leaf = True  # metered in code_execution.execute()
                 start_time = time.time()
                 result = await execute_code(
                     code=arguments.get("code", ""),
@@ -763,6 +771,7 @@ async def execute_single_tool(
 
             # Metadata-driven tools — identity comes from _metadata, not tool name parsing
             elif tool_metadata.get("agent_id"):
+                counted_at_leaf = True  # sub-agent metered in message_service
                 result = await execute_agent_tool(
                     db=db,
                     chat=chat,
@@ -783,6 +792,7 @@ async def execute_single_tool(
                 )
                 logger.debug(f"Collection tool completed in {time.time() - start_time:.3f}s: {tool_name}")
             elif tool_metadata.get("type") == "pipeline":
+                counted_at_leaf = True  # pipeline steps meter at their leaves
                 start_time = time.time()
                 from app.services.pipeline_tools import PipelineToolConverter
 
@@ -833,6 +843,7 @@ async def execute_single_tool(
                     result = {"error": f"Skill not found for tool: {tool_name}"}
                 logger.debug(f"Skill retrieval completed in {time.time() - start_time:.3f}s: {tool_name}")
             elif tool_name.startswith("query_"):
+                counted_at_leaf = True  # metered in DatabasePoolManager.execute_query
                 start_time = time.time()
                 # Get enabled queries list from agent
                 enabled_query_list = []
@@ -863,6 +874,7 @@ async def execute_single_tool(
                 logger.debug(f"Query execution completed in {time.time() - start_time:.3f}s: {tool_name}")
             elif tool_found_in_list:
                 # Function tool — metadata has namespace/name
+                counted_at_leaf = True  # metered in execute_function
                 start_time = time.time()
                 enabled_function_list = []
                 if chat and chat.agent_id:
@@ -895,6 +907,12 @@ async def execute_single_tool(
                     "error": "Unauthorized tool call",
                     "message": f"Tool '{tool_name}' was not in the approved tools list for this agent.",
                 }
+                counted_at_leaf = True  # rejected — no work done, not billable
+
+            if not counted_at_leaf:
+                from app.services import metering
+
+                await metering.record(metering.OperationKind.TOOL)
 
             result_content = json.dumps(result) if not isinstance(result, str) else result
 

--- a/backend/tests/unit/test_metering.py
+++ b/backend/tests/unit/test_metering.py
@@ -1,0 +1,383 @@
+"""Operations metering: hot-path counting, snapshots, cumulative push.
+
+Redis is faked (local test env has no reachable Redis, and the fake lets us
+assert exact keys); the DB is real. metering.py imports get_redis inside each
+function, so patching app.core.redis.get_redis covers everything.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models import UsagePeriod
+from app.services import metering
+from app.services.metering import (
+    SCHEMA,
+    OperationKind,
+    period_bounds,
+    period_id,
+    push_jitter_seconds,
+    record,
+    seed_redis_from_db,
+    snapshot,
+)
+
+INSTANCE = "test-instance"
+
+
+class _FakePipeline:
+    def __init__(self, store):
+        self._store = store
+        self._ops = []
+
+    def incrby(self, key, n):
+        self._ops.append(("incrby", key, n))
+
+    def set(self, key, value):
+        self._ops.append(("set", key, value))
+
+    async def execute(self):
+        for op, key, arg in self._ops:
+            if op == "incrby":
+                self._store[key] = int(self._store.get(key, 0)) + arg
+            else:
+                self._store[key] = arg
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store: dict = {}
+        self.expired: dict = {}
+
+    def pipeline(self, transaction=True):
+        return _FakePipeline(self.store)
+
+    async def get(self, key):
+        v = self.store.get(key)
+        return None if v is None else str(v)
+
+    async def set(self, key, value):
+        self.store[key] = value
+
+    async def expire(self, key, ttl):
+        self.expired[key] = ttl
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    redis = _FakeRedis()
+
+    async def _get_redis():
+        return redis
+
+    monkeypatch.setattr("app.core.redis.get_redis", _get_redis)
+    return redis
+
+
+@pytest.fixture
+def metering_on(monkeypatch, fake_redis):
+    monkeypatch.setattr(settings, "metering_enabled", True)
+    monkeypatch.setattr(settings, "metering_instance_id", INSTANCE)
+    return fake_redis
+
+
+def _k(suffix, pid=None):
+    return f"usage:{INSTANCE}:{pid or period_id()}:{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# record(): hot path
+# ---------------------------------------------------------------------------
+
+
+class TestRecord:
+    async def test_disabled_is_noop(self, fake_redis, monkeypatch):
+        monkeypatch.setattr(settings, "metering_enabled", False)
+        await record(OperationKind.FUNCTION)
+        assert fake_redis.store == {}
+
+    async def test_increments_total_and_kind(self, metering_on):
+        await record(OperationKind.FUNCTION)
+        await record(OperationKind.FUNCTION)
+        await record(OperationKind.QUERY)
+
+        assert metering_on.store[_k("total")] == 3
+        assert metering_on.store[_k("kind:function")] == 2
+        assert metering_on.store[_k("kind:query")] == 1
+        assert f"usage:{INSTANCE}:last_op_at" in metering_on.store
+
+    async def test_never_raises_on_redis_failure(self, monkeypatch):
+        monkeypatch.setattr(settings, "metering_enabled", True)
+
+        async def _boom():
+            raise ConnectionError("redis down")
+
+        monkeypatch.setattr("app.core.redis.get_redis", _boom)
+        # A metering outage must never fail the customer's operation
+        await record(OperationKind.AGENT)
+
+
+# ---------------------------------------------------------------------------
+# snapshot / seed: Redis <-> usage_periods
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    async def test_creates_and_updates_row(self, db: AsyncSession, metering_on):
+        await record(OperationKind.FUNCTION)
+        await record(OperationKind.AGENT)
+        await snapshot(db)
+
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
+            )
+        ).scalar_one()
+        assert row.period_id == period_id()
+        assert row.total == 2
+        assert row.by_kind == {"function": 1, "agent": 1}
+        start, end = period_bounds(row.period_id)
+        assert (row.period_start, row.period_end) == (start, end)
+
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        await db.refresh(row)
+        assert row.total == 3
+        assert row.by_kind["function"] == 2
+
+    async def test_snapshot_never_regresses_the_row(self, db, metering_on):
+        """A wiped Redis (count lower than the durable row) must not pull the
+        durable count down — the meter only moves up."""
+        await record(OperationKind.FUNCTION)
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+
+        metering_on.store[_k("total")] = 1
+        metering_on.store[_k("kind:function")] = 1
+        await snapshot(db)
+
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
+            )
+        ).scalar_one()
+        assert row.total == 2
+        assert row.by_kind["function"] == 2
+
+    async def test_seed_restores_redis_after_restart(self, db, metering_on):
+        await record(OperationKind.FUNCTION)
+        await record(OperationKind.QUERY)
+        await snapshot(db)
+
+        metering_on.store.clear()  # Redis restart
+        await seed_redis_from_db(db)
+        assert metering_on.store[_k("total")] == 2
+        assert metering_on.store[_k("kind:query")] == 1
+
+    async def test_seed_keeps_higher_redis_value(self, db, metering_on):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        # Redis moved on since the last snapshot — seeding must not regress it
+        await record(OperationKind.FUNCTION)
+        await seed_redis_from_db(db)
+        assert metering_on.store[_k("total")] == 2
+
+
+# ---------------------------------------------------------------------------
+# push: cumulative heartbeat
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = responses
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.posts.append({"url": url, "json": json, "headers": headers})
+        result = self._responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    monkeypatch.setattr(settings, "metering_endpoint", "https://ops.example.com/v1/usage")
+    monkeypatch.setattr(settings, "metering_api_key", "sekrit")
+    # No real sleeping in retry backoff
+    async def _no_sleep(_):
+        pass
+
+    monkeypatch.setattr("asyncio.sleep", _no_sleep)
+
+
+def _patch_client(monkeypatch, responses):
+    client = _FakeClient(responses)
+    monkeypatch.setattr("app.services.metering.httpx.AsyncClient", lambda **kw: client)
+    return client
+
+
+class TestPush:
+    async def test_pushes_cumulative_total_with_idempotency_key(
+        self, db, metering_on, endpoint, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        client = _patch_client(monkeypatch, [_Resp(200)])
+
+        pushed = await metering.push(db)
+        assert pushed == 1
+
+        post = client.posts[0]
+        assert post["headers"]["Authorization"] == "Bearer sekrit"
+        assert post["headers"]["Idempotency-Key"] == f"{INSTANCE}:{period_id()}:1"
+        payload = post["json"]
+        assert payload["schema"] == SCHEMA
+        assert payload["total"] == 2  # cumulative, not a delta
+        assert payload["by_kind"] == {"function": 2}
+        assert payload["snapshot_seq"] == 1
+
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
+            )
+        ).scalar_one()
+        assert row.reported_at is not None
+
+    async def test_no_progress_means_no_push(self, db, metering_on, endpoint, monkeypatch):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        _patch_client(monkeypatch, [_Resp(200)])
+        assert await metering.push(db) == 1
+
+        _patch_client(monkeypatch, [])
+        assert await metering.push(db) == 0  # nothing changed since report
+
+    async def test_new_activity_pushes_again_with_next_seq(
+        self, db, metering_on, endpoint, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        _patch_client(monkeypatch, [_Resp(200)])
+        await metering.push(db)
+
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        # In-test transaction timestamps don't advance, so simulate the
+        # updated_at bump a later transaction would produce
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
+            )
+        ).scalar_one()
+        row.updated_at = datetime.now(UTC) + timedelta(seconds=1)
+        await db.flush()
+
+        client = _patch_client(monkeypatch, [_Resp(200)])
+        assert await metering.push(db) == 1
+        payload = client.posts[0]["json"]
+        assert payload["total"] == 2  # still cumulative
+        assert payload["snapshot_seq"] == 2
+        assert client.posts[0]["headers"]["Idempotency-Key"].endswith(":2")
+
+    async def test_failed_push_retries_next_cycle_no_data_loss(
+        self, db, metering_on, endpoint, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+
+        _patch_client(monkeypatch, [_Resp(503), _Resp(503), ConnectionError("dns")])
+        assert await metering.push(db) == 0  # all attempts failed, no raise
+
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
+            )
+        ).scalar_one()
+        assert row.reported_at is None  # still owed
+
+        # Next cycle succeeds; total is cumulative so nothing was lost
+        client = _patch_client(monkeypatch, [_Resp(200)])
+        assert await metering.push(db) == 1
+        assert client.posts[0]["json"]["total"] == 1
+
+    async def test_empty_endpoint_sends_nothing(self, db, metering_on, monkeypatch):
+        monkeypatch.setattr(settings, "metering_endpoint", "")
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        assert await metering.push(db) == 0
+
+
+# ---------------------------------------------------------------------------
+# Rollover
+# ---------------------------------------------------------------------------
+
+
+class TestRollover:
+    async def test_previous_period_finalized_and_keys_expired(
+        self, db, metering_on, endpoint, monkeypatch
+    ):
+        prev = metering._previous_period_id(period_id())
+        # Leftover counters from last month + fresh activity this month
+        metering_on.store[_k("total", prev)] = 40
+        metering_on.store[_k("kind:function", prev)] = 40
+        await record(OperationKind.AGENT)
+
+        await snapshot(db)
+        rows = (
+            (
+                await db.execute(
+                    select(UsagePeriod)
+                    .where(UsagePeriod.instance_id == INSTANCE)
+                    .order_by(UsagePeriod.period_start)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [r.period_id for r in rows] == [prev, period_id()]
+        assert rows[0].total == 40
+        assert rows[1].total == 1
+
+        client = _patch_client(monkeypatch, [_Resp(200), _Resp(200)])
+        assert await metering.push(db) == 2
+        # Old period got its final push; its Redis keys are set to expire
+        assert _k("total", prev) in metering_on.expired
+
+
+# ---------------------------------------------------------------------------
+# Jitter
+# ---------------------------------------------------------------------------
+
+
+class TestJitter:
+    def test_deterministic_and_bounded(self, monkeypatch):
+        monkeypatch.setattr(settings, "metering_instance_id", "acme-prod")
+        a = push_jitter_seconds(15)
+        b = push_jitter_seconds(15)
+        assert a == b
+        assert 0 <= a < 15 * 60
+
+    def test_spreads_instances(self, monkeypatch):
+        offsets = set()
+        for name in ("inst-a", "inst-b", "inst-c", "inst-d", "inst-e"):
+            monkeypatch.setattr(settings, "metering_instance_id", name)
+            offsets.add(push_jitter_seconds(15))
+        assert len(offsets) > 1

--- a/backend/tests/unit/test_trusted_executor_modes.py
+++ b/backend/tests/unit/test_trusted_executor_modes.py
@@ -1,0 +1,236 @@
+"""Trusted executor modes: disabled + k8s_shared (warm credential-free pods)."""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models import Function
+from app.services.executor import factory
+from app.services.executor.base import ResultStatus
+from app.services.executor.k8s_shared_trusted import K8sSharedTrustedExecutor
+
+
+@pytest.fixture
+def reset_factory():
+    factory._reset_cache_for_tests()
+    yield
+    factory._reset_cache_for_tests()
+
+
+class TestFactoryModes:
+    def test_disabled_returns_none(self, monkeypatch, reset_factory):
+        monkeypatch.setattr(settings, "trusted_executor", "disabled")
+        assert factory.get_trusted_executor() is None
+
+    def test_k8s_shared_resolves(self, monkeypatch, reset_factory):
+        monkeypatch.setattr(settings, "trusted_executor", "k8s_shared")
+        assert isinstance(factory.get_trusted_executor(), K8sSharedTrustedExecutor)
+
+    def test_unknown_mode_rejected(self, monkeypatch, reset_factory):
+        monkeypatch.setattr(settings, "trusted_executor", "carrier-pigeon")
+        with pytest.raises(ValueError, match="carrier-pigeon"):
+            factory.get_trusted_executor()
+
+
+class TestDisabledMode:
+    async def test_shared_pool_execution_rejected_with_clear_error(
+        self, monkeypatch, reset_factory
+    ):
+        from app.services.execution_engine import (
+            FunctionExecutionError,
+            FunctionExecutor,
+        )
+
+        monkeypatch.setattr(settings, "trusted_executor", "disabled")
+        engine = FunctionExecutor()
+        fn = SimpleNamespace(namespace="acme", name="report")
+
+        with pytest.raises(FunctionExecutionError, match="disabled.*acme/report"):
+            await engine._execute_in_shared_pool(
+                function=fn,
+                input_data={},
+                execution_id="e1",
+                user_id="u1",
+                user_email="u@example.com",
+                access_token="t",
+                trigger_type="api",
+                chat_id=None,
+                db=None,
+            )
+
+
+@pytest.fixture
+async def shared_fn(db: AsyncSession, test_user):
+    fn = Function(
+        user_id=test_user.id,
+        namespace="acme",
+        name=f"trusted-{uuid.uuid4().hex[:6]}",
+        code="def handler(input, context): return {'ok': True}",
+        input_schema={},
+        output_schema={},
+        is_active=True,
+        shared_pool=True,
+    )
+    db.add(fn)
+    await db.flush()
+    return fn
+
+
+@pytest.fixture
+def k8s_mocks(monkeypatch):
+    """Patch the k8s runtime boundary; capture dispatches."""
+    calls = SimpleNamespace(dispatches=[], ready_checks=[], wire=None)
+
+    monkeypatch.setattr(
+        "app.services.executor._k8s_runtime.resolve_namespace", lambda: "test-ns"
+    )
+
+    def _ready(name, namespace):
+        calls.ready_checks.append(name)
+        return True
+
+    monkeypatch.setattr(
+        "app.services.executor.k8s_shared_trusted._pod_ready_blocking", _ready
+    )
+
+    async def _run(name, namespace, payload, timeout):
+        calls.dispatches.append({"pod": name, "payload": payload})
+        return calls.wire
+
+    monkeypatch.setattr(
+        "app.services.executor._k8s_runtime.run_payload_in_pod", _run
+    )
+
+    async def _secrets(self, db, user_id=None):
+        return {"API_KEY": "decrypted"}
+
+    monkeypatch.setattr(
+        "app.services.shared_worker_manager.SharedWorkerManager._load_secrets",
+        _secrets,
+    )
+    monkeypatch.setattr(settings, "k8s_release_name", "acme")
+    monkeypatch.setattr(settings, "k8s_trusted_workers", 2)
+    return calls
+
+
+class TestK8sSharedExecute:
+    async def _execute(self, db, fn):
+        return await K8sSharedTrustedExecutor().execute(
+            user_id="u1",
+            user_email="u@example.com",
+            access_token="tok",
+            function_namespace=fn.namespace,
+            function_name=fn.name,
+            input_data={"x": 1},
+            execution_id="e-123",
+            trigger_type="api",
+            chat_id=None,
+            db=db,
+            timeout=30,
+        )
+
+    async def test_dispatches_shared_payload_to_warm_pod(self, db, shared_fn, k8s_mocks):
+        k8s_mocks.wire = {"status": "completed", "result": {"ok": True}}
+        res = await self._execute(db, shared_fn)
+
+        assert res.status is ResultStatus.COMPLETED
+        d = k8s_mocks.dispatches[0]
+        assert d["pod"].startswith("acme-trusted-worker-")
+        payload = d["payload"]
+        assert payload["action"] == "execute_inline"
+        assert payload["function_code"] == shared_fn.code
+        ctx = payload["context"]
+        assert ctx["access_token"] == "tok"
+        # Trusted context carries decrypted secrets, same as docker_shared
+        assert ctx["secrets"] == {"API_KEY": "decrypted"}
+
+    async def test_non_shared_pool_function_refused(self, db, shared_fn, k8s_mocks):
+        shared_fn.shared_pool = False
+        await db.flush()
+        k8s_mocks.wire = {"status": "completed"}
+        res = await self._execute(db, shared_fn)
+        assert res.status is ResultStatus.FAILED
+        assert "shared_pool" in res.error
+        assert k8s_mocks.dispatches == []  # never reached a pod
+
+    async def test_awaiting_input_gets_pod_handle_stamped(self, db, shared_fn, k8s_mocks):
+        # The pod doesn't know its own name — the executor must stamp it so
+        # resume can find the same pod.
+        k8s_mocks.wire = {"status": "awaiting_input", "prompt": "continue?"}
+        res = await self._execute(db, shared_fn)
+        assert res.status is ResultStatus.AWAITING_INPUT
+        assert res.handle == k8s_mocks.dispatches[0]["pod"]
+
+    async def test_fails_over_to_next_pod_on_infra_error(
+        self, db, shared_fn, k8s_mocks, monkeypatch
+    ):
+        attempts = []
+
+        async def _flaky(name, namespace, payload, timeout):
+            attempts.append(name)
+            if len(attempts) == 1:
+                raise RuntimeError("exec websocket died")
+            return {"status": "completed", "result": 1}
+
+        monkeypatch.setattr(
+            "app.services.executor._k8s_runtime.run_payload_in_pod", _flaky
+        )
+        res = await self._execute(db, shared_fn)
+        assert res.status is ResultStatus.COMPLETED
+        assert len(attempts) == 2
+        assert attempts[0] != attempts[1]  # tried a different pod
+
+
+class TestK8sSharedResume:
+    async def test_dead_pod_fails_cleanly(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.executor._k8s_runtime.resolve_namespace", lambda: "ns"
+        )
+        monkeypatch.setattr(
+            "app.services.executor.k8s_shared_trusted._pod_ready_blocking",
+            lambda n, ns: False,
+        )
+        res = await K8sSharedTrustedExecutor().resume(
+            handle="acme-trusted-worker-0",
+            resume_value="yes",
+            execution_id="e1",
+            timeout=10,
+        )
+        assert res.status is ResultStatus.FAILED
+        assert "no longer available" in res.error
+
+    async def test_writes_resume_value_and_returns_result(self, monkeypatch):
+        import json as _json
+
+        monkeypatch.setattr(
+            "app.services.executor._k8s_runtime.resolve_namespace", lambda: "ns"
+        )
+        monkeypatch.setattr(
+            "app.services.executor.k8s_shared_trusted._pod_ready_blocking",
+            lambda n, ns: True,
+        )
+        execs = []
+
+        def _exec(name, namespace, command, *, stdin_payload=None, timeout):
+            execs.append({"cmd": command, "stdin": stdin_payload})
+            if stdin_payload is not None:
+                n = len(stdin_payload.encode())
+                return (f"WROTE {n}", "", 0)
+            return (_json.dumps({"status": "completed", "result": 42}), "", 0)
+
+        monkeypatch.setattr(
+            "app.services.executor._k8s_runtime._exec_blocking", _exec
+        )
+
+        res = await K8sSharedTrustedExecutor().resume(
+            handle="acme-trusted-worker-1",
+            resume_value={"answer": "yes"},
+            execution_id="e1",
+            timeout=10,
+        )
+        assert res.status is ResultStatus.COMPLETED
+        # First exec wrote the resume value via the length-prefixed protocol
+        assert _json.loads(execs[0]["stdin"]) == {"value": {"answer": "yes"}}

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -96,6 +96,10 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
   value: {{ include "sinas.sandboxSA" . | quote }}
 - name: K8S_SANDBOX_INSTALL_DEPENDENCIES
   value: {{ .Values.executor.installDependencies | quote }}
+- name: K8S_RELEASE_NAME
+  value: {{ .Release.Name | quote }}
+- name: K8S_TRUSTED_WORKERS
+  value: {{ .Values.executor.trustedWorkers | default 2 | quote }}
 - name: K8S_SANDBOX_POD_READY_TIMEOUT
   value: {{ .Values.executor.podReadyTimeout | quote }}
 - name: POD_NAMESPACE

--- a/charts/sinas/templates/networkpolicy.yaml
+++ b/charts/sinas/templates/networkpolicy.yaml
@@ -16,7 +16,7 @@ spec:
     matchExpressions:
       - key: sinas.type
         operator: NotIn
-        values: ["sandbox-executor"]
+        values: ["sandbox-executor", "trusted-executor"]
   policyTypes:
     - Ingress
     - Egress
@@ -102,6 +102,53 @@ spec:
         - port: 53
           protocol: TCP
     ## Internet only — no RFC1918, so no cluster-internal services.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+## Trusted worker pods (executor.trusted="k8s_shared"): admin-approved code.
+## Wider than sandbox — may call the Sinas API and the internet — but still
+## no direct line to postgres/redis/clickhouse: the pods carry no credentials
+## (meter integrity), and since in-cluster redis is unauthenticated this
+## policy is what makes that stick at the network level too.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-trusted-isolation
+  labels:
+    {{- include "sinas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      sinas.type: trusted-executor
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    ## kube-dns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    ## Sinas backend API only (functions call back with their access token)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+      ports:
+        - port: 8000
+          protocol: TCP
+    ## Internet — no RFC1918, so no other cluster-internal services.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -31,12 +31,18 @@ superadminEmail: ""
 ##   "k8s_pod"  — one ephemeral hardened Pod per execution (default).
 ##   "disabled" — reject sandbox executions (trusted-only deployment).
 ## trusted: admin-approved code (Function.shared_pool=true).
-##   "inprocess" — runs inside the queue-worker process (default).
-##                 Note: shares the worker's credentials; approve shared_pool
-##                 functions accordingly.
+##   "k8s_shared" — warm long-lived credential-free pods (default). Trusted
+##                  code cannot reach platform credentials or the usage
+##                  meter; paired with the trusted-isolation NetworkPolicy.
+##   "inprocess"  — runs inside the queue-worker process. Smallest footprint
+##                  (no warm pods), but trusted code shares the worker's
+##                  credentials — do not use on metered/billable instances.
+##   "disabled"   — reject shared_pool executions with a clear error.
 executor:
   sandbox: "k8s_pod"
-  trusted: "inprocess"
+  trusted: "k8s_shared"
+  ## Number of warm trusted worker pods (k8s_shared only).
+  trustedWorkers: 2
   ## Image for sandbox pods. Must be pullable by the cluster. Extra packages
   ## (Dependency table) are pip-installed into each pod at create time; bake
   ## them into a custom image and set installDependencies: false to skip that

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -84,6 +84,21 @@ reject explicitly rather than half-working.
 | `CODE_EXECUTION_ENABLED` | `true` | `false` disables **all** execution of user-supplied code: Functions and the agent `codeExecution` tool. The tool is not advertised to the model, function execution is refused at every trigger (API, webhook, schedule, agent, CDC), and sandbox/shared-worker startup is skipped entirely — no pool, no per-execution pods, no executor image. The single biggest footprint reduction available. |
 | `BUILTIN_DATABASE_ENABLED` | `true` | `false` skips creating the `sinas_data` database and its default Database Connection at startup, for deployments that only use their own connections. Does **not** affect the platform's own PostgreSQL, and an already-created database and record are left untouched (so the toggle is reversible and non-destructive). |
 
+## Usage Metering (Optional)
+
+Default off. When enabled, every operation (function execution, code execution, query, agent invocation, file upload, other tool calls) increments a live counter; the scheduler snapshots it durably and pushes the **cumulative** period-to-date total to an external collector. Pure emission — nothing is enforced on the instance, no limits are pulled down, and an unreachable collector or Redis blip never affects platform behavior (the next heartbeat self-heals). Intended for managed/multi-instance operators.
+
+| Variable | Default | Description |
+|---|---|---|
+| `METERING_ENABLED` | `false` | Master switch. |
+| `METERING_ENDPOINT` | _(none)_ | Endpoint receiving heartbeat JSON (`sinas.metering/v1`), cumulative totals + `by_kind`, `Idempotency-Key` per push. |
+| `METERING_API_KEY` | _(none)_ | Sent as `Authorization: Bearer <key>`. |
+| `METERING_INSTANCE_ID` | `DOMAIN` | Identifier for this instance in reports. |
+| `METERING_SNAPSHOT_MINUTES` | `5` | Cadence of the durable Redis → Postgres snapshot. |
+| `METERING_PUSH_MINUTES` | `15` | Heartbeat cadence (jittered per instance so fleets don't push in sync). |
+
+Meter integrity: sandbox and shared executor containers receive no Redis/database credentials, so code they run cannot alter the count. `TRUSTED_EXECUTOR=inprocess` breaks that guarantee (client code runs inside a credential-bearing process) — enabling metering in that mode logs a warning; use `docker_shared` on billable instances.
+
 ## Executors
 
 How Sinas runs user code. `SANDBOX_EXECUTOR` handles untrusted code

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -97,7 +97,7 @@ Default off. When enabled, every operation (function execution, code execution, 
 | `METERING_SNAPSHOT_MINUTES` | `5` | Cadence of the durable Redis → Postgres snapshot. |
 | `METERING_PUSH_MINUTES` | `15` | Heartbeat cadence (jittered per instance so fleets don't push in sync). |
 
-Meter integrity: sandbox and shared executor containers receive no Redis/database credentials, so code they run cannot alter the count. `TRUSTED_EXECUTOR=inprocess` breaks that guarantee (client code runs inside a credential-bearing process) — enabling metering in that mode logs a warning; use `docker_shared` on billable instances.
+Meter integrity: sandbox and shared executor containers/pods receive no Redis/database credentials, so code they run cannot alter the count. `TRUSTED_EXECUTOR=inprocess` breaks that guarantee (client code runs inside a credential-bearing process) — enabling metering in that mode logs a warning. Metered instances should use `docker_shared` (Docker) or `k8s_shared` (Kubernetes), or `disabled` if shared-pool functions aren't needed.
 
 ## Executors
 
@@ -109,12 +109,16 @@ execution; `TRUSTED_EXECUTOR` handles admin-approved functions
 | Variable | Default | Description |
 |---|---|---|
 | `SANDBOX_EXECUTOR` | `docker_pool` | `docker_pool` (warm container pool), `docker_ephemeral` (single-use container per execution, baked package image), `k8s_pod` (single-use Kubernetes pod per execution), or `disabled` (reject sandbox executions) |
-| `TRUSTED_EXECUTOR` | `docker_shared` | `docker_shared` (long-lived shared worker containers) or `inprocess` (run inside the queue-worker process — no Docker socket needed, but no `input()`/pause support) |
+| `TRUSTED_EXECUTOR` | `docker_shared` | `docker_shared` (long-lived shared worker containers), `k8s_shared` (long-lived credential-free Kubernetes pods), `inprocess` (run inside the queue-worker process — no Docker socket needed, but no `input()`/pause support), or `disabled` (reject shared-pool executions) |
+| `K8S_TRUSTED_WORKERS` | `2` | Number of warm trusted worker pods (`k8s_shared` only). |
 
-With `SANDBOX_EXECUTOR=k8s_pod` and `TRUSTED_EXECUTOR=inprocess`, no process
-needs a Docker socket — this is the configuration the Helm chart uses.
-`inprocess` runs trusted code with the worker's own environment and
-credentials, so only enable `shared_pool` on functions you'd trust with them.
+On Kubernetes, `SANDBOX_EXECUTOR=k8s_pod` with `TRUSTED_EXECUTOR=k8s_shared`
+is the Helm chart's default: no process needs a Docker socket, and trusted
+code runs in warm pods that carry no platform credentials (dispatch latency
+is an exec round-trip, not a pod cold-start). `inprocess` remains the
+smallest-footprint option, but it runs trusted code with the worker's own
+environment and credentials — only enable `shared_pool` on functions you'd
+trust with them, and don't combine it with usage metering.
 
 ### Kubernetes executor (`SANDBOX_EXECUTOR=k8s_pod`)
 


### PR DESCRIPTION
Implements the [metering design](https://brain-agency.atlassian.net/wiki/spaces/Sinas/pages/5034508290/Operations+metering+usage-based+billing+design) at pure-emission scope: **nothing is enforced on the instance** — no limits pulled, no status obeyed, heartbeat response body ignored (2xx = ack).

## Counting (§2, leaf-only)
`metering.record(kind)` → atomic Redis `INCRBY`, fire-and-forget (Redis blip can never fail a customer request; `METERING_ENABLED=false` = no-op). Wired at the five leaf chokepoints — function execution (all triggers), query execution (the single shared path), agent invocation (after the hook-block check), file upload (after authz), code execution — plus `TOOL` in the dispatch ladder **only** for branches without a leaf meter. `counted_at_leaf` flags on the code/sub-agent/pipeline/query/function branches keep "agent turn calling 3 functions" = 1 agent + 3 function, never double-counted. Rejected/unauthorized calls aren't counted.

## Durability (§3b)
- `usage_periods` — one row per `(instance_id, period_id)`, upserted by a 5-min snapshot job with **max() semantics** (the durable count never regresses).
- Redis re-seeded from the row at scheduler startup (max of both sides): neither a Redis restart nor a stale snapshot moves the count backwards.

## Emission (§5)
- Heartbeat POSTs the **cumulative** period-to-date `total` + `by_kind` — never deltas. A missed beat needs no catch-up: the next push carries the current total; receiver takes `max(total)` per `(instance, period)`.
- `Idempotency-Key: {instance}:{period}:{snapshot_seq}` per push; seq is monotonic.
- **Jitter**: per-instance start offset from `hash(instance_id)`, APScheduler trigger jitter, and backoff-with-jitter on retries — fleets never push in sync.
- Monthly `period_id` (UTC) as the fallback anchor (platform-supplied anchors slot into the same field later). Rollover finalizes the old period through the same snapshot→push path, then expires its Redis keys.

## Meter integrity (§6) — including the k8s executor fix
The invariant: no process that executes client code may hold meter write access. Credential scoping alone can't deliver this (in-process client code can monkeypatch `record()` in memory, or `INCRBY` negative values ACLs can't block) — only a process boundary can.

- **Verified**: sandbox and shared executor containers receive no `REDIS_URL`/`DATABASE_URL` — the invariant holds on Docker (`docker_shared`) as-is.
- **New `TRUSTED_EXECUTOR=k8s_shared`** (now the chart default, was `inprocess`): warm long-lived credential-free trusted worker pods (`K8S_TRUSTED_WORKERS=2`), dispatched over the existing k8s exec IPC — docker_shared-class latency (warm pod + exec round-trip, no cold start), same payload/secrets/resume semantics. Deterministic pod names, self-healing recreation, round-robin with failover.
- **New trusted-isolation NetworkPolicy**: trusted pods get egress to DNS + backend API + internet, but not postgres/redis/clickhouse (in-cluster redis is unauthenticated — the services policy would otherwise have granted them intra-namespace reach; it now excludes them).
- **New `TRUSTED_EXECUTOR=disabled`**: shared-pool executions rejected with a clear error, for metered instances that don't need them. No silent sandbox fallback.
- `inprocess` remains for slim self-hosted deployments; combining it with `METERING_ENABLED` logs a loud warning (client code in a credential-bearing process = forgeable meter).
- Platform-side backstop in the contract: cumulative totals + monotonic `snapshot_seq` → any decrease flags tampering.

## Env
`METERING_ENABLED` (off) · `METERING_ENDPOINT` · `METERING_API_KEY` · `METERING_INSTANCE_ID` (falls back to `DOMAIN`) · `METERING_SNAPSHOT_MINUTES=5` · `METERING_PUSH_MINUTES=15` · `K8S_TRUSTED_WORKERS=2`

## Tests
25 new: 15 metering (disabled no-op · increments + kinds · record-never-raises · snapshot upsert + never-regress · restart re-seed both directions · cumulative payload + Idempotency-Key + bearer · no-progress-no-push · re-push with next seq · failed-push retry, zero data loss · rollover finalize + key expiry · jitter deterministic/bounded/spread) + 10 executor-mode (factory modes · disabled rejects with clear error · k8s_shared payload incl. secrets · non-shared_pool refused · awaiting_input handle stamping · pod failover · resume dead-pod + happy path). Full suite: 288 passed, 7 pre-existing local-Redis failures. `helm lint` + template render clean.

Migration `u1s2a3g4e5p6` (new table only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)