### PR TITLE
fix(webhooks): partial template renders append payload instead of replacing the message

### DIFF
--- a/backend/app/api/runtime/endpoints/webhooks.py
+++ b/backend/app/api/runtime/endpoints/webhooks.py
@@ -113,18 +113,25 @@ async def _execute_agent_webhook(
         webhook.message_template or "", context
     )
     message = message.strip()
-    # Fall back on a PARTIAL render too, not just an empty one: 'New issue {{a}}:
-    # {{b}}' against an unexpected payload renders 'New issue :' — non-empty, but
-    # it would invoke (and bill) the agent with no information about the event.
-    if not message or msg_had_undefined:
+    # A partial render must never REPLACE the author's framing — multi-event
+    # templates legitimately reference fields absent per event type, and the
+    # trailing instructions ("act on this per your triage instructions") are
+    # the whole point of the template. Non-empty partial render → keep it and
+    # APPEND the raw payload so no data is lost either. Only a fully empty
+    # render falls back to bare payload JSON.
+    if not message:
         logger.warning(
-            "Webhook %s: message template did not fully render (empty=%s, undefined=%s); "
-            "falling back to raw payload",
+            "Webhook %s: message template rendered empty; falling back to raw payload",
             webhook.path,
-            not message,
-            msg_had_undefined,
         )
         message = json.dumps(context)
+    elif msg_had_undefined:
+        logger.info(
+            "Webhook %s: message template partially rendered (undefined variables); "
+            "appending raw payload",
+            webhook.path,
+        )
+        message = f"{message}\n\nFull event payload:\n{json.dumps(context)}"
 
     session_key: Optional[str] = None
     if webhook.session_key_template:

--- a/backend/tests/unit/test_webhook_targets.py
+++ b/backend/tests/unit/test_webhook_targets.py
@@ -659,14 +659,18 @@ class TestRuntimeAgentTarget:
         monkeypatch.setattr(queue_service, "enqueue_agent_message", fake_enqueue_agent_message)
 
         # Payload missing everything the template references: the webhook must
-        # still succeed (undefined variables never raise), but a PARTIAL render
-        # must not be sent as-is. 'New issue :' is non-empty yet carries no
-        # information about the event, so the agent would be invoked — and
-        # billed — with nothing to act on. Fall back to the raw payload instead.
+        # still succeed (undefined variables never raise), and a PARTIAL render
+        # keeps the author's framing while APPENDING the raw payload — the
+        # template's instructions are the point, and replacing them with bare
+        # JSON handed the agent data with zero guidance (field report from the
+        # integration packages: multi-event templates legitimately reference
+        # fields absent per event type).
         resp = await client.post(f"/webhooks/{path}", json={"unrelated": True})
         assert resp.status_code == 202, resp.text
-        assert captured["content"] != "New issue :"
-        assert "unrelated" in captured["content"]
+        content = captured["content"]
+        assert content.startswith("New issue")          # author framing kept
+        assert "Full event payload:" in content         # data appended
+        assert "unrelated" in content                   # nothing lost
 
     async def test_fully_empty_render_falls_back_to_payload(
         self, client, db, test_user, monkeypatch

--- a/docs-mint/triggers/webhooks.mdx
+++ b/docs-mint/triggers/webhooks.mdx
@@ -56,7 +56,7 @@ return {"_status": 201, "_headers": {"X-Request-Id": "abc"}, "_body": {"ok": Tru
 
 ## Agent targets
 
-A webhook can trigger an agent directly, without a bridge function. The request payload is rendered through `message_template` (Jinja2) and sent to the agent as a user message. Undefined template variables render as empty strings — an unexpected payload shape never fails the webhook.
+A webhook can trigger an agent directly, without a bridge function. The request payload is rendered through `message_template` (Jinja2) and sent to the agent as a user message. Undefined template variables render as empty strings — an unexpected payload shape never fails the webhook. If any variable was undefined, the rendered message is delivered with the full raw payload appended (so the agent keeps both your instructions and the data); a template that renders fully empty falls back to the raw payload alone. For multi-event sources (e.g. GitHub issues + PRs + comments), reference only fields present in every payload variant, or guard with `{% if x is defined %}`.
 
 With a `session_key_template`, repeated events that render the same key continue the same conversation (like the `session_key` on `POST /agents/{ns}/{name}/invoke`) — e.g. all events for one Jira issue or one Slack thread share a chat. Without it, each delivery starts a fresh chat.
 


### PR DESCRIPTION
Integration-testing finding: the undefined-variable fallback replaced the whole rendered message with raw JSON, discarding the template author's instructions — the common case for multi-event templates (fields legitimately absent per event type). Non-empty partial renders now keep the authored message and append the full payload; fully-empty renders keep the existing raw fallback; sessionKeyTemplate strictness untouched. Docs updated with the {% if x is defined %} guidance. Suite 387 passed + 7 known env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)