### PR TITLE
fix(helm): fail fast when required secrets are empty

### DIFF
--- a/charts/sinas/templates/secret.yaml
+++ b/charts/sinas/templates/secret.yaml
@@ -6,9 +6,9 @@ metadata:
     {{- include "sinas.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  secret-key: {{ .Values.secrets.secretKey | quote }}
-  encryption-key: {{ .Values.secrets.encryptionKey | quote }}
-  database-password: {{ .Values.postgres.password | quote }}
+  secret-key: {{ required "secrets.secretKey is required — set it via --set secrets.secretKey=... or a values file" .Values.secrets.secretKey | quote }}
+  encryption-key: {{ required "secrets.encryptionKey is required — set it via --set secrets.encryptionKey=... or a values file" .Values.secrets.encryptionKey | quote }}
+  database-password: {{ required "postgres.password is required — set it via --set postgres.password=... or a values file (postgres refuses to start without a superuser password)" .Values.postgres.password | quote }}
   {{- if .Values.clickhouse.enabled }}
   clickhouse-password: {{ .Values.clickhouse.password | quote }}
   {{- end }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -62,7 +62,7 @@ registry:
 postgres:
   user: postgres
   database: sinas
-  password: ""
+  password: ""  # required — install fails if empty
   storage: 5Gi
 
 ## Redis


### PR DESCRIPTION
## Summary
A fresh `helm install` without `postgres.password` left `postgres-0` in CrashLoopBackOff ("Database is uninitialized and superuser password is not specified"), with the failure only visible in pod logs. This wraps `postgres.password` in Helm's `required` so `helm install`/`helm template` errors immediately with a clear message.

While at it: `secrets.secretKey` and `secrets.encryptionKey` were only marked required by a comment in values.yaml and rendered into the Secret as empty strings, failing just as silently — they now get the same `required` treatment.

## Changes
- `charts/sinas/templates/secret.yaml` — `secret-key`, `encryption-key`, and `database-password` wrapped in `required` with messages naming the exact `--set` flag to pass
- `charts/sinas/values.yaml` — `postgres.password` commented as required

## Verification
- `helm template` with no values → fails fast on `secrets.secretKey`
- `helm template` with only `postgres.password` missing → fails on exactly that, message explains postgres refuses to start without a superuser password
- `helm template` with all three set → renders correctly
- `helm lint` with values → passes; compact profile (`clickhouse.enabled=false`) renders clean
- CI (`.github/workflows/helm.yml`) already passes all three values in every step, so it stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)