### PR TITLE
feat(agents): per-agent provider overrides — prompt_caching first

### DIFF
--- a/backend/alembic/versions/a1g2t3o4v5r6_agent_provider_overrides.py
+++ b/backend/alembic/versions/a1g2t3o4v5r6_agent_provider_overrides.py
@@ -1,0 +1,22 @@
+"""agent.provider_overrides — per-agent whitelisted provider settings
+
+Revision ID: a1g2t3o4v5r6
+Revises: p1r2o3v4b5t6
+Create Date: 2026-08-11
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1g2t3o4v5r6"
+down_revision = "p1r2o3v4b5t6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("provider_overrides", sa.JSON, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "provider_overrides")

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -75,6 +75,7 @@ async def create_agent(
         description=agent_data.description,
         llm_provider_id=agent_data.llm_provider_id,
         model=agent_data.model,
+        provider_overrides=agent_data.provider_overrides,
         temperature=agent_data.temperature or 0.7,
         max_tokens=agent_data.max_tokens,
         system_prompt=agent_data.system_prompt,
@@ -214,6 +215,10 @@ async def update_agent(
         agent.llm_provider_id = agent_data.llm_provider_id
     if agent_data.model is not None:
         agent.model = agent_data.model
+    if agent_data.provider_overrides is not None:
+        # {} clears all overrides (back to pure inherit); keys are whitelisted
+        # by the schema validator.
+        agent.provider_overrides = agent_data.provider_overrides or None
     if agent_data.temperature is not None:
         agent.temperature = agent_data.temperature
     if agent_data.max_tokens is not None:

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -38,6 +38,11 @@ class Agent(Base, PermissionMixin):
         ForeignKey("llm_providers.id"), index=True
     )  # NULL = use default provider
     model: Mapped[Optional[str]] = mapped_column(String(100))  # NULL = use provider's default model
+    # Per-agent overrides of provider BEHAVIOR settings (whitelisted keys
+    # only — see app.providers.factory.AGENT_OVERRIDABLE). Absent key =
+    # inherit the provider's setting. Connection/credential settings are
+    # deliberately not overridable here.
+    provider_overrides: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
     temperature: Mapped[float] = mapped_column(Float, default=0.7)
     max_tokens: Mapped[Optional[int]] = mapped_column(Integer)  # NULL = use provider's default
 

--- a/backend/app/providers/factory.py
+++ b/backend/app/providers/factory.py
@@ -14,12 +14,54 @@ from .ollama_provider import OllamaProvider
 from .openai_provider import OpenAIProvider
 from .tracking import UsageTrackingProvider
 
+# Provider settings an AGENT may override (Agent.provider_overrides).
+# key -> (expected type, provider attribute). Strictly behavior settings:
+# connection/credential settings (api_key, base_url, org ids) must never be
+# agent-overridable — an agent author could redirect the provider's key.
+# Keys whose attribute a provider doesn't have are ignored for that provider
+# (e.g. prompt_caching on OpenAI, where caching is automatic).
+AGENT_OVERRIDABLE: dict[str, tuple[type, str]] = {
+    "prompt_caching": (bool, "enable_prompt_caching"),
+}
+
+
+def validate_provider_overrides(overrides: Any) -> list[str]:
+    """Validate an Agent.provider_overrides value. Returns error strings."""
+    if overrides is None:
+        return []
+    if not isinstance(overrides, dict):
+        return ["provider_overrides must be an object"]
+    errors = []
+    for key, value in overrides.items():
+        spec = AGENT_OVERRIDABLE.get(key)
+        if spec is None:
+            errors.append(
+                f"Unknown provider override '{key}' — allowed: "
+                f"{', '.join(sorted(AGENT_OVERRIDABLE))}"
+            )
+        elif not isinstance(value, spec[0]):
+            errors.append(
+                f"Provider override '{key}' must be {spec[0].__name__}, "
+                f"got {type(value).__name__}"
+            )
+    return errors
+
+
+def _apply_overrides(provider: BaseLLMProvider, overrides: Optional[dict[str, Any]]) -> None:
+    if not overrides:
+        return
+    for key, value in overrides.items():
+        spec = AGENT_OVERRIDABLE.get(key)
+        if spec and isinstance(value, spec[0]) and hasattr(provider, spec[1]):
+            setattr(provider, spec[1], value)
+
 
 async def create_provider(
     provider_name: Optional[str] = None,
     model: Optional[str] = None,
     db: Optional[AsyncSession] = None,
     usage_context: Optional[dict[str, Any]] = None,
+    overrides: Optional[dict[str, Any]] = None,
 ) -> BaseLLMProvider:
     """
     Create an LLM provider instance from database configuration.
