### PR TITLE
feat(workers): configurable shared-worker memory limit

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -244,6 +244,10 @@ class Settings(BaseSettings):
     docker_network: str = "auto"  # Docker network for containers (auto-detect or specify)
     sandbox_network: str = "sinas-sandbox"  # Isolated network for executor containers (internet only, no access to internal services)
     default_worker_count: int = 4  # Number of workers to start on backend startup
+    # Memory limit per shared worker container (Docker size string). Was
+    # hardcoded to 1g; heavier post-processing functions (document parsing,
+    # embedding prep) legitimately need more.
+    worker_memory_limit: str = "1g"
 
     # Message history
     max_history_messages: int = 100  # Max messages to load for conversation history

--- a/backend/app/services/shared_worker_manager.py
+++ b/backend/app/services/shared_worker_manager.py
@@ -481,7 +481,7 @@ class SharedWorkerManager:
                 name=container_name,
                 detach=True,
                 network=self.sandbox_network,
-                mem_limit="1g",
+                mem_limit=settings.worker_memory_limit,
                 nano_cpus=1_000_000_000,  # 1 CPU core
                 cap_drop=["ALL"],  # Drop all capabilities for security
                 cap_add=["CHOWN", "SETUID", "SETGID"],  # Only essential capabilities

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -178,6 +178,7 @@ Used by `SANDBOX_EXECUTOR=docker_pool` (the warm pool).
 | `QUEUE_FUNCTION_CONCURRENCY` | `10` | Concurrent functions per worker |
 | `QUEUE_AGENT_CONCURRENCY` | `5` | Concurrent agent jobs per worker |
 | `QUEUE_SATURATION_TIMEOUT_SECONDS` | `21600` | How long a queued function job may wait for a shared-pool slot (deferred retries with backoff) before failing. Bulk ingest drains through this window; `0` = wait forever. |
+| `WORKER_MEMORY_LIMIT` | `1g` | Memory limit per shared worker container (Docker size string). |
 | `QUEUE_AGENT_SUB_REPLICAS` | `2` | Sub-agent queue worker replicas (delegated agent jobs) |
 | `QUEUE_AGENT_SUB_CONCURRENCY` | `5` | Concurrent jobs per sub-agent worker |
 | `DEFAULT_WORKER_COUNT` | `4` | Shared (trusted) worker containers for `shared_pool` functions. Also the default ceiling for `MAX_EXECUTION_DEPTH`. |


### PR DESCRIPTION
Shared worker mem_limit was hardcoded 1g; now WORKER_MEMORY_LIMIT (Docker size string, default unchanged). Needed for heavier post-upload processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)