### PR TITLE
fix(providers): Anthropic structured outputs + long-request stream fallback

### DIFF
--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -49,10 +49,55 @@ class AnthropicProvider(BaseLLMProvider):
             # Convert OpenAI tool format to Anthropic format
             params["tools"] = self._convert_tools_to_anthropic(tools)
 
+        # Structured outputs: Anthropic has no response_format param; its
+        # structured-output path is forced tool use. Only when the request
+        # carries no real tools — forcing a tool_choice would otherwise
+        # stop the agent's actual tool loop, and tool-using agents already
+        # get the schema instruction in their system prompt.
+        structured_tool = None
+        response_format = kwargs.get("response_format")
+        if response_format and not tools and response_format.get("type") == "json_schema":
+            js = response_format.get("json_schema") or {}
+            structured_tool = {
+                "name": (js.get("name") or "structured_response")[:64],
+                "description": (
+                    "Deliver the final response in the required JSON shape. "
+                    "Call exactly once with the complete answer."
+                ),
+                "input_schema": js.get("schema") or {"type": "object"},
+            }
+            params["tools"] = [structured_tool]
+            params["tool_choice"] = {"type": "tool", "name": structured_tool["name"]}
+
         if self.enable_prompt_caching:
             self._apply_cache_control(params)
 
-        response = await self.client.messages.create(**params)
+        try:
+            response = await self.client.messages.create(**params)
+        except ValueError as e:
+            # The SDK refuses non-streaming requests whose ESTIMATED duration
+            # exceeds its limit (derived from max_tokens and model speed).
+            # Rather than encode any threshold ourselves, catch its guard and
+            # accumulate a stream into the identical Message object.
+            if "streaming" not in str(e).lower():
+                raise
+            async with self.client.messages.stream(**params) as s:
+                response = await s.get_final_message()
+
+        if structured_tool is not None:
+            # The forced tool call IS the answer: return its input as the
+            # message content so downstream parses one clean JSON document.
+            for block in response.content:
+                if block.type == "tool_use" and block.name == structured_tool["name"]:
+                    return {
+                        "content": self._serialize_args(block.input),
+                        "tool_calls": None,
+                        "usage": self.extract_usage(response),
+                        # stop_reason is "tool_use" mechanically; semantically
+                        # this is a completed final answer.
+                        "finish_reason": "stop",
+                    }
+            # Model refused the tool (rare) — fall through to normal parsing.
 
         # Extract content (Anthropic returns list of content blocks)
         content = ""

