### PR TITLE
Console: enable pipeline tools on agents

### DIFF
--- a/console/src/pages/AgentDetail.tsx
+++ b/console/src/pages/AgentDetail.tsx
@@ -66,6 +66,12 @@ export function AgentDetail() {
     retry: false,
   });
 
+  const { data: pipelines } = useQuery({
+    queryKey: ['pipelines'],
+    queryFn: () => apiClient.listPipelines(),
+    retry: false,
+  });
+
   const { data: databaseConnections } = useQuery({
     queryKey: ['databaseConnections'],
     queryFn: () => apiClient.listDatabaseConnections(),
@@ -79,7 +85,7 @@ export function AgentDetail() {
     retry: false,
   });
 
-  const [toolsTab, setToolsTab] = useState<'assistants' | 'skills' | 'functions' | 'queries' | 'states' | 'collections' | 'components' | 'connectors' | 'hooks' | 'status' | 'platform'>('assistants');
+  const [toolsTab, setToolsTab] = useState<'assistants' | 'skills' | 'functions' | 'queries' | 'states' | 'collections' | 'components' | 'connectors' | 'pipelines' | 'hooks' | 'status' | 'platform'>('assistants');
   const [expandedFunctionParams, setExpandedFunctionParams] = useState<Set<string>>(new Set());
   const [expandedConnectorParams, setExpandedConnectorParams] = useState<Set<string>>(new Set());
   const [iconMode, setIconMode] = useState<'collection' | 'url'>('collection');
@@ -114,6 +120,7 @@ export function AgentDetail() {
         enabled_collections: agent.enabled_collections || [],
         enabled_components: agent.enabled_components || [],
         enabled_connectors: agent.enabled_connectors || [],
+        enabled_pipelines: agent.enabled_pipelines || [],
         hooks: agent.hooks || { on_user_message: [], on_assistant_message: [] },
         status_templates: agent.status_templates || {},
         icon: agent.icon || undefined,
@@ -749,6 +756,17 @@ for chunk in client.chats.stream(chat["id"], "Hello"):
             </button>
             <button
               type="button"
+              onClick={() => setToolsTab('pipelines')}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                toolsTab === 'pipelines'
+                  ? 'text-primary-600 border-b-2 border-primary-600'
+                  : 'text-gray-400 hover:text-gray-100'
+              }`}
+            >
+              Pipelines
+            </button>
+            <button
+              type="button"
               onClick={() => setToolsTab('hooks')}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
                 toolsTab === 'hooks'
@@ -1305,6 +1323,65 @@ for chunk in client.chats.stream(chat["id"], "Hello"):
                     <p className="text-sm text-gray-500">No queries available. Create queries first.</p>
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Pipelines Tab */}
+            {toolsTab === 'pipelines' && (
+              <div>
+                <p className="text-xs text-gray-500 mb-3">
+                  Enable pipelines exposed as tools (asTool) — one semantic tool per pipeline,
+                  executed inline within the pipeline's sync timeout
+                </p>
+                {(() => {
+                  const toolPipelines = (pipelines || []).filter((p: any) => p.as_tool);
+                  return toolPipelines.length > 0 ? (
+                    <div className="space-y-2 border border-line-soft rounded-lg p-3 max-h-64 overflow-y-auto">
+                      {toolPipelines.map((pipeline: any) => {
+                        const pipelineRef = `${pipeline.namespace}/${pipeline.name}`;
+                        return (
+                          <label
+                            key={pipelineRef}
+                            className="flex items-start p-2 hover:bg-hover rounded cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={(formData.enabled_pipelines || agent.enabled_pipelines || []).includes(pipelineRef)}
+                              onChange={(e) => {
+                                const current = formData.enabled_pipelines || agent.enabled_pipelines || [];
+                                const updated = e.target.checked
+                                  ? [...current, pipelineRef]
+                                  : current.filter((ref: string) => ref !== pipelineRef);
+                                setFormData({ ...formData, enabled_pipelines: updated });
+                              }}
+                              className="mt-1 w-4 h-4 text-primary-600 border-line rounded focus:ring-primary-500"
+                            />
+                            <div className="ml-3 flex-1">
+                              <span className="text-sm font-medium text-gray-100 font-mono">{pipelineRef}</span>
+                              {!pipeline.is_active && (
+                                <span className="ml-2 px-1.5 py-0.5 text-xs font-medium rounded bg-red-900/30 text-red-400">
+                                  inactive
+                                </span>
+                              )}
+                              {(pipeline.tool_description || pipeline.description) && (
+                                <p className="text-xs text-gray-400 mt-0.5">
+                                  {pipeline.tool_description || pipeline.description}
+                                </p>
+                              )}
+                            </div>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <div className="bg-surface-0 rounded-lg p-3 border border-line-soft">
+                      <p className="text-sm text-gray-500">
+                        No tool-exposed pipelines available. Mark a pipeline with "Expose as an
+                        agent tool" (asTool) in the pipeline editor first.
+                      </p>
+                    </div>
+                  );
+                })()}
               </div>
             )}
 

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -253,6 +253,7 @@ export interface Agent {
   enabled_collections: EnabledCollectionConfig[];
   enabled_components: string[];
   enabled_connectors: EnabledConnectorConfig[];
+  enabled_pipelines: string[];
   hooks: AgentHooks | null;
   status_templates: Record<string, string>;
   icon: string | null;
@@ -287,6 +288,7 @@ export interface AgentCreate {
   enabled_stores?: EnabledStoreConfig[];
   enabled_collections?: EnabledCollectionConfig[];
   enabled_connectors?: EnabledConnectorConfig[];
+  enabled_pipelines?: string[];
   hooks?: AgentHooks;
   icon?: string;
   is_default?: boolean;
@@ -317,6 +319,7 @@ export interface AgentUpdate {
   enabled_collections?: EnabledCollectionConfig[];
   enabled_components?: string[];
   enabled_connectors?: EnabledConnectorConfig[];
+  enabled_pipelines?: string[];
   hooks?: AgentHooks;
   status_templates?: Record<string, string>;
   icon?: string;

--- a/docs-mint/build-resources/agents.mdx
+++ b/docs-mint/build-resources/agents.mdx
@@ -28,6 +28,7 @@ Agents are configurable AI assistants. Each agent has an LLM provider, a system 
 | `enabled_collections` | File collections the agent can access. Plain string (readonly) or `{"collection": "namespace/name", "access": "readonly\|readwrite"}`. Supports wildcards. Readwrite enables write/edit/delete file tools. |
 | `enabled_stores` | Stores the agent can access. List of `{"store": "namespace/name", "access": "readonly"}` or `{"store": "namespace/name", "access": "readwrite"}` |
 | `enabled_connectors` | Connectors available as tools. List of `{"connector": "namespace/name", "operations": [...], "parameters": {"op_name": {"param": "value"}}}`. Parameters support Jinja2 templates and are locked (hidden from LLM). |
+| `enabled_pipelines` | [Pipelines](/build-resources/pipelines) available as tools — only those marked `asTool`. Supports wildcards. Each becomes one semantic tool whose parameters are the pipeline's `inputSchema`. |
 | `hooks` | Message lifecycle hooks. `{"on_user_message": [...], "on_assistant_message": [...]}` |
 | `system_tools` | Platform capabilities. List of strings or config objects. See [System Tools](#system-tools). |
 | `icon` | Icon reference (see [Icons](#icons)) |
@@ -46,6 +47,8 @@ enabledFunctions:
   - shared/utils     # one specific function
 enabledQueries:
   - "*/*"            # all queries (quote wildcards in YAML)
+enabledPipelines:
+  - search/semantic  # an asTool pipeline, exposed as one tool
 enabledCollections:
   - collection: "docs/*"
     access: readonly


### PR DESCRIPTION
Closes a gap left by #114: the backend has supported `agent.enabled_pipelines` end to end (tool discovery, execution dispatch, permission check, config round-trip) since pipelines landed, but the **agent editor had no control for it** — so `asTool` pipelines were only reachable by editing YAML or calling the API directly. Not an intentional omission; just missed when wiring the console.

## Changes

- **Agent editor → new Pipelines tab** (next to Connectors): checkbox list of pipelines that have `asTool` set, showing the tool description (falling back to the pipeline description) and an `inactive` badge where relevant. Same shape as the Queries tab, so nothing new to learn.
- **Empty state that tells you what to do**: when no pipeline qualifies, it says to mark one with "Expose as an agent tool" in the pipeline editor — rather than an unexplained blank list. Pipelines without `asTool` are deliberately filtered out: enabling one would be silently ignored at tool-discovery time (the converter skips them with a warning), so offering them would be a lie.
- **Types**: `enabled_pipelines` added to the console's `Agent` / `AgentCreate` / `AgentUpdate` (it was missing, so the field would have been dropped from update payloads even if set elsewhere).
- **Docs**: `enabled_pipelines` row in the agents property table + a line in the wildcard example, pointing at the pipelines page.

## Verification

`tsc`: 19 errors before and after the change — all pre-existing `@sinas/sdk` workspace-package resolution in the chat components, unrelated to this diff. Not browser-clicked (the console can't fully build in this checkout for that same workspace-package reason); the tab reuses the Queries tab's exact interaction pattern, and the field round-trips through the same `formData` path as every other `enabled_*` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)