### PR TITLE
fix(chart): compute requests for postgres/redis/pgbouncer (Autopilot cost + QoS)

### DIFF
--- a/charts/sinas/templates/pgbouncer.yaml
+++ b/charts/sinas/templates/pgbouncer.yaml
@@ -20,6 +20,8 @@ spec:
       containers:
         - name: pgbouncer
           image: edoburu/pgbouncer:latest
+          resources:
+            {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
           env:
             - name: DATABASE_PASSWORD
               valueFrom:

--- a/charts/sinas/templates/postgres.yaml
+++ b/charts/sinas/templates/postgres.yaml
@@ -21,6 +21,8 @@ spec:
       containers:
         - name: postgres
           image: postgres:16-alpine
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
           env:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.user | quote }}

--- a/charts/sinas/templates/redis.yaml
+++ b/charts/sinas/templates/redis.yaml
@@ -21,6 +21,8 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
           command:
             - redis-server
             - --appendonly

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -64,11 +64,25 @@ postgres:
   database: sinas
   password: ""  # required — install fails if empty
   storage: 5Gi
+  ## Compute requests matter: without them, GKE Autopilot bills its platform
+  ## default (0.5 vCPU / 2Gi PER POD) and standard clusters give the database
+  ## BestEffort QoS (first evicted under pressure). Requests below are sized
+  ## for an idle/small instance — raise for production load. Limits are
+  ## deliberately not set by default (an undersized memory limit OOM-kills
+  ## your database); add resources.limits here if you want a ceiling.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 768Mi
 
 ## Redis
 redis:
   maxmemory: "256mb"
   storage: 1Gi
+  resources:
+    requests:
+      cpu: 50m
+      memory: 320Mi  # headroom over maxmemory
 
 ## ClickHouse
 clickhouse:
@@ -88,6 +102,10 @@ pgbouncer:
   defaultPoolSize: 50
   minPoolSize: 10
   reservePoolSize: 10
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 ## File storage — shared volume for uploaded files (/var/sinas/files).
 ## Mounted into backend, queue-worker, queue-agent, scheduler.


### PR DESCRIPTION
Live-measured on GKE Autopilot: the three datastores had no compute requests, so each got the platform default 0.5 vCPU/2Gi — ~55% of the whole release's bill for idle pods (~$129/mo → ~$58/mo after). On standard clusters, no requests = BestEffort QoS for the database. Adds idle-sized default requests (overridable, same values pattern as app workloads). Deliberately no default limits: Autopilot bills by requests anyway, and a default memory ceiling on postgres is a production OOM footgun — reporters' verified numbers kept for requests, limits left to operators. helm lint + template clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)