### PR TITLE
fix(queue): defer-and-retry function jobs when the shared pool is saturated

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -261,6 +261,11 @@ class Settings(BaseSettings):
     queue_agent_sub_concurrency: int = 5  # concurrency of the sub-agent queue worker
     queue_default_timeout: int = 300
     queue_max_retries: int = 3
+    # Saturation backpressure: how many deferred retries a function job gets
+    # when the shared worker pool is full, before it becomes a real failure.
+    # With exponential backoff capped at 30s this is roughly a 9-minute
+    # window for the pool to drain (bulk uploads, batch fan-outs).
+    queue_saturation_max_retries: int = 20
     queue_retry_delay: int = 10
 
     # Pipeline runs (see ADR 2026-07-28-pipelines-triggers-and-linear-steps).

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -2,12 +2,16 @@
 import asyncio
 import json
 import logging
+import random
 import time
 import uuid
 from typing import Any
 
+from arq.worker import Retry
+
 from app.core.config import settings
 from app.core.redis import get_redis_settings
+from app.services.shared_admission import SharedPoolSaturated
 from app.services.queue_service import (
     DLQ_KEY,
     JOB_RESULT_PREFIX,
@@ -148,6 +152,63 @@ async def execute_function_job(ctx: dict, **kwargs: Any) -> Any:
         completed = True
         logger.info(f"Function job {job_id} completed successfully")
         return result
+
+    except SharedPoolSaturated as e:
+        # Backpressure, not failure: the engine left the Execution row
+        # PENDING. Defer the job and let arq re-run it as slots free — this
+        # is what makes "30 rapid uploads onto a 4-slot pool" drain instead
+        # of 26 of them dying instantly.
+        job_try = ctx.get("job_try", 1)
+        budget = settings.queue_saturation_max_retries
+        if job_try < budget:
+            defer = min(2 ** job_try, 30) + random.uniform(0, 2)
+            await redis.set(
+                f"{JOB_STATUS_PREFIX}{job_id}",
+                json.dumps({
+                    **base_fields,
+                    "status": "queued",
+                    "detail": f"shared pool saturated; retry {job_try}/{budget} in {defer:.0f}s",
+                }),
+                ex=JOB_TTL,
+            )
+            logger.info(
+                f"Function job {job_id} deferred {defer:.0f}s "
+                f"(pool saturated, attempt {job_try}/{budget})"
+            )
+            completed = True
+            raise Retry(defer=defer)
+
+        # Budget exhausted — now it IS a failure. The engine skipped its
+        # failure bookkeeping for saturation, so do it here.
+        logger.error(f"Function job {job_id} failed: pool saturated for {budget} attempts")
+        from app.core.database import AsyncSessionLocal
+        from app.models.execution import Execution, ExecutionStatus
+        from sqlalchemy import select as _select
+        from datetime import datetime as _dt
+
+        async with AsyncSessionLocal() as _db:
+            row = (
+                await _db.execute(
+                    _select(Execution).where(Execution.execution_id == execution_id)
+                )
+            ).scalar_one_or_none()
+            if row and row.status == ExecutionStatus.PENDING:
+                row.status = ExecutionStatus.FAILED
+                row.error = str(e)
+                row.completed_at = _dt.utcnow()
+                await _db.commit()
+
+        await redis.set(
+            f"{JOB_STATUS_PREFIX}{job_id}",
+            json.dumps({**base_fields, "status": "failed", "error": str(e)}),
+            ex=JOB_TTL,
+        )
+        await redis.publish(
+            f"{JOB_DONE_CHANNEL_PREFIX}{execution_id}",
+            json.dumps({"status": "failed", "error": str(e)}),
+        )
+        completed = True
+        raise
 
     except Exception as e:
         logger.error(f"Function job {job_id} failed: {e}")
@@ -410,7 +471,10 @@ class WorkerSettings:
     queue_name = "sinas:queue:functions"
     max_jobs = settings.queue_function_concurrency
     job_timeout = settings.queue_default_timeout
-    max_tries = settings.queue_max_retries
+    # Must exceed the saturation budget or arq's own cap kills a deferred
+    # job before our explicit exhausted-path bookkeeping runs. Plain
+    # exceptions are unaffected: arq only re-runs jobs that raise Retry.
+    max_tries = max(settings.queue_max_retries, settings.queue_saturation_max_retries + 1)
     retry_delay = settings.queue_retry_delay
 
 

--- a/backend/app/services/execution_engine.py
+++ b/backend/app/services/execution_engine.py
@@ -18,6 +18,7 @@ from app.models.execution import Execution, ExecutionStatus
 from app.models.function import Function
 from app.services.clickhouse_logger import clickhouse_logger
 from app.services.executor.base import ExecutionResult, ResultStatus
+from app.services.shared_admission import SharedPoolSaturated
 
 logger = logging.getLogger(__name__)
 
@@ -350,28 +351,25 @@ class FunctionExecutor:
                     # (the nested-execution deadlock). Opt-in via
                     # settings.shared_pool_reserve; nested calls (depth > 0)
                     # bypass the gate.
-                    from app.services.shared_admission import (
-                        SharedPoolSaturated,
-                        shared_pool_admission,
-                    )
+                    from app.services.shared_admission import shared_pool_admission
 
-                    try:
-                        async with shared_pool_admission(depth, execution_id):
-                            exec_result = await self._execute_in_shared_pool(
-                                function=function,
-                                input_data=input_data,
-                                execution_id=execution_id,
-                                user_id=user_id,
-                                user_email=user_email,
-                                user_custom_fields=user_custom_fields,
-                                access_token=access_token,
-                                trigger_type=trigger_type,
-                                chat_id=chat_id,
-                                db=db,
-                                timeout=function_timeout,
-                            )
-                    except SharedPoolSaturated as e:
-                        raise FunctionExecutionError(str(e))
+                    # SharedPoolSaturated propagates raw from here — the
+                    # outer handler resets the row to PENDING and re-raises so
+                    # the queue worker can defer-and-retry instead of failing.
+                    async with shared_pool_admission(depth, execution_id):
+                        exec_result = await self._execute_in_shared_pool(
+                            function=function,
+                            input_data=input_data,
+                            execution_id=execution_id,
+                            user_id=user_id,
+                            user_email=user_email,
+                            user_custom_fields=user_custom_fields,
+                            access_token=access_token,
+                            trigger_type=trigger_type,
+                            chat_id=chat_id,
+                            db=db,
+                            timeout=function_timeout,
+                        )
                     elapsed = time.time() - start_time
                     print(f"⏱️  [TIMING] Shared pool execution completed in {elapsed:.3f}s")
                 else:
@@ -472,6 +470,14 @@ class FunctionExecutor:
 
                 return result
 
+            except SharedPoolSaturated:
+                # Backpressure, not failure ("fail-fast, retryable" by
+                # design): leave the row PENDING so the queue worker's
+                # deferred retry finds it un-failed, and skip the failure
+                # callback/logging entirely.
+                execution.status = ExecutionStatus.PENDING
+                await db.commit()
+                raise
             except Exception as e:
                 # Update execution record with error
                 execution.status = ExecutionStatus.FAILED

--- a/backend/tests/unit/test_saturation_retry.py
+++ b/backend/tests/unit/test_saturation_retry.py
@@ -1,0 +1,210 @@
+"""Shared-pool saturation is backpressure, not failure.
+
+Regression coverage for the bulk-upload incident: 30 rapid uploads triggered
+30 post-upload function jobs onto a 4-slot shared pool; the first 4 ran, the
+other 26 failed instantly ("worker pool saturated") with no retry. Saturation
+now defers the queue job (arq Retry with backoff) and leaves the Execution
+row PENDING until a slot frees or the retry budget runs out.
+"""
+
+import contextlib
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from arq.worker import Retry
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models import Function
+from app.models.execution import Execution, ExecutionStatus
+from app.services.shared_admission import SharedPoolSaturated
+
+
+@contextlib.asynccontextmanager
+async def _saturated(depth, execution_id):
+    raise SharedPoolSaturated("Shared worker pool saturated: 4/4 top-level slots in use")
+    yield  # pragma: no cover
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store: dict = {}
+        self.published: list = []
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+
+    async def publish(self, channel, payload):
+        self.published.append((channel, payload))
+
+
+@pytest.fixture
+async def shared_fn(db: AsyncSession, test_user):
+    fn = Function(
+        user_id=test_user.id,
+        namespace="default",
+        name=f"sat_{uuid.uuid4().hex[:6]}",
+        code="def handler(input, context): return 1",
+        input_schema={},
+        output_schema={},
+        is_active=True,
+        shared_pool=True,
+    )
+    db.add(fn)
+    await db.commit()
+    yield fn
+    await db.delete(fn)
+    await db.commit()
+
+
+class TestEngineLeavesRowPending:
+    async def test_saturation_propagates_and_row_stays_pending(
+        self, db, test_user, shared_fn, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.services.shared_admission.shared_pool_admission", _saturated
+        )
+
+        @contextlib.asynccontextmanager
+        async def fake_session():
+            yield db
+
+        monkeypatch.setattr(
+            "app.services.execution_engine.AsyncSessionLocal", fake_session
+        )
+        from app.services.execution_engine import executor
+
+        execution_id = str(uuid.uuid4())
+        with pytest.raises(SharedPoolSaturated):
+            await executor.execute_function(
+                function_namespace=shared_fn.namespace,
+                function_name=shared_fn.name,
+                input_data={},
+                execution_id=execution_id,
+                trigger_type="API",
+                trigger_id="test",
+                user_id=str(test_user.id),
+            )
+
+        row = (
+            await db.execute(
+                select(Execution).where(Execution.execution_id == execution_id)
+            )
+        ).scalar_one()
+        try:
+            assert row.status == ExecutionStatus.PENDING  # NOT FAILED
+            assert row.error is None
+        finally:
+            await db.delete(row)
+            await db.commit()
+
+
+def _job_kwargs(execution_id):
+    return {
+        "job_id": f"job-{uuid.uuid4().hex[:8]}",
+        "function_namespace": "default",
+        "function_name": "post_upload",
+        "input_data": {},
+        "execution_id": execution_id,
+        "trigger_type": "API",
+        "trigger_id": "test",
+        "user_id": str(uuid.uuid4()),
+    }
+
+
+class TestWorkerDefersOnSaturation:
+    async def test_saturated_job_raises_arq_retry_with_backoff(self, monkeypatch):
+        from app.queue import worker
+
+        async def boom(**kwargs):
+            raise SharedPoolSaturated("4/4 slots in use")
+
+        monkeypatch.setattr(
+            "app.services.execution_engine.executor.execute_function", boom
+        )
+        redis = _FakeRedis()
+        kwargs = _job_kwargs(str(uuid.uuid4()))
+
+        with pytest.raises(Retry) as exc:
+            await worker.execute_function_job({"redis": redis, "job_try": 1}, **kwargs)
+
+        assert 2 <= exc.value.defer_score / 1000 <= 5  # 2**1 + jitter(0..2)
+        from app.services.queue_service import JOB_STATUS_PREFIX
+        status = json.loads(redis.store[f"{JOB_STATUS_PREFIX}{kwargs['job_id']}"])
+        assert status["status"] == "queued"
+        assert "saturated" in status["detail"]
+        assert redis.published == []  # no failure signal
+
+    async def test_backoff_caps_at_30s(self, monkeypatch):
+        from app.queue import worker
+
+        async def boom(**kwargs):
+            raise SharedPoolSaturated("4/4")
+
+        monkeypatch.setattr(
+            "app.services.execution_engine.executor.execute_function", boom
+        )
+        with pytest.raises(Retry) as exc:
+            await worker.execute_function_job(
+                {"redis": _FakeRedis(), "job_try": 10}, **_job_kwargs(str(uuid.uuid4()))
+            )
+        assert exc.value.defer_score / 1000 <= 32  # 30s cap + jitter
+
+    async def test_exhausted_budget_fails_for_real(self, db, test_user, monkeypatch):
+        from app.queue import worker
+
+        execution_id = str(uuid.uuid4())
+        row = Execution(
+            user_id=test_user.id,
+            execution_id=execution_id,
+            function_name="default/post_upload",
+            trigger_type="API",
+            trigger_id="test",
+            status=ExecutionStatus.PENDING,
+            input_data={},
+            started_at=__import__("datetime").datetime.utcnow(),
+        )
+        db.add(row)
+        await db.commit()
+
+        async def boom(**kwargs):
+            raise SharedPoolSaturated("4/4")
+
+        monkeypatch.setattr(
+            "app.services.execution_engine.executor.execute_function", boom
+        )
+
+        @contextlib.asynccontextmanager
+        async def fake_session():
+            yield db
+
+        monkeypatch.setattr("app.core.database.AsyncSessionLocal", fake_session)
+
+        redis = _FakeRedis()
+        budget = settings.queue_saturation_max_retries
+        with pytest.raises(SharedPoolSaturated):
+            await worker.execute_function_job(
+                {"redis": redis, "job_try": budget}, **_job_kwargs(execution_id)
+            )
+
+        await db.refresh(row)
+        try:
+            assert row.status == ExecutionStatus.FAILED
+            assert "saturated" in (row.error or "").lower() or "4/4" in (row.error or "")
+            assert len(redis.published) == 1  # failure IS signalled now
+        finally:
+            await db.delete(row)
+            await db.commit()
+
+
+class TestWorkerSettings:
+    def test_max_tries_exceeds_saturation_budget(self):
+        from app.queue.worker import WorkerSettings
+
+        assert WorkerSettings.max_tries > settings.queue_saturation_max_retries


### PR DESCRIPTION
Field incident: 30 rapid uploads → 30 post-upload jobs → 4-slot shared pool → 26 instant "worker pool saturated" failures, no retry, registrations lost.

Root cause chain: the admission gate raises `SharedPoolSaturated` (designed "fail-fast, **retryable**"), the engine flattened it into a generic `FunctionExecutionError` and marked the Execution FAILED, and the worker's `raise  # Re-raise for arq retry` never worked — arq only re-runs jobs that raise its `Retry` exception.

**Now:** saturation = backpressure. Engine leaves the row PENDING and lets the exception reach the worker; worker raises `Retry` with jittered exponential backoff (cap 30s) under a dedicated budget (`QUEUE_SATURATION_MAX_RETRIES=20` ≈ 9 min of drain window); exhausted budget becomes a real, fully-bookkept failure (row FAILED, waiters notified). `WorkerSettings.max_tries` is raised above the budget so arq's cap can't preempt the explicit exhaustion path — behavior-neutral for plain exceptions, which arq never retried anyway.

5 tests: engine leaves PENDING (not FAILED, no error), worker defers with correct backoff bounds + "queued" status + no failure signal, 30s cap, exhausted-budget marks FAILED + notifies, and a guard that `max_tries` > budget. Full suite 361 passed + the 7 known local-Redis env failures.

Known limitation left as-is (pre-existing): plain job failures still don't retry or DLQ (`job_try` never advances past 1) — that's a separate, older bug; tracked for 0.4.1 rather than smuggled into this RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)