### PR TITLE
fix(packages): secret-type variables 500 on preview/install

### DIFF
--- a/backend/app/services/package_service.py
+++ b/backend/app/services/package_service.py
@@ -184,7 +184,10 @@ class PackageService:
 
         # Substitute variables if provided
         if variables:
-            yaml_content, _ = await self._resolve_variables(yaml_content, variables, user_id)
+            # Preview is a dry run: validate + substitute, persist nothing.
+            yaml_content, _ = await self._resolve_variables(
+                yaml_content, variables, user_id, persist_secrets=False
+            )
 
         config, validation = await ConfigParser.parse_and_validate(yaml_content, db=self.db)
 
@@ -488,8 +491,12 @@ class PackageService:
         yaml_content: str,
         provided: dict[str, Any],
         user_id: str,
+        persist_secrets: bool = True,
     ) -> tuple[str, dict[str, Any]]:
         """Validate and substitute install-time variables.
+
+        persist_secrets=False (preview) validates secret variables but writes
+        nothing — a dry run must never persist secrets.
 
         Returns (substituted_yaml, stored_values).
         stored_values is what gets persisted in Package.values
@@ -563,23 +570,31 @@ class PackageService:
                 value = str(value)
 
             elif var_type == "secret":
-                # Create/upsert the secret
-                from app.core.encryption import encryption_service
-                from app.models.secret import Secret
-                existing = await self.db.execute(
-                    select(Secret).where(Secret.name == name)
-                )
-                secret = existing.scalar_one_or_none()
-                if secret:
-                    secret.encrypted_value = encryption_service.encrypt(str(value))
-                else:
-                    secret = Secret(
-                        name=name,
-                        encrypted_value=encryption_service.encrypt(str(value)),
-                        description=decl.get("description"),
+                if persist_secrets:
+                    # Upsert the SHARED secret. Scoped to visibility="shared":
+                    # a name-only lookup could silently overwrite another
+                    # user's PRIVATE secret of the same name (same bug class
+                    # the config-apply secrets path fixed).
+                    from app.core.encryption import encryption_service
+                    from app.models.secret import Secret
+                    existing = await self.db.execute(
+                        select(Secret).where(
+                            Secret.name == name, Secret.visibility == "shared"
+                        )
                     )
-                    self.db.add(secret)
-                await self.db.flush()
+                    secret = existing.scalar_one_or_none()
+                    if secret:
+                        secret.encrypted_value = encryption_service.encrypt(str(value))
+                    else:
+                        secret = Secret(
+                            name=name,
+                            encrypted_value=encryption_service.encrypt(str(value)),
+                            description=decl.get("description"),
+                            user_id=user_id,
+                            visibility="shared",
+                        )
+                        self.db.add(secret)
+                    await self.db.flush()
                 # The substitution value is the secret reference syntax
                 resolved[name] = f"{{{{{name}}}}}"
                 stored_values[name] = "***"

--- a/backend/tests/unit/test_package_secret_vars.py
+++ b/backend/tests/unit/test_package_secret_vars.py
@@ -1,0 +1,109 @@
+"""Package secret-type variables: user attribution, preview purity, scoping.
+
+Field report from integration-package testing: any package declaring a
+`type: secret` variable 500'd on preview AND install with a NOT NULL
+violation (secrets.user_id) — 5 of 6 integration packages uninstallable.
+Preview also performed the INSERT, so a dry run persisted secrets.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.encryption import encryption_service
+from app.models.secret import Secret
+from app.services.package_service import PackageService
+
+YAML = """
+kind: SinasPackage
+metadata:
+  name: test-secret-pkg
+spec:
+  variables:
+    - name: {name}
+      type: secret
+      description: token
+  connectors:
+    - namespace: default
+      name: probe
+      baseUrl: https://example.com
+      auth:
+        type: bearer
+        token: ${{{{ vars.{name} }}}}
+"""
+
+
+class TestPackageSecretVariables:
+    async def test_install_path_creates_shared_secret_with_owner(
+        self, db: AsyncSession, test_user
+    ):
+        name = f"TOK_{uuid.uuid4().hex[:6].upper()}"
+        svc = PackageService(db)
+        substituted, stored = await svc._resolve_variables(
+            YAML.format(name=name), {name: "s3cret"}, str(test_user.id)
+        )
+        row = (
+            await db.execute(select(Secret).where(Secret.name == name))
+        ).scalar_one()
+        assert str(row.user_id) == str(test_user.id)  # was NULL -> 500
+        assert row.visibility == "shared"
+        assert encryption_service.decrypt(row.encrypted_value) == "s3cret"
+        assert stored[name] == "***"
+        assert f"{{{{{name}}}}}" in substituted
+
+    async def test_preview_persists_nothing(self, db: AsyncSession, test_user):
+        name = f"TOK_{uuid.uuid4().hex[:6].upper()}"
+        svc = PackageService(db)
+        substituted, stored = await svc._resolve_variables(
+            YAML.format(name=name), {name: "s3cret"}, str(test_user.id),
+            persist_secrets=False,
+        )
+        assert (
+            await db.execute(select(Secret).where(Secret.name == name))
+        ).scalar_one_or_none() is None  # dry run wrote a secret before
+        # Substitution still behaves identically
+        assert f"{{{{{name}}}}}" in substituted
+        assert stored[name] == "***"
+
+    async def test_private_secret_of_other_user_not_overwritten(
+        self, db: AsyncSession, test_user, admin_user
+    ):
+        name = f"TOK_{uuid.uuid4().hex[:6].upper()}"
+        private = Secret(
+            user_id=test_user.id,
+            name=name,
+            encrypted_value=encryption_service.encrypt("private-value"),
+            visibility="private",
+        )
+        db.add(private)
+        await db.flush()
+
+        svc = PackageService(db)
+        await svc._resolve_variables(
+            YAML.format(name=name), {name: "package-value"}, str(admin_user.id)
+        )
+        await db.refresh(private)
+        assert encryption_service.decrypt(private.encrypted_value) == "private-value"
+        shared = (
+            await db.execute(
+                select(Secret).where(
+                    Secret.name == name, Secret.visibility == "shared"
+                )
+            )
+        ).scalar_one()
+        assert encryption_service.decrypt(shared.encrypted_value) == "package-value"
+
+    async def test_existing_shared_secret_updated_in_place(
+        self, db: AsyncSession, test_user
+    ):
+        name = f"TOK_{uuid.uuid4().hex[:6].upper()}"
+        svc = PackageService(db)
+        await svc._resolve_variables(YAML.format(name=name), {name: "one"}, str(test_user.id))
+        await svc._resolve_variables(YAML.format(name=name), {name: "two"}, str(test_user.id))
+        rows = (
+            await db.execute(select(Secret).where(Secret.name == name))
+        ).scalars().all()
+        assert len(rows) == 1
+        assert encryption_service.decrypt(rows[0].encrypted_value) == "two"


### PR DESCRIPTION
Release-blocker from live integration-package testing: any package with a `type: secret` variable failed preview AND install (NOT NULL on secrets.user_id) — 5 of 6 new integration packages uninstallable. Fixes: owner attribution + explicit shared visibility on create; preview no longer persists secrets (dry runs wrote rows); lookup scoped to shared so a package can't overwrite a user's private secret of the same name. 4 tests. Suite 387 passed + 7 known env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)