### PR TITLE
fix(providers): parse Gemini camelCase batch usage

### DIFF
--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -300,12 +300,22 @@ class OpenAIProvider(BaseLLMProvider):
                     if choices:
                         item["content"] = (choices[0].get("message") or {}).get("content")
                     usage = body.get("usage") or {}
-                    details = usage.get("prompt_tokens_details") or {}
+                    # Gemini's batch output reports usage in camelCase
+                    # (promptTokens); OpenAI uses snake_case. Accept both.
+                    details = (
+                        usage.get("prompt_tokens_details")
+                        or usage.get("promptTokensDetails")
+                        or {}
+                    )
                     item["usage"] = {
-                        "prompt_tokens": usage.get("prompt_tokens", 0) or 0,
-                        "completion_tokens": usage.get("completion_tokens", 0) or 0,
-                        "total_tokens": usage.get("total_tokens", 0) or 0,
-                        "cache_read_tokens": details.get("cached_tokens", 0) or 0,
+                        "prompt_tokens": usage.get("prompt_tokens")
+                        or usage.get("promptTokens") or 0,
+                        "completion_tokens": usage.get("completion_tokens")
+                        or usage.get("completionTokens") or 0,
+                        "total_tokens": usage.get("total_tokens")
+                        or usage.get("totalTokens") or 0,
+                        "cache_read_tokens": details.get("cached_tokens")
+                        or details.get("cachedTokens") or 0,
                         "cache_write_tokens": 0,
                     }
                 else:

--- a/backend/tests/unit/test_provider_batch.py
+++ b/backend/tests/unit/test_provider_batch.py
@@ -479,3 +479,29 @@ async def test_gemini_submit_batch_uses_google_upload(monkeypatch):
     assert batch_id == "batches/gem1"
     assert captured["input_file_id"] == "files/in123"
     assert captured["endpoint"] == "/v1/chat/completions"
+
+
+async def test_gemini_camelcase_usage_parsed():
+    """Gemini's batch output JSONL reports usage in camelCase — zeros were
+    recorded until the parser accepted both namings."""
+    import json as _json
+    from types import SimpleNamespace as NS
+
+    output = _json.dumps({
+        "custom_id": "exec-1",
+        "response": {
+            "status_code": 200,
+            "body": {
+                "choices": [{"message": {"content": "hi"}}],
+                "usage": {"promptTokens": 29, "completionTokens": 21, "totalTokens": 1373},
+            },
+        },
+    })
+    provider, _ = _openai_with_fake_batches(
+        batch=NS(status="completed", output_file_id="file_out", error_file_id=None),
+        file_contents={"file_out": output + "\n"},
+    )
+    (result,) = await provider.fetch_batch_results("b")
+    assert result["usage"]["prompt_tokens"] == 29
+    assert result["usage"]["completion_tokens"] == 21
+    assert result["usage"]["total_tokens"] == 1373

--- a/console/src/pages/LLMProviders.tsx
+++ b/console/src/pages/LLMProviders.tsx
@@ -245,6 +245,7 @@ export function LLMProviders() {
                 >
                   <option value="openai">OpenAI</option>
                   <option value="azure">Azure OpenAI</option>
+                  <option value="gemini">Google Gemini</option>
                   <option value="anthropic">Anthropic (Claude)</option>
                   <option value="mistral">Mistral AI</option>
                   <option value="ollama">Ollama</option>
@@ -422,6 +423,7 @@ export function LLMProviders() {
                 >
                   <option value="openai">OpenAI</option>
                   <option value="azure">Azure OpenAI</option>
+                  <option value="gemini">Google Gemini</option>
                   <option value="anthropic">Anthropic (Claude)</option>
                   <option value="mistral">Mistral AI</option>
                   <option value="ollama">Ollama</option>


### PR DESCRIPTION
Follow-up to #128, found in the live e2e: Gemini batches completed 2/2 but recorded 0 tokens — its output JSONL uses camelCase usage keys (`promptTokens`) where OpenAI uses snake_case. Parser now accepts both; test with the exact observed payload. Also actually commits the console dropdown addition #128's description claimed (was edited but never staged — my miss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)