@@ -100,6 +142,10 @@ async def create_provider(
         provider = OllamaProvider(base_url=base_url or "http://localhost:11434")
     else:
         raise ValueError(f"Unknown provider type: {provider_type}")
+
+    # Per-agent behavior overrides (Agent.provider_overrides), applied after
+    # construction so they win over the provider-level config.
+    _apply_overrides(provider, overrides)
 
     return UsageTrackingProvider(
         inner=provider,

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -72,6 +72,20 @@ class AgentCreate(BaseModel):
     description: Optional[str] = None
     llm_provider_id: Optional[uuid.UUID] = None  # NULL = use default provider
     model: Optional[str] = None  # NULL = use provider's default model
+    # Whitelisted provider behavior overrides (e.g. {"prompt_caching": false});
+    # absent key = inherit provider setting. See providers.factory.AGENT_OVERRIDABLE.
+    provider_overrides: Optional[dict[str, Any]] = None
+
+    @field_validator("provider_overrides")
+    @classmethod
+    def _check_provider_overrides(cls, v):
+        from app.providers.factory import validate_provider_overrides
+
+        errors = validate_provider_overrides(v)
+        if errors:
+            raise ValueError("; ".join(errors))
+        return v
+
     temperature: Optional[float] = 0.7
     max_tokens: Optional[int] = None  # NULL = use provider's default
     system_prompt: Optional[str] = None
@@ -129,6 +143,18 @@ class AgentUpdate(BaseModel):
     description: Optional[str] = None
     llm_provider_id: Optional[uuid.UUID] = None
     model: Optional[str] = None
+    provider_overrides: Optional[dict[str, Any]] = None
+
+    @field_validator("provider_overrides")
+    @classmethod
+    def _check_provider_overrides(cls, v):
+        from app.providers.factory import validate_provider_overrides
+
+        errors = validate_provider_overrides(v)
+        if errors:
+            raise ValueError("; ".join(errors))
+        return v
+
     temperature: Optional[float] = None
     max_tokens: Optional[int] = None
     system_prompt: Optional[str] = None
@@ -177,6 +203,7 @@ class AgentResponse(BaseModel):
     description: Optional[str]
     llm_provider_id: Optional[uuid.UUID]
     model: Optional[str]
+    provider_overrides: Optional[dict[str, Any]] = None
     temperature: float
     max_tokens: Optional[int]
     system_prompt: Optional[str]

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -186,6 +186,8 @@ class AgentConfig(BaseModel):
     description: Optional[str] = None
     llmProviderName: Optional[str] = None  # NULL = use default provider
     model: Optional[str] = None  # NULL = use provider's default model
+    # Whitelisted provider behavior overrides, e.g. {"prompt_caching": false}
+    providerOverrides: Optional[dict[str, Any]] = None
     temperature: float = 0.7
     maxTokens: Optional[int] = None
     systemPrompt: Optional[str] = None

--- a/backend/app/services/batch_service.py
+++ b/backend/app/services/batch_service.py
@@ -109,7 +109,9 @@ async def _resolve_batch_provider(
             f"Agent has no model and provider '{provider_row.name}' has no default_model"
         )
 
-    provider = await create_provider(provider_name=provider_row.name, db=db)
+    provider = await create_provider(
+        provider_name=provider_row.name, db=db, overrides=agent.provider_overrides
+    )
     if not provider.supports_batch:
         raise BatchError(
             f"Provider '{provider_row.name}' ({provider_row.provider_type}) does not "

--- a/backend/app/services/config_apply/agents.py
+++ b/backend/app/services/config_apply/agents.py
@@ -22,6 +22,24 @@ from app.services.config_apply.normalizers import (
 logger = logging.getLogger(__name__)
 
 
+def _validated_overrides(agent_config, errors: list[str]):
+    """Whitelist-check providerOverrides; invalid entries become apply errors
+    (same fail-loudly posture as unresolvable provider names)."""
+    overrides = getattr(agent_config, "providerOverrides", None)
+    if not overrides:
+        return None
+    from app.providers.factory import validate_provider_overrides
+
+    problems = validate_provider_overrides(overrides)
+    if problems:
+        errors.extend(
+            f"Agent '{agent_config.namespace}/{agent_config.name}': {p}"
+            for p in problems
+        )
+        return None
+    return overrides
+
+
 async def _resolve_llm_provider_id(
     db: AsyncSession,
     provider_name: str | None,
@@ -188,6 +206,9 @@ async def apply_agents(
 
                     existing.description = agent_config.description
                     existing.model = agent_config.model
+                    existing.provider_overrides = _validated_overrides(
+                        agent_config, errors
+                    )
                     existing.temperature = agent_config.temperature
                     existing.max_tokens = agent_config.maxTokens
                     existing.system_prompt = agent_config.systemPrompt
@@ -247,6 +268,7 @@ async def apply_agents(
                         description=agent_config.description,
                         llm_provider_id=llm_provider_id,
                         model=agent_config.model,
+                        provider_overrides=_validated_overrides(agent_config, errors),
                         temperature=agent_config.temperature,
                         max_tokens=agent_config.maxTokens,
                         system_prompt=agent_config.systemPrompt,

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -316,6 +316,7 @@ class MessageService:
                 "agent": f"{agent.namespace}/{agent.name}" if agent else None,
                 "source": "chat",
             },
+            overrides=agent.provider_overrides if agent else None,
         )
 
         # If no model specified, use the provider's default model
@@ -1153,6 +1154,7 @@ class MessageService:
         chat = result_chat.scalar_one_or_none()
 
         updated_messages = []
+        agent = None
 
         if chat and chat.agent_id:
             result_agent = await self.db.execute(select(Agent).where(Agent.id == chat.agent_id))
@@ -1205,6 +1207,7 @@ class MessageService:
                 "agent": _agent_label,
                 "source": "chat",
             },
+            overrides=agent.provider_overrides if agent else None,
         )
 
         clean_tools = strip_tool_metadata(tools)

--- a/backend/tests/unit/test_provider_overrides.py
+++ b/backend/tests/unit/test_provider_overrides.py
@@ -1,0 +1,145 @@
+"""Per-agent provider overrides (Agent.provider_overrides).
+
+Whitelisted behavior settings only — the first key is prompt_caching, which
+retires the "duplicate the provider as X-Uncached" pattern.
+"""
+
+from types import SimpleNamespace
+
+from app.providers import AnthropicProvider, OpenAIProvider
+from app.providers.factory import (
+    AGENT_OVERRIDABLE,
+    _apply_overrides,
+    validate_provider_overrides,
+)
+
+
+class TestValidation:
+    def test_none_and_valid(self):
+        assert validate_provider_overrides(None) == []
+        assert validate_provider_overrides({"prompt_caching": False}) == []
+        assert validate_provider_overrides({"prompt_caching": True}) == []
+
+    def test_unknown_key_rejected(self):
+        errors = validate_provider_overrides({"api_key": "steal-me"})
+        assert len(errors) == 1
+        assert "api_key" in errors[0]
+        # The error names what IS allowed
+        assert "prompt_caching" in errors[0]
+
+    def test_wrong_type_rejected(self):
+        errors = validate_provider_overrides({"prompt_caching": "false"})
+        assert len(errors) == 1
+        assert "bool" in errors[0]
+
+    def test_non_dict_rejected(self):
+        assert validate_provider_overrides("prompt_caching=false") != []
+
+    def test_whitelist_never_contains_connection_settings(self):
+        """Guard rail: an agent override must not be able to redirect the
+        provider's credentials."""
+        forbidden = {"api_key", "base_url", "api_endpoint", "azure_endpoint"}
+        assert not forbidden & set(AGENT_OVERRIDABLE)
+
+
+class TestApplication:
+    def test_disables_caching_on_anthropic(self):
+        provider = AnthropicProvider(api_key="k")  # caching defaults to on
+        assert provider.enable_prompt_caching is True
+        _apply_overrides(provider, {"prompt_caching": False})
+        assert provider.enable_prompt_caching is False
+
+    def test_enables_caching_over_provider_config(self):
+        provider = AnthropicProvider(api_key="k", enable_prompt_caching=False)
+        _apply_overrides(provider, {"prompt_caching": True})
+        assert provider.enable_prompt_caching is True
+
+    def test_ignored_on_providers_without_the_attr(self):
+        provider = OpenAIProvider(api_key="k")  # OpenAI caching is automatic
+        _apply_overrides(provider, {"prompt_caching": False})
+        assert not hasattr(provider, "enable_prompt_caching")
+
+    def test_none_is_noop(self):
+        provider = AnthropicProvider(api_key="k")
+        _apply_overrides(provider, None)
+        assert provider.enable_prompt_caching is True
+
+
+class TestConfigApply:
+    def test_valid_overrides_pass_through(self):
+        from app.services.config_apply.agents import _validated_overrides
+
+        cfg = SimpleNamespace(
+            namespace="default", name="a",
+            providerOverrides={"prompt_caching": False},
+        )
+        errors: list[str] = []
+        assert _validated_overrides(cfg, errors) == {"prompt_caching": False}
+        assert errors == []
+
+    def test_invalid_overrides_become_apply_errors(self):
+        from app.services.config_apply.agents import _validated_overrides
+
+        cfg = SimpleNamespace(
+            namespace="default", name="a",
+            providerOverrides={"base_url": "https://evil.example"},
+        )
+        errors: list[str] = []
+        assert _validated_overrides(cfg, errors) is None
+        assert len(errors) == 1
+        assert "default/a" in errors[0]
+
+    def test_absent_is_none(self):
+        from app.services.config_apply.agents import _validated_overrides
+
+        cfg = SimpleNamespace(namespace="default", name="a", providerOverrides=None)
+        errors: list[str] = []
+        assert _validated_overrides(cfg, errors) is None
+        assert errors == []
+
+
+class TestAgentAPI:
+    async def test_round_trip_and_validation(self, client, test_user, db):
+        from tests.conftest import auth_headers
+
+        headers = auth_headers(test_user)
+        create = await client.post(
+            "/api/v1/agents",
+            headers=headers,
+            json={
+                "namespace": "default",
+                "name": "override_agent",
+                "provider_overrides": {"prompt_caching": False},
+            },
+        )
+        assert create.status_code == 201, create.text
+        assert create.json()["provider_overrides"] == {"prompt_caching": False}
+
+        # Unknown key → validation error, not silent drop
+        bad = await client.post(
+            "/api/v1/agents",
+            headers=headers,
+            json={
+                "namespace": "default",
+                "name": "override_agent2",
+                "provider_overrides": {"base_url": "https://evil.example"},
+            },
+        )
+        assert bad.status_code == 422
+
+        # Update flips it; {} clears back to inherit
+        upd = await client.put(
+            "/api/v1/agents/default/override_agent",
+            headers=headers,
+            json={"provider_overrides": {"prompt_caching": True}},
+        )
+        assert upd.status_code == 200, upd.text
+        assert upd.json()["provider_overrides"] == {"prompt_caching": True}
+
+        cleared = await client.put(
+            "/api/v1/agents/default/override_agent",
+            headers=headers,
+            json={"provider_overrides": {}},
+        )
+        assert cleared.status_code == 200
+        assert cleared.json()["provider_overrides"] is None

--- a/console/src/pages/AgentDetail.tsx
+++ b/console/src/pages/AgentDetail.tsx
@@ -606,6 +606,36 @@ for chunk in client.chats.stream(chat["id"], "Hello"):
                 Maximum number of tokens to generate in the response
               </p>
             </div>
+
+            <div>
+              <label htmlFor="prompt_caching" className="block text-sm font-medium text-gray-300 mb-2">
+                Prompt Caching
+              </label>
+              <select
+                id="prompt_caching"
+                className="input"
+                value={
+                  (formData.provider_overrides ?? agent.provider_overrides ?? {}).prompt_caching === undefined
+                    ? 'inherit'
+                    : String((formData.provider_overrides ?? agent.provider_overrides ?? {}).prompt_caching)
+                }
+                onChange={(e) => {
+                  const current = { ...(formData.provider_overrides ?? agent.provider_overrides ?? {}) };
+                  if (e.target.value === 'inherit') delete current.prompt_caching;
+                  else current.prompt_caching = e.target.value === 'true';
+                  setFormData({ ...formData, provider_overrides: current });
+                }}
+              >
+                <option value="inherit">Inherit from provider</option>
+                <option value="true">Enabled</option>
+                <option value="false">Disabled</option>
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                Override the provider's prompt-caching setting for this agent.
+                Caching pays off for agents with large, reused system prompts;
+                one-shot agents may be cheaper without it.
+              </p>
+            </div>
           </div>
         </div>
 

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -235,6 +235,7 @@ export interface Agent {
   name: string;
   description: string | null;
   llm_provider_id: string | null;
+  provider_overrides?: Record<string, boolean> | null;
   model: string | null;
   temperature: number;
   max_tokens: number | null;
@@ -271,6 +272,7 @@ export interface AgentCreate {
   name: string;
   description?: string;
   llm_provider_id?: string;
+  provider_overrides?: Record<string, boolean>;
   model?: string;
   temperature?: number;
   max_tokens?: number;
@@ -300,6 +302,7 @@ export interface AgentUpdate {
   name?: string;
   description?: string;
   llm_provider_id?: string;
+  provider_overrides?: Record<string, boolean>;
   model?: string;
   temperature?: number;
   max_tokens?: number;

--- a/docs-mint/build-resources/agents.mdx
+++ b/docs-mint/build-resources/agents.mdx
@@ -13,6 +13,7 @@ Agents are configurable AI assistants. Each agent has an LLM provider, a system 
 | `namespace` / `name` | Unique identifier (e.g., `support/ticket-agent`) |
 | `llm_provider_id` | LLM provider to use (null = system default) |
 | `model` | Model override (null = provider's default) |
+| `provider_overrides` | Per-agent overrides of provider behavior settings, e.g. `{"prompt_caching": false}`. Absent key = inherit the provider's setting. Only whitelisted behavior keys are accepted; connection settings can't be overridden. Config key: `providerOverrides`. |
 | `system_prompt` | Jinja2 template for the system message |
 | `temperature` | Sampling temperature (default: 0.7) |
 | `max_tokens` | Max token limit for responses |


### PR DESCRIPTION
Targets **release/0.4.0** per Kjeld — small feature, big cost lever.

Cached/uncached was provider-level, so per-workload tuning meant duplicating providers (\`Claude Haiku Uncached\` in our own dev DB). Caching is per-workload by nature: chatty agents with big system prompts win; one-shot agents pay the 25% write premium for nothing — and provider batches sharpen the tradeoff.

## Design
- \`Agent.provider_overrides\` (JSON, nullable) — whitelisted **behavior** settings; absent key = inherit provider. First key: \`prompt_caching\`.
- **Whitelist as security boundary** (\`factory.AGENT_OVERRIDABLE\`): connection/credential settings are never agent-overridable (an agent-level \`base_url\` would redirect the provider's API key). A test pins that.
- Applied post-construction in \`create_provider(overrides=...)\`; wired through both chat paths and provider-batch submission. Providers without the attribute ignore the key (OpenAI caching is automatic).
- API validation → 422 on unknown key/wrong type; \`{}\` on update clears. Config apply: \`providerOverrides\`, invalid entries are apply errors.
- Console: Prompt Caching tri-state (inherit/enabled/disabled) in the agent editor.

## Tests
13 new (whitelist validation incl. the connection-settings guard, application semantics, config apply, API round-trip/422/clear). Full suite 345 passed + the 7 known local-Redis env failures. Console tsc + build clean.

Migration \`a1g2t3o4v5r6\` — nullable column only, chains off the release head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)