### PR TITLE
fix(chart): SMTP-less install login path + cross-namespace egress allowlist

### DIFF
--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -123,6 +123,19 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
       name: {{ .Release.Name }}-secrets
       key: clickhouse-password
 {{- end }}
+{{- $auto := "otp" }}
+{{- if .Values.superadminPassword }}
+{{- $auto = ternary "password+otp" "password" (ne .Values.smtp.host "") }}
+{{- end }}
+- name: AUTH_MODE
+  value: {{ .Values.auth.mode | default $auto | quote }}
+{{- if .Values.superadminPassword }}
+- name: SUPERADMIN_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets
+      key: superadmin-password
+{{- end }}
 - name: CODE_EXECUTION_ENABLED
   value: {{ .Values.features.codeExecution | quote }}
 - name: BUILTIN_DATABASE_ENABLED

--- a/charts/sinas/templates/networkpolicy.yaml
+++ b/charts/sinas/templates/networkpolicy.yaml
@@ -62,6 +62,20 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+    {{- range .Values.networkPolicy.egressNamespaces }}
+    ## Operator-allowlisted cross-namespace egress
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .namespace }}
+      {{- if .ports }}
+      ports:
+        {{- range .ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+      {{- end }}
+    {{- end }}
     ## External internet — except RFC1918 (blocks cross-namespace pod IPs).
     - to:
         - ipBlock:
@@ -148,6 +162,20 @@ spec:
       ports:
         - port: 8000
           protocol: TCP
+    {{- range .Values.networkPolicy.egressNamespaces }}
+    ## Operator-allowlisted cross-namespace egress
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .namespace }}
+      {{- if .ports }}
+      ports:
+        {{- range .ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+      {{- end }}
+    {{- end }}
     ## Internet — no RFC1918, so no other cluster-internal services.
     - to:
         - ipBlock:

--- a/charts/sinas/templates/secret.yaml
+++ b/charts/sinas/templates/secret.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.superadminEmail (not .Values.smtp.host) (not .Values.superadminPassword) }}
+{{- fail "superadminEmail is set but there is no way to log in: the default auth mode delivers OTP login codes by email and smtp.host is empty. Set superadminPassword (recommended for SMTP-less installs) or configure smtp.*" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,6 +11,9 @@ type: Opaque
 stringData:
   secret-key: {{ required "secrets.secretKey is required — set it via --set secrets.secretKey=... or a values file" .Values.secrets.secretKey | quote }}
   encryption-key: {{ required "secrets.encryptionKey is required — set it via --set secrets.encryptionKey=... or a values file" .Values.secrets.encryptionKey | quote }}
+  {{- if .Values.superadminPassword }}
+  superadmin-password: {{ .Values.superadminPassword | quote }}
+  {{- end }}
   database-password: {{ required "postgres.password is required — set it via --set postgres.password=... or a values file (postgres refuses to start without a superuser password)" .Values.postgres.password | quote }}
   {{- if .Values.clickhouse.enabled }}
   clickhouse-password: {{ .Values.clickhouse.password | quote }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -22,8 +22,19 @@ secrets:
   secretKey: ""
   encryptionKey: ""
 
-## Superadmin
+## Superadmin. With the default OTP auth mode, login codes arrive by EMAIL —
+## so without smtp.* configured a fresh install would be impossible to log
+## into. Set superadminPassword for SMTP-less installs (the install fails
+## fast if superadminEmail is set with neither). When superadminPassword is
+## set, auth mode auto-selects "password" (or "password+otp" with SMTP);
+## override with auth.mode.
 superadminEmail: ""
+superadminPassword: ""
+
+## Authentication mode: "otp", "password", or "password+otp".
+## Empty = auto (see superadmin comment above).
+auth:
+  mode: ""
 
 ## Executor — how sinas runs user/agent code.
 ##
@@ -102,6 +113,14 @@ fileStorage:
 networkPolicy:
   enabled: true
   ingressNamespace: ""
+  ## Cross-namespace EGRESS is denied by default (private ranges are excluded
+  ## from the internet rule, and only same-namespace pods are allowed) — calls
+  ## to companion services in other namespaces will TIME OUT, not be refused.
+  ## Allowlist them here; ports optional (all ports when omitted):
+  ##   egressNamespaces:
+  ##     - namespace: sgr
+  ##       ports: [8080]
+  egressNamespaces: []
 
 ## Builder (Node.js esbuild server)
 builder:


### PR DESCRIPTION
Two live-GKE findings. (1) Fresh installs without SMTP had NO authentication path — OTP mode with no mail delivery, no superadminPassword knob; everything healthy, nobody can log in. Adds superadminPassword (secret-stored), explicit AUTH_MODE with sensible auto-selection, and a render-time fail when superadminEmail is set with neither password nor SMTP. Existing OTP installs render identically. (2) networkPolicy.egressNamespaces allowlist for companion services in other namespaces (default-deny currently fails as a silent timeout), applied to services + trusted policies, sandbox untouched. Render matrix + lint verified for all mode combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)