### PR TITLE
fix(pipelines): persist run output, honest run ids, schedulable pipelines

### DIFF
--- a/backend/alembic/versions/r1u2n3o4u5t6_pipeline_run_output.py
+++ b/backend/alembic/versions/r1u2n3o4u5t6_pipeline_run_output.py
@@ -1,0 +1,22 @@
+"""persist pipeline run output
+
+Revision ID: r1u2n3o4u5t6
+Revises: a1g2t3o4v5r6
+Create Date: 2026-08-21
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "r1u2n3o4u5t6"
+down_revision = "a1g2t3o4v5r6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pipeline_runs", sa.Column("output", sa.JSON, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pipeline_runs", "output")

--- a/backend/app/api/v1/endpoints/schedules.py
+++ b/backend/app/api/v1/endpoints/schedules.py
@@ -65,6 +65,23 @@ async def create_schedule(
                 status_code=404,
                 detail=f"Function '{schedule_data.target_namespace}/{schedule_data.target_name}' not found",
             )
+    elif schedule_data.schedule_type == "pipeline":
+        from app.models import Pipeline
+
+        result = await db.execute(
+            select(Pipeline).where(
+                and_(
+                    Pipeline.namespace == schedule_data.target_namespace,
+                    Pipeline.name == schedule_data.target_name,
+                    Pipeline.is_active == True,
+                )
+            )
+        )
+        if not result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=404,
+                detail=f"Pipeline '{schedule_data.target_namespace}/{schedule_data.target_name}' not found or inactive",
+            )
     else:
         result = await db.execute(
             select(Agent).where(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -135,6 +135,16 @@ app.add_middleware(
 # Add request logging middleware
 app.add_middleware(RequestLoggerMiddleware)
 
+
+@app.middleware("http")
+async def add_version_header(request, call_next):
+    """Stamp every response with the platform version — registered on the
+    root app so mounted sub-apps (/api/v1, adapters) inherit it. Lets
+    clients and operators confirm which build answered without /info."""
+    response = await call_next(request)
+    response.headers["X-Sinas-Version"] = __version__
+    return response
+
 _servers = [
     {"url": "/", "description": "Runtime API"},
     {"url": "/api/v1", "description": "Management API"},

--- a/backend/app/models/pipeline.py
+++ b/backend/app/models/pipeline.py
@@ -129,6 +129,9 @@ class PipelineRun(Base):
     input: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON)
     # [{name, type, status, startedAt, durationMs, executionId?, chatId?, error?}]
     steps: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
+    # Final run output (output_mapping applied), persisted on success so the
+    # record matches what the live caller was given.
+    output: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
     error: Mapped[Optional[str]] = mapped_column(Text)
 
     cursor_before: Mapped[Optional[str]] = mapped_column(Text)

--- a/backend/app/queue/worker.py
+++ b/backend/app/queue/worker.py
@@ -397,6 +397,7 @@ async def execute_pipeline_run_job(ctx: dict, **kwargs: Any) -> Any:
     return await pipeline_runner.run_pipeline(
         pipeline_id,
         kwargs.get("run_input"),
+        run_id=kwargs.get("run_id"),
         trigger_type=kwargs.get("trigger_type", "API"),
         trigger_id=kwargs.get("trigger_id"),
         user_id=user_id,

--- a/backend/app/services/pipeline_runner.py
+++ b/backend/app/services/pipeline_runner.py
@@ -500,6 +500,7 @@ async def run_pipeline(
     trigger_id: Optional[str],
     user_id: str,
     user_token: str,
+    run_id: Optional[str] = None,
     exec_depth: int = 0,
     agent_depth: int = 0,
     sync: bool = False,
@@ -522,7 +523,9 @@ async def run_pipeline(
         db.expunge(pipeline)
 
     label = f"{pipeline.namespace}/{pipeline.name}"
-    run_id = str(uuid.uuid4())
+    # Queued runs arrive with a pre-allocated id (the one their enqueue
+    # response promised); sync runs mint their own.
+    run_id = run_id or str(uuid.uuid4())
     redis = await get_redis()
 
     # --- single-flight ---
@@ -776,6 +779,7 @@ async def _persist_outcome(
                 .values(
                     status=status,
                     error=error,
+                    output=output if status == "succeeded" else None,
                     steps=step_summaries,
                     cursor_after=new_cursor,
                     completed_at=_now(),

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -120,9 +120,15 @@ class QueueService:
         """
         pool = await get_arq_pool()
         job_id = str(uuid.uuid4())
