### PR TITLE
fix(providers): round-trip Gemini 3 thought_signature on tool calls

### DIFF
--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -144,7 +144,14 @@ class OpenAIProvider(BaseLLMProvider):
             yield result
 
     def format_tool_calls(self, tool_calls: Any) -> list[dict[str, Any]]:
-        """Convert OpenAI tool calls to standard format (already in correct format)."""
+        """Convert OpenAI tool calls to standard format (already in correct format).
+
+        Extra fields the endpoint attaches are preserved, not reconstructed
+        away: OpenAI-compatible gateways can require them round-tripped in
+        the conversation history. Gemini 3 rejects tool-loop turns with
+        "Function call is missing a thought_signature" unless the signature
+        from each functionCall part is sent back verbatim.
+        """
         formatted = []
 
         for idx, tc in enumerate(tool_calls):
@@ -164,6 +171,17 @@ class OpenAIProvider(BaseLLMProvider):
             # Include index if present (used in streaming)
             if hasattr(tc, "index"):
                 tool_call_dict["index"] = tc.index
+
+            # Preserve extra fields the SDK didn't model (pydantic stores
+            # unknown response fields in model_extra) — e.g. Gemini's
+            # thought_signature / extra_content on the call or its function.
+            for key, value in (getattr(tc, "model_extra", None) or {}).items():
+                if value is not None and key not in tool_call_dict:
+                    tool_call_dict[key] = value
+            fn = getattr(tc, "function", None)
+            for key, value in (getattr(fn, "model_extra", None) or {}).items():
+                if value is not None and key not in tool_call_dict["function"]:
+                    tool_call_dict["function"][key] = value
 
             formatted.append(tool_call_dict)
 

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -675,6 +675,17 @@ class MessageService:
                         tool_calls_list[tc_index]["function"]["arguments"] += tc["function"][
                             "arguments"
                         ]
+                    # Preserve any extra per-call fields (e.g. Gemini's
+                    # thought_signature) — providers can require them
+                    # round-tripped in the follow-up history.
+                    for key, value in tc.items():
+                        if key in ("id", "type", "function", "index") or value is None:
+                            continue
+                        tool_calls_list[tc_index][key] = value
+                    for key, value in (tc.get("function") or {}).items():
+                        if key in ("name", "arguments") or value is None:
+                            continue
+                        tool_calls_list[tc_index]["function"][key] = value
 
             yield chunk
 
@@ -1263,6 +1274,17 @@ class MessageService:
                         tool_calls_list[tc_index]["function"]["arguments"] += tc["function"][
                             "arguments"
                         ]
+                    # Preserve any extra per-call fields (e.g. Gemini's
+                    # thought_signature) — providers can require them
+                    # round-tripped in the follow-up history.
+                    for key, value in tc.items():
+                        if key in ("id", "type", "function", "index") or value is None:
+                            continue
+                        tool_calls_list[tc_index][key] = value
+                    for key, value in (tc.get("function") or {}).items():
+                        if key in ("name", "arguments") or value is None:
+                            continue
+                        tool_calls_list[tc_index]["function"][key] = value
 
             yield chunk
 

