### PR TITLE
fix(queue): crash-safe shared-pool slot claims + auto-scaling reserve

### DIFF
--- a/backend/app/services/shared_admission.py
+++ b/backend/app/services/shared_admission.py
@@ -2,25 +2,30 @@
 
 Prevents the nested-execution deadlock: a parent `shared_pool` function blocked
 while synchronously waiting on a child can starve the pool when every worker is
-held by a parent. We reserve `settings.shared_pool_reserve` slots that only
-NESTED executions (depth > 0) may use, so a child can always find capacity.
+held by a parent. We reserve slots that only NESTED executions (depth > 0) may
+use, so a child can always find capacity.
 
-Opt-in: `shared_pool_reserve = 0` disables it entirely (default — no behaviour
-change). For full single-chain safety set the reserve to
-`max_execution_depth - 1` AND keep `default_worker_count >= max_execution_depth`
-(a chain of depth D holds D slots at once). A smaller reserve still breaks the
-common contention case (several shallow chains) while throttling top-level work
-less.
+Opt-in: `shared_pool_reserve = 0` disables it entirely. `-1` scales the
+reserve with the pool (a third of the workers, at least 1), so resizing
+DEFAULT_WORKER_COUNT doesn't silently strand top-level capacity behind a
+stale fixed reserve. An explicit positive value is clamped to leave at least
+one top-level slot.
 
-The in-flight set is a Redis sorted-set keyed by execution_id with a timestamp
-score, so the count is correct across the multiple queue-worker processes and
-self-heals if a process dies mid-execution (stale entries age out).
+The in-flight set is a Redis sorted-set keyed by execution_id. Each admitted
+execution HEARTBEATS its entry (score refreshed every few seconds) while it
+runs; entries whose heartbeat goes stale are pruned. This makes slot claims
+crash-safe: a worker killed mid-execution (deploy restart, OOM) frees its
+slots within ~1 minute. The previous design used a 1-hour age-out, which
+after one restart pinned the whole pool behind ghost claims — 13.5K queued
+registrations drained single-file for an hour.
 """
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
+import math
 import time
 
 from app.core.config import settings
@@ -29,13 +34,39 @@ from app.core.redis import get_redis
 logger = logging.getLogger(__name__)
 
 _INFLIGHT_ZSET = "sinas:shared:toplevel_inflight"
-# Entries older than this are treated as dead (crashed worker) and pruned, so a
-# leak can't permanently throttle the pool. Comfortably above any real run.
-_ENTRY_TTL_SECONDS = 3600
+# Heartbeat cadence for live entries, and how stale an entry may be before it
+# is considered a crashed worker's ghost. Stale window = several missed beats,
+# generous for event-loop hiccups but ~1 minute to reclaim after a crash.
+_HEARTBEAT_SECONDS = 10
+_STALE_AFTER_SECONDS = 60
+
+
+def effective_reserve() -> int:
+    """Resolve the nested-call reserve against the current pool size.
+
+    -1 = auto (a third of the pool, at least 1). Positive values are clamped
+    so at least one top-level slot always remains.
+    """
+    reserve = settings.shared_pool_reserve
+    count = settings.default_worker_count
+    if reserve == -1:
+        return max(1, count // 3)
+    if reserve <= 0:
+        return 0
+    return min(reserve, count - 1)
 
 
 class SharedPoolSaturated(Exception):
     """Raised when top-level shared-pool admission is at capacity."""
+
+
+async def _heartbeat(redis, execution_id: str) -> None:
+    while True:
+        await asyncio.sleep(_HEARTBEAT_SECONDS)
+        try:
+            await redis.zadd(_INFLIGHT_ZSET, {execution_id: time.time()}, xx=True)
+        except Exception as e:  # never let the heartbeat kill the execution
+            logger.warning(f"Admission heartbeat failed for {execution_id}: {e}")
 
 
 @contextlib.asynccontextmanager
@@ -44,10 +75,10 @@ async def shared_pool_admission(depth: int, execution_id: str):
 
     Nested executions (depth > 0) bypass the gate — that is the whole point of
     the reserve. Top-level (depth 0) executions are capped at
-    `default_worker_count - shared_pool_reserve`. Raises `SharedPoolSaturated`
+    `default_worker_count - effective_reserve()`. Raises `SharedPoolSaturated`
     (fail-fast, retryable) when the top-level cap is reached.
     """