+        # Pre-allocate the RUN id and return that, not the job id: callers
+        # poll GET /pipelines/runs/{run_id} with what we hand back, and the
+        # job id never appears in pipeline_runs. (The run row itself is
+        # created when the worker starts executing.)
+        run_id = str(uuid.uuid4())
         await pool.enqueue_job(
             "execute_pipeline_run_job",
             job_id=job_id,
+            run_id=run_id,
             pipeline_id=pipeline_id,
             run_input=run_input,
             trigger_type=trigger_type,
@@ -132,8 +138,8 @@ class QueueService:
             _job_id=job_id,
             _queue_name=PIPELINE_QUEUE,
         )
-        logger.info(f"Enqueued pipeline run job {job_id} (pipeline={pipeline_id})")
-        return job_id
+        logger.info(f"Enqueued pipeline run job {job_id} (run={run_id}, pipeline={pipeline_id})")
+        return run_id
 
     async def enqueue_pipeline_fire(
         self,

--- a/backend/tests/unit/test_pipeline_run_contract.py
+++ b/backend/tests/unit/test_pipeline_run_contract.py
@@ -1,0 +1,181 @@
+"""Pipeline run-record contract fixes from the 0.4.0 e2e pass.
+
+Three field findings:
+- run output was computed and returned to the live caller, then dropped —
+  no column, not in the persist UPDATE, so GET /pipelines/runs/{id} always
+  said output: null.
+- async/replay enqueue responses returned the arq JOB id labelled run_id;
+  polling it 404'd forever (the real run got a fresh uuid in the worker).
+- schedules with schedule_type="pipeline" could never be created: target
+  validation fell into the agent branch ("Agent 'ns/name' not found").
+"""
+
+import contextlib
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Pipeline
+from app.models.execution import TriggerType
+from app.models.pipeline import PipelineRun
+from tests.conftest import auth_headers
+
+
+class _FakePool:
+    def __init__(self):
+        self.jobs = []
+
+    async def enqueue_job(self, name, **kwargs):
+        self.jobs.append({"name": name, **kwargs})
+
+
+class TestEnqueueReturnsRunId:
+    async def test_returned_id_is_the_job_kwarg_run_id_not_the_job_id(self, monkeypatch):
+        from app.services import queue_service as qs
+
+        pool = _FakePool()
+
+        async def fake_pool():
+            return pool
+
+        monkeypatch.setattr(qs, "get_arq_pool", fake_pool)
+
+        returned = await qs.queue_service.enqueue_pipeline_run(
+            pipeline_id=str(uuid.uuid4()),
+            run_input={},
+            trigger_type="MANUAL",
+            trigger_id="test",
+            user_id=str(uuid.uuid4()),
+        )
+        (job,) = pool.jobs
+        assert returned == job["run_id"]
+        assert returned != job["job_id"]  # the old, never-resolvable answer
+
+
+class TestOutputPersisted:
+    @pytest.fixture
+    async def run_row(self, db: AsyncSession, test_user):
+        pipeline = Pipeline(user_id=test_user.id, name=f"p-{uuid.uuid4().hex[:6]}")
+        db.add(pipeline)
+        await db.flush()
+        run = PipelineRun(
+            pipeline_id=pipeline.id,
+            run_id=str(uuid.uuid4()),
+            user_id=test_user.id,
+            trigger_type=TriggerType.MANUAL,
+            status="running",
+            started_at=datetime.now(timezone.utc),
+        )
+        db.add(run)
+        await db.flush()
+        return pipeline, run
+
+    async def _persist(self, db, monkeypatch, pipeline, run, *, status, output):
+        from app.services import pipeline_runner as pr
+
+        @contextlib.asynccontextmanager
+        async def fake_session():
+            yield db
+
+        monkeypatch.setattr(pr, "AsyncSessionLocal", fake_session)
+
+        class _NoRedis:
+            async def eval(self, *a):  # lock release path
+                return 0
+
+            async def get(self, *a):
+                return None
+
+        await pr._persist_outcome(
+            pipeline, str(run.user_id), run.run_id, status,
+            None if status == "succeeded" else "boom",
+            output, [],
+            new_cursor=None, t0=0.0, use_lock=False,
+            lock_key="", redis=_NoRedis(),
+        )
+
+    async def test_success_persists_output(self, db, monkeypatch, run_row):
+        pipeline, run = run_row
+        await self._persist(
+            db, monkeypatch, pipeline, run,
+            status="succeeded", output={"answer": 42},
+        )
+        await db.refresh(run)
+        assert run.output == {"answer": 42}
+
+    async def test_failure_persists_no_output(self, db, monkeypatch, run_row):
+        pipeline, run = run_row
+        await self._persist(
+            db, monkeypatch, pipeline, run,
+            status="failed", output={"partial": True},
+        )
+        await db.refresh(run)
+        assert run.output is None
+        assert run.error == "boom"
+
+
+class TestPipelineSchedules:
+    @pytest.fixture(autouse=True)
+    def _fake_redis(self, monkeypatch):
+        """The endpoint notifies the running scheduler via Redis pub/sub;
+        the unit env has no reachable Redis (same as the known test_auth
+        situation), so fake it."""
+        class _R:
+            async def publish(self, *a):
+                return 0
+
+        async def _get():
+            return _R()
+
+        monkeypatch.setattr("app.api.v1.endpoints.schedules.get_redis", _get)
+
+    async def test_pipeline_schedule_creates(self, client, db, admin_user):
+        pipeline = Pipeline(
+            user_id=admin_user.id, namespace="default",
+            name=f"sched-{uuid.uuid4().hex[:6]}",
+            steps=[{"name": "s", "type": "function", "function": "default/f"}],
+        )
+        db.add(pipeline)
+        await db.flush()
+
+        resp = await client.post(
+            "/api/v1/schedules",
+            headers=auth_headers(admin_user),
+            json={
+                "name": f"sched-{uuid.uuid4().hex[:6]}",
+                "schedule_type": "pipeline",
+                "target_namespace": "default",
+                "target_name": pipeline.name,
+                "cron_expression": "*/5 * * * *",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        assert resp.json()["schedule_type"] == "pipeline"
+
+    async def test_missing_pipeline_404s_with_pipeline_message(self, client, admin_user):
+        resp = await client.post(
+            "/api/v1/schedules",
+            headers=auth_headers(admin_user),
+            json={
+                "name": f"sched-{uuid.uuid4().hex[:6]}",
+                "schedule_type": "pipeline",
+                "target_namespace": "default",
+                "target_name": "does_not_exist",
+                "cron_expression": "*/5 * * * *",
+            },
+        )
+        assert resp.status_code == 404
+        assert "Pipeline" in resp.json()["detail"]  # not "Agent"
+
+
+class TestVersionHeader:
+    async def test_all_responses_carry_version(self, client):
+        from app._version import __version__
+
+        # Root app, mounted v1 app, and an error response
+        for path in ("/info", "/api/v1/agents", "/definitely-not-a-route"):
+            resp = await client.get(path)
+            assert resp.headers.get("x-sinas-version") == __version__, path


### PR DESCRIPTION
First true e2e pass over pipelines (nothing had ever executed one against a live stack). Working: connector/function/agent/load steps, JMESPath mappings, webhook trigger, sync/async/replay mechanics, pipeline-as-agent-tool, cursor advance with per-run before/after. Three real bugs found and fixed:

1. **Run output was never persisted** — no column, not in the persist UPDATE; \`GET /pipelines/runs/{id}\` always said \`output: null\` while the schema promised it. Now stored on success (migration \`r1u2n3o4u5t6\`).
2. **Enqueue/replay returned the arq job id as \`run_id\`** — polling it 404'd forever. Run ids are now pre-allocated at enqueue and threaded through to the runner; the id you're given is the id your run gets.
3. **Pipeline schedules were uncreatable** — target validation only knew function/agent, so \`schedule_type: pipeline\` 404'd as "Agent not found" despite the scheduler execution path existing.

Also adds \`X-Sinas-Version\` response header on the root app (per request).

6 new tests; suite 383 passed + 7 known env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)