--- a/backend/tests/unit/test_anthropic_structured.py
+++ b/backend/tests/unit/test_anthropic_structured.py
@@ -1,0 +1,186 @@
+"""Anthropic structured outputs (forced tool use) + long-request stream fallback.
+
+Two field bugs from the Gate-2 load weekend:
+- message_service builds a json_schema response_format from agent.output_schema;
+  OpenAI-family providers forward it, but the Anthropic provider built its
+  params dict field-by-field and never read kwargs — every JSON contract with
+  a Claude agent was silently prompt-and-parse.
+- The Anthropic SDK refuses non-streaming requests whose estimated duration
+  exceeds its limit (a function of max_tokens and model speed), which surfaced
+  as naked 500s. No threshold is encoded here: the SDK's own guard triggers an
+  internal stream-accumulate that returns the identical Message object.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.providers import AnthropicProvider
+
+SCHEMA_RF = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "planner_response",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"steps": {"type": "array"}},
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def _usage():
+    return SimpleNamespace(
+        input_tokens=10, output_tokens=5,
+        cache_read_input_tokens=0, cache_creation_input_tokens=0,
+    )
+
+
+def _tool_use_response(name, payload):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="tool_use", id="tu_1", name=name, input=payload)],
+        usage=_usage(),
+        stop_reason="tool_use",
+    )
+
+
+def _text_response(text):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        usage=_usage(),
+        stop_reason="end_turn",
+    )
+
+
+def _provider(create_result=None, create_raises=None, stream_final=None):
+    provider = AnthropicProvider(api_key="k", enable_prompt_caching=False)
+    captured = {}
+
+    async def fake_create(**params):
+        captured["params"] = params
+        if create_raises:
+            raise create_raises
+        return create_result
+
+    class _StreamCM:
+        async def __aenter__(self):
+            captured["streamed"] = True
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get_final_message(self):
+            return stream_final
+
+    def fake_stream(**params):
+        captured["stream_params"] = params
+        return _StreamCM()
+
+    provider.client = SimpleNamespace(
+        messages=SimpleNamespace(create=fake_create, stream=fake_stream)
+    )
+    return provider, captured
+
+
+class TestStructuredOutputs:
+    async def test_response_format_becomes_forced_tool(self):
+        provider, captured = _provider(
+            create_result=_tool_use_response("planner_response", {"steps": [1, 2]})
+        )
+        result = await provider.complete(
+            messages=[{"role": "user", "content": "plan"}],
+            model="claude-sonnet-5",
+            response_format=SCHEMA_RF,
+        )
+
+        params = captured["params"]
+        (tool,) = params["tools"]
+        assert tool["name"] == "planner_response"
+        assert tool["input_schema"]["properties"] == {"steps": {"type": "array"}}
+        assert params["tool_choice"] == {"type": "tool", "name": "planner_response"}
+
+        # The tool call IS the answer: clean JSON content, no tool loop
+        assert json.loads(result["content"]) == {"steps": [1, 2]}
+        assert result["tool_calls"] is None
+        assert result["finish_reason"] == "stop"
+
+    async def test_real_tools_win_over_response_format(self):
+        """Forcing tool_choice would kill the agent's actual tool loop, so
+        tool-carrying requests keep prompt-based structured output."""
+        provider, captured = _provider(create_result=_text_response("ok"))
+        real_tools = [{
+            "type": "function",
+            "function": {"name": "search", "parameters": {"type": "object"}},
+        }]
+        await provider.complete(
+            messages=[{"role": "user", "content": "x"}],
+            model="claude-sonnet-5",
+            tools=real_tools,
+            response_format=SCHEMA_RF,
+        )
+        params = captured["params"]
+        assert "tool_choice" not in params
+        assert params["tools"][0]["name"] == "search"
+
+    async def test_no_response_format_unchanged(self):
+        provider, captured = _provider(create_result=_text_response("hi"))
+        result = await provider.complete(
+            messages=[{"role": "user", "content": "x"}], model="claude-sonnet-5"
+        )
+        assert "tools" not in captured["params"]
+        assert result["content"] == "hi"
+
+    async def test_model_refusing_forced_tool_falls_back_to_text(self):
+        provider, _ = _provider(create_result=_text_response('{"steps": []}'))
+        result = await provider.complete(
+            messages=[{"role": "user", "content": "x"}],
+            model="claude-sonnet-5",
+            response_format=SCHEMA_RF,
+        )
+        assert result["content"] == '{"steps": []}'
+
+
+class TestLongRequestStreamFallback:
+    async def test_sdk_streaming_guard_triggers_internal_stream(self):
+        provider, captured = _provider(
+            create_raises=ValueError(
+                "Streaming is strongly recommended for operations that may "
+                "take longer than 10 minutes."
+            ),
+            stream_final=_text_response("long answer"),
+        )
+        result = await provider.complete(
+            messages=[{"role": "user", "content": "write a book"}],
+            model="claude-sonnet-5",
+            max_tokens=32000,
+        )
+        assert captured["streamed"] is True
+        assert captured["stream_params"]["max_tokens"] == 32000
+        assert result["content"] == "long answer"
+        assert result["finish_reason"] == "end_turn"
+
+    async def test_unrelated_valueerror_propagates(self):
+        provider, _ = _provider(create_raises=ValueError("bad temperature"))
+        with pytest.raises(ValueError, match="bad temperature"):
+            await provider.complete(
+                messages=[{"role": "user", "content": "x"}], model="claude-sonnet-5"
+            )
+
+    async def test_guard_plus_structured_output_compose(self):
+        provider, captured = _provider(
+            create_raises=ValueError("...requires streaming..."),
+            stream_final=_tool_use_response("planner_response", {"steps": ["a"]}),
+        )
+        result = await provider.complete(
+            messages=[{"role": "user", "content": "x"}],
+            model="claude-sonnet-5",
+            max_tokens=32000,
+            response_format=SCHEMA_RF,
+        )
+        assert captured["streamed"] is True
+        assert json.loads(result["content"]) == {"steps": ["a"]}
+        assert result["finish_reason"] == "stop"


### PR DESCRIPTION
Two Claude-provider bugs surfaced by a heavy ingestion weekend, both provider-local:

**Structured outputs never reached Claude.** \`response_format\` (built from \`agent.output_schema\`) was forwarded by OpenAI-family providers but silently dropped by the Anthropic provider — every JSON contract with a Claude agent was prompt-and-parse. Now mapped to Anthropic's structured-output path: forced single tool named after the schema, tool input returned as message content. Gated to requests without real tools (forcing \`tool_choice\` would break the tool loop; those agents keep the existing prompt-based path). Model-refuses-tool falls back to text parsing.

**\`max_tokens\` past the SDK's non-streaming estimate → naked 500.** Per review discussion: no save-time clamp and no hardcoded threshold — the SDK's own guard (\`ValueError\` mentioning streaming) triggers an internal stream-accumulate returning the identical Message object. Hot path unchanged; agent \`job_timeout\` stays the real bound.

7 tests incl. composition of the two paths. Full suite 377 passed + 7 known env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)