-    reserve = settings.shared_pool_reserve
+    reserve = effective_reserve()
     if reserve <= 0 or depth > 0:
         # Disabled, or a nested call that must always be allowed through.
         yield
@@ -57,8 +88,9 @@ async def shared_pool_admission(depth: int, execution_id: str):
     redis = await get_redis()
     now = time.time()
 
-    # Prune dead entries, then count live top-level executions.
-    await redis.zremrangebyscore(_INFLIGHT_ZSET, 0, now - _ENTRY_TTL_SECONDS)
+    # Prune entries whose heartbeat went stale (crashed worker), then count
+    # live top-level executions.
+    await redis.zremrangebyscore(_INFLIGHT_ZSET, 0, now - _STALE_AFTER_SECONDS)
     live = await redis.zcard(_INFLIGHT_ZSET)
     if live >= cap:
         raise SharedPoolSaturated(
@@ -67,7 +99,12 @@ async def shared_pool_admission(depth: int, execution_id: str):
         )
 
     await redis.zadd(_INFLIGHT_ZSET, {execution_id: now})
+    beat = asyncio.create_task(_heartbeat(redis, execution_id))
     try:
         yield
     finally:
-        await redis.zrem(_INFLIGHT_ZSET, execution_id)
+        beat.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await beat
+        with contextlib.suppress(Exception):
+            await redis.zrem(_INFLIGHT_ZSET, execution_id)