--- a/backend/tests/unit/test_tool_call_extras_roundtrip.py
+++ b/backend/tests/unit/test_tool_call_extras_roundtrip.py
@@ -1,0 +1,113 @@
+"""Round-tripping provider-specific extra fields on tool calls.
+
+Gemini 3 (via its OpenAI-compat endpoint) rejects tool-loop turns with
+"400: Function call is missing a thought_signature in functionCall parts"
+unless the signature it emitted on each function call is sent back verbatim
+in the conversation history. Sinas used to reconstruct tool calls "clean" at
+two points; these tests pin that extras now survive every hop:
+
+  provider response -> format_tool_calls -> persisted Message.tool_calls
+  -> history rebuild -> request params
+"""
+
+from types import SimpleNamespace
+
+from app.providers import OpenAIProvider
+
+
+def _sdk_tool_call(**extra):
+    """Mimic an OpenAI-SDK tool call object; pydantic puts unknown response
+    fields in model_extra."""
+    fn = SimpleNamespace(name="search", arguments='{"q": "x"}', model_extra=None)
+    tc = SimpleNamespace(
+        id="call_1", type="function", function=fn, model_extra=extra or None
+    )
+    return tc
+
+
+class TestFormatToolCalls:
+    def test_preserves_call_level_extras(self):
+        tc = _sdk_tool_call(thought_signature="sig-abc")
+        (formatted,) = OpenAIProvider(api_key="k").format_tool_calls([tc])
+        assert formatted["thought_signature"] == "sig-abc"
+        # standard fields intact
+        assert formatted["id"] == "call_1"
+        assert formatted["function"]["name"] == "search"
+
+    def test_preserves_nested_extra_content(self):
+        tc = _sdk_tool_call(
+            extra_content={"google": {"thought_signature": "sig-abc"}}
+        )
+        (formatted,) = OpenAIProvider(api_key="k").format_tool_calls([tc])
+        assert formatted["extra_content"] == {
+            "google": {"thought_signature": "sig-abc"}
+        }
+
+    def test_preserves_function_level_extras(self):
+        tc = _sdk_tool_call()
+        tc.function.model_extra = {"thought_signature": "sig-fn"}
+        (formatted,) = OpenAIProvider(api_key="k").format_tool_calls([tc])
+        assert formatted["function"]["thought_signature"] == "sig-fn"
+        assert formatted["function"]["arguments"] == '{"q": "x"}'
+
+    def test_no_extras_unchanged(self):
+        (formatted,) = OpenAIProvider(api_key="k").format_tool_calls(
+            [_sdk_tool_call()]
+        )
+        assert set(formatted) == {"id", "type", "function"}
+
+
+class TestDownstreamPassthrough:
+    """The hops after the provider must not re-strip what we preserved."""
+
+    def test_validate_tool_calls_keeps_extras(self):
+        from app.services.tool_execution import validate_tool_calls
+
+        tc = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": "{}"},
+            "thought_signature": "sig-abc",
+        }
+        (validated,) = validate_tool_calls([tc])
+        assert validated["thought_signature"] == "sig-abc"
+
+    async def test_history_rebuild_keeps_extras(self, db, test_user):
+        from app.models import Chat, Message
+        from app.services.conversation_history import build_conversation_history
+        from app.services.skill_tools import SkillToolConverter
+
+        chat = Chat(user_id=test_user.id, title="t")
+        db.add(chat)
+        await db.flush()
+        db.add(Message(chat_id=chat.id, role="user", content="find x"))
+        db.add(
+            Message(
+                chat_id=chat.id,
+                role="assistant",
+                content=None,
+                tool_calls=[{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                    "thought_signature": "sig-abc",
+                    "description": "ui-only, must be stripped",
+                }],
+            )
+        )
+        db.add(
+            Message(
+                chat_id=chat.id, role="tool", tool_call_id="call_1",
+                name="search", content='{"found": true}',
+            )
+        )
+        await db.flush()
+
+        messages = await build_conversation_history(
+            db=db, chat=chat, skill_converter=SkillToolConverter(),
+            inject_context=False, user_id=str(test_user.id),
+        )
+        assistant = next(m for m in messages if m.get("tool_calls"))
+        (tc,) = assistant["tool_calls"]
+        assert tc["thought_signature"] == "sig-abc"
+        assert "description" not in tc  # UI-only strip still applies


### PR DESCRIPTION
Field report: all tool-using agents on Gemini 3 die on turn two with \`400: Function call is missing a thought_signature in functionCall parts\`; tool-less agents work. Root cause confirmed in Sinas — we reconstructed tool calls "clean" and dropped the extra fields the compat layer requires round-tripped.

Two strip points, both fixed:
1. \`openai_provider.format_tool_calls\` — whitelisted \`id/type/function/index\`; now merges the SDK's \`model_extra\` (call-level and function-level) into the formatted dict.
2. The stream delta merge in \`message_service\` (both the initial-turn and follow-up copies) — now carries unknown per-call/per-function fields.

Everything downstream (Message.tool_calls persistence, history rebuild, \`validate_tool_calls\`) was already passthrough — 6 new tests pin the full chain, including that the UI-only \`description\` strip still applies and that plain-OpenAI formatting is unchanged when no extras exist.

Targets release/0.4.0: Gemini 3 + tools is fully broken without it. Full suite 351 passed + 7 known local-Redis env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)