### PR TITLE
feat(providers): Gemini provider type with working batch support

### DIFF
--- a/backend/app/providers/__init__.py
+++ b/backend/app/providers/__init__.py
@@ -2,6 +2,7 @@ from .anthropic_provider import AnthropicProvider
 from .azure_openai_provider import AzureOpenAIProvider
 from .base import BaseLLMProvider
 from .factory import create_provider
+from .gemini_provider import GeminiProvider
 from .mistral_provider import MistralProvider
 from .ollama_provider import OllamaProvider
 from .openai_provider import OpenAIProvider
@@ -13,6 +14,7 @@ __all__ = [
     "OpenAIProvider",
     "AzureOpenAIProvider",
     "AnthropicProvider",
+    "GeminiProvider",
     "OllamaProvider",
     "MistralProvider",
     "create_provider",

--- a/backend/app/providers/factory.py
+++ b/backend/app/providers/factory.py
@@ -8,6 +8,7 @@ from app.core.encryption import EncryptionService
 
 from .anthropic_provider import AnthropicProvider
 from .azure_openai_provider import AzureOpenAIProvider
+from .gemini_provider import GeminiProvider
 from .base import BaseLLMProvider
 from .mistral_provider import MistralProvider
 from .ollama_provider import OllamaProvider
@@ -129,6 +130,8 @@ async def create_provider(
             drop_params=config.get("drop_params"),
             extra_params=config.get("extra_params"),
         )
+    elif provider_type == "gemini":
+        provider = GeminiProvider(api_key=api_key, base_url=base_url)
     elif provider_type == "mistral":
         provider = MistralProvider(api_key=api_key, base_url=base_url)
     elif provider_type == "anthropic":

--- a/backend/app/providers/gemini_provider.py
+++ b/backend/app/providers/gemini_provider.py
@@ -1,0 +1,89 @@
+"""Gemini LLM provider — OpenAI-compatible chat with Google-native batch files.
+
+Chat completions, streaming, and tool calling run through Google's
+OpenAI-compatible endpoint, inherited unchanged from OpenAIProvider.
+Prompt caching is implicit on Gemini 2.5+ models (server-side, nothing to
+send); cache hits surface via prompt_tokens_details.cached_tokens when the
+compat layer reports them.
+
+Batch is the hybrid flow from https://ai.google.dev/gemini-api/docs/openai#batch:
+batches.create/retrieve/cancel work through the OpenAI client, but the
+compat layer does NOT support files.create/files.content — the JSONL input
+upload and result download must use Google's Files API, which the two hook
+overrides below implement over plain REST.
+"""
+import logging
+from typing import Any, Optional
+
+import httpx
+
+from .openai_provider import OpenAIProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+# Google's SDK uploads batch JSONL with this literal mime type.
+_JSONL_MIME = "jsonl"
+
+
+class GeminiProvider(OpenAIProvider):
+    supports_batch = True
+
+    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
+        super().__init__(api_key=api_key, base_url=base_url or DEFAULT_BASE_URL)
+
+        # Derive the Files API roots from the compat base URL:
+        #   https://host/v1beta/openai/  →  https://host/v1beta         (download)
+        #                                →  https://host/upload/v1beta  (upload)
+        root = (self.base_url or DEFAULT_BASE_URL).rstrip("/")
+        if root.endswith("/openai"):
+            root = root[: -len("/openai")]
+        self._files_root = root
+        scheme_host, _, api_path = root.partition("/v1")
+        self._upload_root = f"{scheme_host}/upload/v1{api_path}"
+
+    def _files_headers(self) -> dict[str, str]:
+        return {"x-goog-api-key": self.api_key or ""}
+
+    async def _upload_batch_file(self, jsonl: bytes) -> str:
+        """Upload via Google's resumable Files API; returns the file name
+        (e.g. "files/abc123"), which the compat batches.create accepts as
+        input_file_id."""
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            start = await client.post(
+                f"{self._upload_root}/files",
+                headers={
+                    **self._files_headers(),
+                    "X-Goog-Upload-Protocol": "resumable",
+                    "X-Goog-Upload-Command": "start",
+                    "X-Goog-Upload-Header-Content-Length": str(len(jsonl)),
+                    "X-Goog-Upload-Header-Content-Type": _JSONL_MIME,
+                },
+                json={"file": {"display_name": "sinas-batch.jsonl"}},
+            )
+            start.raise_for_status()
+            upload_url = start.headers["X-Goog-Upload-URL"]
+
+            finish = await client.post(
+                upload_url,
+                headers={
+                    **self._files_headers(),
+                    "X-Goog-Upload-Command": "upload, finalize",
+                    "X-Goog-Upload-Offset": "0",
+                },
+                content=jsonl,
+            )
+            finish.raise_for_status()
+            return finish.json()["file"]["name"]
+
+    async def _download_batch_file(self, file_id: str) -> str:
+        """Download a generated batch result file via the Files API."""
+        async with httpx.AsyncClient(timeout=300.0, follow_redirects=True) as client:
+            resp = await client.get(
+                f"{self._files_root}/{file_id}:download",
+                params={"alt": "media"},
+                headers=self._files_headers(),
+            )
+            resp.raise_for_status()
+            return resp.text

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -217,6 +217,22 @@ class OpenAIProvider(BaseLLMProvider):
 
     # ── Batch API ─────────────────────────────────────────────────────────
 
+    async def _upload_batch_file(self, jsonl: bytes) -> str:
+        """Upload the batch input file; returns its file id.
+
+        Hook: Gemini's OpenAI-compat endpoint supports batches.create but not
+        files.create — its subclass replaces this with Google's Files API.
+        """
+        input_file = await self.client.files.create(
+            file=("batch.jsonl", jsonl), purpose="batch"
+        )
+        return input_file.id
+
+    async def _download_batch_file(self, file_id: str) -> str:
+        """Download a batch output/error file's text content (same hook rationale)."""
+        content = await self.client.files.content(file_id)
+        return content.text
+
     async def submit_batch(self, requests: list[dict[str, Any]]) -> str:
         lines = []
         for req in requests:
@@ -236,11 +252,9 @@ class OpenAIProvider(BaseLLMProvider):
             }))
         jsonl = ("\n".join(lines) + "\n").encode("utf-8")
 