--- a/backend/tests/unit/test_shared_admission.py
+++ b/backend/tests/unit/test_shared_admission.py
@@ -1,0 +1,124 @@
+"""Shared-pool admission: crash-safe slot claims + scaled reserve.
+
+Field incident: a worker restart orphaned 8 slot claims (the finally-zrem
+never ran) and the old 1-hour age-out let those ghosts pin the entire pool —
+13.5K queued jobs drained single-file. Claims now heartbeat while running
+and go stale in ~1 minute.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from app.core.config import settings
+from app.services import shared_admission
+from app.services.shared_admission import (
+    _INFLIGHT_ZSET,
+    _STALE_AFTER_SECONDS,
+    SharedPoolSaturated,
+    effective_reserve,
+    shared_pool_admission,
+)
+
+
+class _FakeZRedis:
+    """Just enough of Redis sorted sets for the admission gate."""
+
+    def __init__(self):
+        self.z: dict[str, float] = {}
+
+    async def zremrangebyscore(self, key, lo, hi):
+        dead = [m for m, s in self.z.items() if lo <= s <= hi]
+        for m in dead:
+            del self.z[m]
+        return len(dead)
+
+    async def zcard(self, key):
+        return len(self.z)
+
+    async def zadd(self, key, mapping, xx=False):
+        for m, s in mapping.items():
+            if xx and m not in self.z:
+                continue
+            self.z[m] = s
+        return len(mapping)
+
+    async def zrem(self, key, member):
+        return 1 if self.z.pop(member, None) is not None else 0
+
+
+@pytest.fixture
+def zredis(monkeypatch):
+    r = _FakeZRedis()
+
+    async def _get():
+        return r
+
+    monkeypatch.setattr("app.services.shared_admission.get_redis", _get)
+    monkeypatch.setattr(settings, "default_worker_count", 12)
+    monkeypatch.setattr(settings, "shared_pool_reserve", 4)
+    return r
+
+
+class TestEffectiveReserve:
+    def test_auto_scales_with_pool(self, monkeypatch):
+        monkeypatch.setattr(settings, "shared_pool_reserve", -1)
+        for count, expected in ((4, 1), (12, 4), (24, 8), (2, 1)):
+            monkeypatch.setattr(settings, "default_worker_count", count)
+            assert effective_reserve() == expected
+
+    def test_explicit_value_clamped_to_leave_a_slot(self, monkeypatch):
+        monkeypatch.setattr(settings, "default_worker_count", 4)
+        monkeypatch.setattr(settings, "shared_pool_reserve", 4)
+        # Old behavior: cap = max(1, 4-4) = ... reserve swallowed the pool.
+        assert effective_reserve() == 3  # at least one top-level slot
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setattr(settings, "shared_pool_reserve", 0)
+        assert effective_reserve() == 0
+
+
+class TestCrashSafety:
+    async def test_ghost_claims_pruned_after_stale_window(self, zredis):
+        """A restart-orphaned claim must free its slot in ~a minute, not an
+        hour — this is the regression that serialized 13.5K jobs."""
+        now = time.time()
+        for i in range(8):  # fill the cap (12-4=8) with restart ghosts
+            zredis.z[f"ghost-{i}"] = now - _STALE_AFTER_SECONDS - 5
+
+        async with shared_pool_admission(0, "fresh-exec"):
+            assert "fresh-exec" in zredis.z
+        assert all(not m.startswith("ghost") for m in zredis.z)
+
+    async def test_live_claims_are_not_pruned(self, zredis):
+        now = time.time()
+        for i in range(8):
+            zredis.z[f"live-{i}"] = now - 5  # recent heartbeats
+
+        with pytest.raises(SharedPoolSaturated):
+            async with shared_pool_admission(0, "x"):
+                pass  # pragma: no cover
+        assert len(zredis.z) == 8
+
+    async def test_heartbeat_refreshes_score(self, zredis, monkeypatch):
+        monkeypatch.setattr(shared_admission, "_HEARTBEAT_SECONDS", 0.05)
+        async with shared_pool_admission(0, "beating"):
+            first = zredis.z["beating"]
+            await asyncio.sleep(0.2)
+            assert zredis.z["beating"] > first  # refreshed while running
+        assert "beating" not in zredis.z  # removed on exit
+
+    async def test_claim_removed_even_on_execution_error(self, zredis):
+        with pytest.raises(RuntimeError):
+            async with shared_pool_admission(0, "err-exec"):
+                raise RuntimeError("function blew up")
+        assert "err-exec" not in zredis.z
+
+    async def test_nested_calls_bypass(self, zredis):
+        now = time.time()
+        for i in range(12):
+            zredis.z[f"live-{i}"] = now
+        async with shared_pool_admission(depth=1, execution_id="nested"):
+            pass  # admitted despite a full pool
+        assert "nested" not in zredis.z  # bypass never claims


### PR DESCRIPTION
Diagnosis of the serialized-dispatch incident (13.5K PENDING, RUNNING pinned at 1–2 despite 12 workers):

**Not** the backoff path, the reservation math, or a held lock — the inflight zset held exactly 8 entries all timestamped at the 18:34 worker restart: **ghost slot claims** from killed processes whose \`finally: zrem\` never ran, protected by a 1-hour age-out. One ghost expired at 18:54 → exactly 1 usable slot → ~9/min observed.

**Fix:** claims heartbeat every 10s while running; 60s stale window reclaims a crashed worker's slots in ~a minute. \`zadd XX\` on heartbeats prevents a falsely-pruned entry from resurrecting into over-claim. Plus the acceptance-criteria change: \`SHARED_POOL_RESERVE=-1\` = auto (⅓ of pool, min 1) so resizing the pool scales the reserve; explicit values clamp to leave ≥1 top-level slot.

Live remediation already applied (stale claims swept): RUNNING went 1 → 7 within 20s, backlog draining at full width.

8 new tests. Full suite 370 passed + 7 known local-Redis env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)