### PR TITLE
feat(providers): cached-token reporting for OpenAI-compat + fix mid-turn system prompt loss

### DIFF
--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -167,12 +167,29 @@ class OpenAIProvider(BaseLLMProvider):
         return formatted
 
     def extract_usage(self, response: Any) -> dict[str, int]:
-        """Extract token usage from OpenAI response."""
-        if not response.usage:
-            return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        """Extract token usage from OpenAI response.
 
+        OpenAI's automatic prompt caching reports the cached portion in
+        prompt_tokens_details.cached_tokens (already included in
+        prompt_tokens). Also covers OpenAI-compatible endpoints (Azure
+        inherits this; Gemini's compat layer may report it too).
+        cache_write_tokens stays 0: OpenAI has no write premium.
+        """
+        if not response.usage:
+            return {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+
+        details = getattr(response.usage, "prompt_tokens_details", None)
+        cache_read = (getattr(details, "cached_tokens", 0) or 0) if details else 0
         return {
             "prompt_tokens": response.usage.prompt_tokens,
             "completion_tokens": response.usage.completion_tokens,
             "total_tokens": response.usage.total_tokens,
+            "cache_read_tokens": cache_read,
+            "cache_write_tokens": 0,
         }

--- a/backend/app/services/conversation_history.py
+++ b/backend/app/services/conversation_history.py
@@ -18,6 +18,44 @@ from app.services.template_renderer import render_template
 logger = logging.getLogger(__name__)
 
 
+async def build_agent_system_content(
+    db: AsyncSession,
+    agent: Agent,
+    skill_converter: SkillToolConverter,
+    template_variables: Optional[dict[str, Any]] = None,
+) -> str:
+    """Render the agent's full system content: Jinja2-templated system
+    prompt + preloaded skills + output-schema instruction.
+
+    Shared by the initial LLM call (build_conversation_history) and the
+    tool-loop follow-up (message_service) so the system prompt can't
+    diverge mid-turn.
+    """
+    system_content = ""
+    if agent.system_prompt:
+        if template_variables:
+            try:
+                system_content = render_template(agent.system_prompt, template_variables)
+            except Exception as e:
+                logger.error(f"Failed to render system prompt template: {e}")
+                system_content = agent.system_prompt
+        else:
+            system_content = agent.system_prompt
+
+    if agent.enabled_skills:
+        preloaded_content = await skill_converter.get_preloaded_skills_content(
+            db=db, enabled_skills=agent.enabled_skills
+        )
+        if preloaded_content:
+            system_content += f"\n\n# Preloaded Skills\n\n{preloaded_content}"
+
+    if agent.output_schema and agent.output_schema.get("properties"):
+        schema_instruction = f"\n\nIMPORTANT: You must respond with valid JSON matching this exact schema:\n```json\n{json.dumps(agent.output_schema, indent=2)}\n```\nDo not include any text outside the JSON object."
+        system_content += schema_instruction
+
+    return system_content
+
+
 async def build_conversation_history(
     db: AsyncSession,
     chat: Chat,
@@ -52,29 +90,10 @@ async def build_conversation_history(
     if chat.agent_id:
         result = await db.execute(select(Agent).where(Agent.id == chat.agent_id))
         agent = result.scalar_one_or_none()
-        if agent and agent.system_prompt:
-            # Render system prompt with Jinja2 if template_variables provided
-            if template_variables:
-                try:
-                    system_content = render_template(agent.system_prompt, template_variables)
-                except Exception as e:
-                    logger.error(f"Failed to render system prompt template: {e}")
-                    system_content = agent.system_prompt
-            else:
-                system_content = agent.system_prompt
-
-        # Inject preloaded skills content into system prompt
-        if agent and agent.enabled_skills:
-            preloaded_content = await skill_converter.get_preloaded_skills_content(
-                db=db, enabled_skills=agent.enabled_skills
+        if agent:
+            system_content = await build_agent_system_content(
+                db, agent, skill_converter, template_variables
             )
-            if preloaded_content:
-                system_content += f"\n\n# Preloaded Skills\n\n{preloaded_content}"
-
-        # Add output schema instruction if agent has one
-        if agent and agent.output_schema and agent.output_schema.get("properties"):
-            schema_instruction = f"\n\nIMPORTANT: You must respond with valid JSON matching this exact schema:\n```json\n{json.dumps(agent.output_schema, indent=2)}\n```\nDo not include any text outside the JSON object."
-            system_content += schema_instruction
 
     # Inject relevant context if enabled
     # No agent = no context injection

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -25,7 +25,10 @@ from app.utils.schema import validate_with_coercion
 from app.services.content_tokens import strip_base64_data, refresh_message_tokens  # noqa: F401 — re-exported
 from app.services.hook_service import run_hooks, HookResult
 from app.services.tool_result_store import save_tool_result
-from app.services.conversation_history import build_conversation_history
+from app.services.conversation_history import (
+    build_agent_system_content,
+    build_conversation_history,
+)
 from app.services.function_tools import FunctionToolConverter
 from app.services.query_tools import QueryToolConverter
 from app.services.skill_tools import SkillToolConverter
@@ -1154,21 +1157,15 @@ class MessageService:
         if chat and chat.agent_id:
             result_agent = await self.db.execute(select(Agent).where(Agent.id == chat.agent_id))
             agent = result_agent.scalar_one_or_none()
-            if agent and agent.system_prompt:
-                system_content = agent.system_prompt
+            if agent:
+                template_vars = None
                 if chat.chat_metadata and "agent_input" in chat.chat_metadata:
-                    try:
-                        system_content = render_template(
-                            agent.system_prompt, chat.chat_metadata["agent_input"]
-                        )
-                    except Exception as e:
-                        logger.error(f"Failed to render system prompt template: {e}")
-
-                if agent.output_schema and agent.output_schema.get("properties"):
-                    schema_instruction = f"\n\nIMPORTANT: You must respond with valid JSON matching this exact schema:\n```json\n{json.dumps(agent.output_schema, indent=2)}\n```\nDo not include any text outside the JSON object."
-                    system_content += schema_instruction
-
-                updated_messages.append({"role": "system", "content": system_content})
+                    template_vars = chat.chat_metadata["agent_input"]
+                system_content = await build_agent_system_content(
+                    self.db, agent, self.skill_converter, template_vars
+                )
+                if system_content:
+                    updated_messages.append({"role": "system", "content": system_content})
 
         result = await self.db.execute(
             select(Message).where(Message.chat_id == chat_id).order_by(Message.created_at)

--- a/backend/tests/unit/test_agent_system_content.py
+++ b/backend/tests/unit/test_agent_system_content.py
@@ -1,0 +1,92 @@
+"""Unit tests for build_agent_system_content — the shared system-prompt
+builder used by both the initial LLM call and the tool-loop follow-up.
+
+Regression coverage for the bug where follow-up calls dropped preloaded
+skills (and, for promptless agents, the output-schema instruction) because
+the follow-up path rebuilt the system prompt with its own inline logic.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.conversation_history import build_agent_system_content
+
+
+class _FakeSkillConverter:
+    def __init__(self, content=""):
+        self._content = content
+        self.calls = []
+
+    async def get_preloaded_skills_content(self, db, enabled_skills):
+        self.calls.append(enabled_skills)
+        return self._content
+
+
+def _agent(**overrides):
+    agent = SimpleNamespace(
+        system_prompt="You are a helpful assistant.",
+        enabled_skills=None,
+        output_schema=None,
+    )
+    for key, value in overrides.items():
+        setattr(agent, key, value)
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_plain_system_prompt():
+    content = await build_agent_system_content(None, _agent(), _FakeSkillConverter())
+    assert content == "You are a helpful assistant."
+
+
+@pytest.mark.asyncio
+async def test_template_rendering_with_variables():
+    agent = _agent(system_prompt="Hello {{ name }}.")
+    content = await build_agent_system_content(
+        None, agent, _FakeSkillConverter(), {"name": "Kjeld"}
+    )
+    assert content == "Hello Kjeld."
+
+
+@pytest.mark.asyncio
+async def test_preloaded_skills_appended():
+    agent = _agent(enabled_skills=[{"name": "docs", "preload": True}])
+    converter = _FakeSkillConverter("How to write docs...")
+    content = await build_agent_system_content(None, agent, converter)
+    assert content.startswith("You are a helpful assistant.")
+    assert "# Preloaded Skills" in content
+    assert "How to write docs..." in content
+    assert converter.calls == [[{"name": "docs", "preload": True}]]
+
+
+@pytest.mark.asyncio
+async def test_output_schema_instruction_appended():
+    agent = _agent(output_schema={"properties": {"answer": {"type": "string"}}})
+    content = await build_agent_system_content(None, agent, _FakeSkillConverter())
+    assert "valid JSON matching this exact schema" in content
+    assert '"answer"' in content
+
+
+@pytest.mark.asyncio
+async def test_skills_and_schema_without_system_prompt():
+    """Agents with no system_prompt still get skills + schema content —
+    the old follow-up path dropped everything in this case."""
+    agent = _agent(
+        system_prompt=None,
+        enabled_skills=[{"name": "docs", "preload": True}],
+        output_schema={"properties": {"x": {}}},
+    )
+    content = await build_agent_system_content(
+        None, agent, _FakeSkillConverter("Skill body")
+    )
+    assert "Skill body" in content
+    assert "valid JSON" in content
+
+
+@pytest.mark.asyncio
+async def test_template_error_falls_back_to_raw_prompt():
+    agent = _agent(system_prompt="Broken {% if %}")
+    content = await build_agent_system_content(
+        None, agent, _FakeSkillConverter(), {"name": "x"}
+    )
+    assert content == "Broken {% if %}"

--- a/backend/tests/unit/test_llm_usage_tracking.py
+++ b/backend/tests/unit/test_llm_usage_tracking.py
@@ -198,7 +198,13 @@ async def test_openai_stream_requests_and_emits_usage():
     assert captured["stream_options"] == {"include_usage": True}
     assert out[0]["content"] == "hi"
     assert "usage" not in out[0]
-    assert out[-1]["usage"] == {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+    assert out[-1]["usage"] == {
+        "prompt_tokens": 7,
+        "completion_tokens": 3,
+        "total_tokens": 10,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
 
 
 async def test_azure_drop_params_strips_stream_options():

--- a/backend/tests/unit/test_openai_cache_usage.py
+++ b/backend/tests/unit/test_openai_cache_usage.py
@@ -1,0 +1,67 @@
+"""Unit tests for cached-token extraction in the OpenAI provider.
+
+OpenAI's automatic prompt caching reports the cached portion of the prompt
+in usage.prompt_tokens_details.cached_tokens; Azure and OpenAI-compatible
+endpoints (e.g. Gemini's compat layer) reuse this code path.
+"""
+from types import SimpleNamespace
+
+from app.providers import OpenAIProvider
+
+
+def _provider():
+    return OpenAIProvider(api_key="test-key")
+
+
+def test_extract_usage_with_cached_tokens():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=5000,
+            completion_tokens=100,
+            total_tokens=5100,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=4096),
+        )
+    )
+    usage = _provider().extract_usage(response)
+    # OpenAI's prompt_tokens already includes the cached portion — no summing
+    assert usage["prompt_tokens"] == 5000
+    assert usage["cache_read_tokens"] == 4096
+    assert usage["cache_write_tokens"] == 0  # OpenAI has no write premium
+    assert usage["total_tokens"] == 5100
+
+
+def test_extract_usage_without_details():
+    """Endpoints that don't report prompt_tokens_details (older APIs, some
+    compat layers) must not break — cache fields default to 0."""
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=200, completion_tokens=50, total_tokens=250,
+            prompt_tokens_details=None,
+        )
+    )
+    usage = _provider().extract_usage(response)
+    assert usage["prompt_tokens"] == 200
+    assert usage["cache_read_tokens"] == 0
+    assert usage["cache_write_tokens"] == 0
+
+
+def test_extract_usage_details_without_cached_tokens():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=200, completion_tokens=50, total_tokens=250,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=None),
+        )
+    )
+    usage = _provider().extract_usage(response)
+    assert usage["cache_read_tokens"] == 0
+
+
+def test_extract_usage_no_usage():
+    usage = _provider().extract_usage(SimpleNamespace(usage=None))
+    assert usage == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }


### PR DESCRIPTION
## Summary
Two follow-ups to #98 (Anthropic prompt caching):

**1. Cached-token visibility for OpenAI-compatible providers.** `OpenAIProvider.extract_usage` now reads `prompt_tokens_details.cached_tokens` into `cache_read_tokens`. OpenAI/Azure caching is automatic and server-side (50% off cached tokens, ≥1024-token stable prefixes) — this makes hits visible in `llm_usage`, including for the default Azure `gpt-5` provider and Gemini via its OpenAI-compat endpoint. No request changes; `cache_write_tokens` stays 0 (no write premium). No migration needed — columns landed in #98.

**2. Fix: tool-loop follow-up calls dropped preloaded skills.** The follow-up path after tool execution rebuilt the system prompt inline with only `system_prompt` + output schema — losing preloaded skills content mid-turn (and the entire system message for promptless agents with skills/schema). Extracted `build_agent_system_content` as the single builder used by both the initial call and the follow-up.

Note: stored-context injection intentionally remains initial-call-only for now — it moves to tail injection in the Phase 2 caching work.

## Test plan
- [x] 10 new unit tests (cached-token extraction variants; system-content builder incl. the promptless-agent regression case)
- [x] Full unit suite: 228 passed, 90 pre-existing env errors (same count on clean dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)