### PR TITLE
fix(queue): time-based saturation window (6h default, 0 = forever)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -261,11 +261,13 @@ class Settings(BaseSettings):
     queue_agent_sub_concurrency: int = 5  # concurrency of the sub-agent queue worker
     queue_default_timeout: int = 300
     queue_max_retries: int = 3
-    # Saturation backpressure: how many deferred retries a function job gets
-    # when the shared worker pool is full, before it becomes a real failure.
-    # With exponential backoff capped at 30s this is roughly a 9-minute
-    # window for the pool to drain (bulk uploads, batch fan-outs).
-    queue_saturation_max_retries: int = 20
+    # Saturation backpressure: how long a function job may wait in the queue
+    # (deferred retries, backoff capped at 30s) for a shared-pool slot before
+    # it becomes a real failure. The queue IS the waiting room — bulk ingest
+    # (thousands of uploads onto a small pool) is expected to drain over
+    # hours. The bound exists only so a permanently wedged pool eventually
+    # fails loudly instead of spinning forever. 0 = wait forever.
+    queue_saturation_timeout_seconds: int = 21600  # 6 hours
     queue_retry_delay: int = 10
 
     # Pipeline runs (see ADR 2026-07-28-pipelines-triggers-and-linear-steps).

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -155,32 +155,43 @@ async def execute_function_job(ctx: dict, **kwargs: Any) -> Any:
 
     except SharedPoolSaturated as e:
         # Backpressure, not failure: the engine left the Execution row
-        # PENDING. Defer the job and let arq re-run it as slots free — this
-        # is what makes "30 rapid uploads onto a 4-slot pool" drain instead
-        # of 26 of them dying instantly.
+        # PENDING. Defer the job and let arq re-run it as slots free — the
+        # queue is the waiting room, so bulk ingest (thousands of uploads
+        # onto a small pool) drains over however long it takes. The
+        # time bound only exists so a permanently wedged pool eventually
+        # fails loudly; 0 = wait forever.
         job_try = ctx.get("job_try", 1)
-        budget = settings.queue_saturation_max_retries
-        if job_try < budget:
+        enqueued_at = base_fields.get("enqueued_at") or time.time()
+        base_fields["enqueued_at"] = enqueued_at  # start the clock if the status key expired
+        elapsed = time.time() - float(enqueued_at)
+        window = settings.queue_saturation_timeout_seconds
+        if window <= 0 or elapsed < window:
             defer = min(2 ** job_try, 30) + random.uniform(0, 2)
             await redis.set(
                 f"{JOB_STATUS_PREFIX}{job_id}",
                 json.dumps({
                     **base_fields,
                     "status": "queued",
-                    "detail": f"shared pool saturated; retry {job_try}/{budget} in {defer:.0f}s",
+                    "detail": (
+                        f"shared pool saturated; waited {elapsed:.0f}s, "
+                        f"retrying in {defer:.0f}s"
+                    ),
                 }),
                 ex=JOB_TTL,
             )
             logger.info(
                 f"Function job {job_id} deferred {defer:.0f}s "
-                f"(pool saturated, attempt {job_try}/{budget})"
+                f"(pool saturated {elapsed:.0f}s, attempt {job_try})"
             )
             completed = True
             raise Retry(defer=defer)
 
-        # Budget exhausted — now it IS a failure. The engine skipped its
+        # Window exhausted — now it IS a failure. The engine skipped its
         # failure bookkeeping for saturation, so do it here.
-        logger.error(f"Function job {job_id} failed: pool saturated for {budget} attempts")
+        logger.error(
+            f"Function job {job_id} failed: pool saturated for {elapsed:.0f}s "
+            f"(window {window}s)"
+        )
         from app.core.database import AsyncSessionLocal
         from app.models.execution import Execution, ExecutionStatus
         from sqlalchemy import select as _select
@@ -471,10 +482,17 @@ class WorkerSettings:
     queue_name = "sinas:queue:functions"
     max_jobs = settings.queue_function_concurrency
     job_timeout = settings.queue_default_timeout