-        input_file = await self.client.files.create(
-            file=("batch.jsonl", jsonl), purpose="batch"
-        )
+        input_file_id = await self._upload_batch_file(jsonl)
         batch = await self.client.batches.create(
-            input_file_id=input_file.id,
+            input_file_id=input_file_id,
             endpoint="/v1/chat/completions",
             completion_window="24h",
         )
@@ -267,8 +281,8 @@ class OpenAIProvider(BaseLLMProvider):
         ):
             if not file_id:
                 continue
-            content = await self.client.files.content(file_id)
-            for line in content.text.splitlines():
+            text = await self._download_batch_file(file_id)
+            for line in text.splitlines():
                 if not line.strip():
                     continue
                 entry = json.loads(line)

--- a/backend/tests/unit/test_provider_batch.py
+++ b/backend/tests/unit/test_provider_batch.py
@@ -338,3 +338,144 @@ async def test_provider_submit_records_agent_ops(monkeypatch):
 
     src = inspect.getsource(batch_service.submit_agent_batch)
     assert "metering.record(metering.OperationKind.AGENT, n=len(requests))" in src
+
+
+# ── Gemini batch adapter (hybrid: OpenAI batches + Google Files API) ─────
+
+
+class _FakeHttpxResponse:
+    def __init__(self, headers=None, json_data=None, text=""):
+        self.headers = headers or {}
+        self._json = json_data
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+class _FakeHttpxClient:
+    """Stands in for httpx.AsyncClient; replays scripted responses."""
+
+    calls: list = []
+    responses: dict = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, **kwargs):
+        _FakeHttpxClient.calls.append(("POST", url, kwargs))
+        post_count = len([c for c in _FakeHttpxClient.calls if c[0] == "POST"])
+        return _FakeHttpxClient.responses[("POST", post_count)]
+
+    async def get(self, url, **kwargs):
+        _FakeHttpxClient.calls.append(("GET", url, kwargs))
+        return _FakeHttpxClient.responses[("GET", 1)]
+
+
+def _patch_httpx(monkeypatch, responses):
+    from app.providers import gemini_provider
+
+    _FakeHttpxClient.calls = []
+    _FakeHttpxClient.responses = responses
+    monkeypatch.setattr(gemini_provider.httpx, "AsyncClient", _FakeHttpxClient)
+    return _FakeHttpxClient
+
+
+def test_gemini_defaults_and_url_derivation():
+    from app.providers import GeminiProvider
+
+    provider = GeminiProvider(api_key="g")
+    assert provider.supports_batch is True
+    assert provider.base_url == "https://generativelanguage.googleapis.com/v1beta/openai/"
+    assert provider._files_root == "https://generativelanguage.googleapis.com/v1beta"
+    assert provider._upload_root == "https://generativelanguage.googleapis.com/upload/v1beta"
+
+    proxied = GeminiProvider(api_key="g", base_url="https://proxy.corp/v1beta/openai/")
+    assert proxied._files_root == "https://proxy.corp/v1beta"
+    assert proxied._upload_root == "https://proxy.corp/upload/v1beta"
+
+
+async def test_gemini_upload_batch_file(monkeypatch):
+    from app.providers import GeminiProvider
+
+    fake = _patch_httpx(monkeypatch, {
+        ("POST", 1): _FakeHttpxResponse(
+            headers={"X-Goog-Upload-URL": "https://upload.example/u1"}
+        ),
+        ("POST", 2): _FakeHttpxResponse(json_data={"file": {"name": "files/in123"}}),
+    })
+
+    provider = GeminiProvider(api_key="g")
+    file_id = await provider._upload_batch_file(b'{"custom_id": "e1"}\n')
+
+    assert file_id == "files/in123"
+    method, url, kwargs = fake.calls[0]
+    assert url == "https://generativelanguage.googleapis.com/upload/v1beta/files"
+    assert kwargs["headers"]["x-goog-api-key"] == "g"
+    assert kwargs["headers"]["X-Goog-Upload-Protocol"] == "resumable"
+    # Second call goes to the session URL from the start response
+    assert fake.calls[1][1] == "https://upload.example/u1"
+    assert fake.calls[1][2]["headers"]["X-Goog-Upload-Command"] == "upload, finalize"
+
+
+async def test_gemini_download_batch_file(monkeypatch):
+    from app.providers import GeminiProvider
+
+    fake = _patch_httpx(monkeypatch, {
+        ("GET", 1): _FakeHttpxResponse(text='{"custom_id": "e1"}\n'),
+    })
+
+    provider = GeminiProvider(api_key="g")
+    text = await provider._download_batch_file("files/out9")
+
+    assert text == '{"custom_id": "e1"}\n'
+    method, url, kwargs = fake.calls[0]
+    assert url == "https://generativelanguage.googleapis.com/v1beta/files/out9:download"
+    assert kwargs["params"] == {"alt": "media"}
+
+
+async def test_gemini_submit_batch_uses_google_upload(monkeypatch):
+    """End-to-end submit: JSONL goes to Google's Files API, the returned
+    file name feeds the OpenAI-compat batches.create."""
+    from app.providers import GeminiProvider
+
+    _patch_httpx(monkeypatch, {
+        ("POST", 1): _FakeHttpxResponse(
+            headers={"X-Goog-Upload-URL": "https://upload.example/u1"}
+        ),
+        ("POST", 2): _FakeHttpxResponse(json_data={"file": {"name": "files/in123"}}),
+    })
+
+    provider = GeminiProvider(api_key="g")
+    captured = {}
+
+    async def fake_batch_create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id="batches/gem1")
+
+    provider.client = SimpleNamespace(
+        batches=SimpleNamespace(create=fake_batch_create)
+    )
+
+    batch_id = await provider.submit_batch([
+        {
+            "custom_id": "exec-1",
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "gemini-2.5-flash",
+            "temperature": 0.2,
+            "max_tokens": None,
+        }
+    ])
+
+    assert batch_id == "batches/gem1"
+    assert captured["input_file_id"] == "files/in123"
+    assert captured["endpoint"] == "/v1/chat/completions"


### PR DESCRIPTION
Lands commit 859f832 (built in a parallel session, pushed to merged #123's old branch — cherry-picked here so it actually ships).

Google's OpenAI-compat endpoint supports `batches.create/retrieve/cancel` but **not** `files.create`/`files.content`, so the inherited OpenAI batch adapter fails at the file steps. New first-class `gemini` provider type: chat/streaming/tools inherit unchanged from `OpenAIProvider` (compat endpoint, default base_url baked in); batch input upload and result download go through Google's native Files API over REST (resumable upload → `files/{name}`, `:download?alt=media`) — the hybrid flow from Google's docs. The two file steps in `OpenAIProvider` became overridable hooks; JSONL building, status mapping, and result parsing stay shared.

Also adds `gemini` to the console's provider-type dropdowns (this PR's one addition on top of the cherry-pick).

Suite: 355 passed + 7 known local-Redis env failures. Live Gemini batch test to follow on the local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)