-    # Must exceed the saturation budget or arq's own cap kills a deferred
-    # job before our explicit exhausted-path bookkeeping runs. Plain
-    # exceptions are unaffected: arq only re-runs jobs that raise Retry.
-    max_tries = max(settings.queue_max_retries, settings.queue_saturation_max_retries + 1)
+    # Must exceed the worst-case saturation attempt count (≈ window / 30s
+    # backoff cap) or arq's own cap kills a deferred job before our explicit
+    # exhausted-path bookkeeping runs. Plain exceptions are unaffected: arq
+    # only re-runs jobs that raise Retry. For window=0 (wait forever), give
+    # arq an effectively unlimited budget.
+    max_tries = max(
+        settings.queue_max_retries,
+        (settings.queue_saturation_timeout_seconds // 30 + 10)
+        if settings.queue_saturation_timeout_seconds > 0
+        else 1_000_000,
+    )
     retry_delay = settings.queue_retry_delay
 
 

--- a/backend/tests/unit/test_saturation_retry.py
+++ b/backend/tests/unit/test_saturation_retry.py
@@ -138,7 +138,7 @@ class TestWorkerDefersOnSaturation:
         from app.services.queue_service import JOB_STATUS_PREFIX
         status = json.loads(redis.store[f"{JOB_STATUS_PREFIX}{kwargs['job_id']}"])
         assert status["status"] == "queued"
-        assert "saturated" in status["detail"]
+        assert "saturated" in status["detail"] and "retrying" in status["detail"]
         assert redis.published == []  # no failure signal
 
     async def test_backoff_caps_at_30s(self, monkeypatch):
@@ -187,10 +187,16 @@ class TestWorkerDefersOnSaturation:
         monkeypatch.setattr("app.core.database.AsyncSessionLocal", fake_session)
 
         redis = _FakeRedis()
-        budget = settings.queue_saturation_max_retries
+        kwargs = _job_kwargs(execution_id)
+        # Job enqueued far beyond the saturation window -> real failure
+        import time as _time
+        old = _time.time() - settings.queue_saturation_timeout_seconds - 60
+        redis.store[
+            f"sinas:job:status:{kwargs['job_id']}"
+        ] = json.dumps({"enqueued_at": old})
         with pytest.raises(SharedPoolSaturated):
             await worker.execute_function_job(
-                {"redis": redis, "job_try": budget}, **_job_kwargs(execution_id)
+                {"redis": redis, "job_try": 5}, **kwargs
             )
 
         await db.refresh(row)
@@ -204,7 +210,32 @@ class TestWorkerDefersOnSaturation:
 
 
 class TestWorkerSettings:
-    def test_max_tries_exceeds_saturation_budget(self):
+    def test_max_tries_covers_saturation_window(self):
         from app.queue.worker import WorkerSettings
 
-        assert WorkerSettings.max_tries > settings.queue_saturation_max_retries
+        # Worst-case attempts ~= window / 30s backoff cap; arq's cap must
+        # never fire before our explicit window check does.
+        assert WorkerSettings.max_tries > settings.queue_saturation_timeout_seconds // 30
+
+
+class TestLongWaitStaysQueued:
+    async def test_within_window_defers_even_after_many_attempts(self, monkeypatch):
+        """1000-upload scenario: hours of waiting is normal, not failure —
+        attempt count must not terminate a job that is still in-window."""
+        from app.queue import worker
+
+        async def boom(**kwargs):
+            raise SharedPoolSaturated("4/4")
+
+        monkeypatch.setattr(
+            "app.services.execution_engine.executor.execute_function", boom
+        )
+        import time as _time
+        redis = _FakeRedis()
+        kwargs = _job_kwargs(str(uuid.uuid4()))
+        # 40 minutes in, attempt 90 — previously dead at attempt 20
+        redis.store[
+            f"sinas:job:status:{kwargs['job_id']}"
+        ] = json.dumps({"enqueued_at": _time.time() - 2400})
+        with pytest.raises(Retry):
+            await worker.execute_function_job({"redis": redis, "job_try": 90}, **kwargs)

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -177,6 +177,7 @@ Used by `SANDBOX_EXECUTOR=docker_pool` (the warm pool).
 | `QUEUE_AGENT_REPLICAS` | `2` | Agent queue worker replicas |
 | `QUEUE_FUNCTION_CONCURRENCY` | `10` | Concurrent functions per worker |
 | `QUEUE_AGENT_CONCURRENCY` | `5` | Concurrent agent jobs per worker |
+| `QUEUE_SATURATION_TIMEOUT_SECONDS` | `21600` | How long a queued function job may wait for a shared-pool slot (deferred retries with backoff) before failing. Bulk ingest drains through this window; `0` = wait forever. |
 | `QUEUE_AGENT_SUB_REPLICAS` | `2` | Sub-agent queue worker replicas (delegated agent jobs) |
 | `QUEUE_AGENT_SUB_CONCURRENCY` | `5` | Concurrent jobs per sub-agent worker |
 | `DEFAULT_WORKER_COUNT` | `4` | Shared (trusted) worker containers for `shared_pool` functions. Also the default ceiling for `MAX_EXECUTION_DEPTH`. |


### PR DESCRIPTION
Follow-up to #134 per review: the 20-attempt budget (~9 min) couldn't survive its own use case — 1000 uploads ÷ 4 slots needs 12+ min healthy. Give-up is now **elapsed time since enqueue** (`QUEUE_SATURATION_TIMEOUT_SECONDS`, default 6h, `0` = wait forever); attempts only shape backoff. The bound exists solely to surface a permanently wedged pool. New test pins the bulk-ingest case: attempt 90 at minute 40 still defers instead of dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)