### PR TITLE
fix(chart): survive helm upgrade --reuse-values from pre-rc.5 values

### DIFF
--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -127,8 +127,10 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
 {{- if .Values.superadminPassword }}
 {{- $auto = ternary "password+otp" "password" (ne .Values.smtp.host "") }}
 {{- end }}
+## Paren-safe: `helm upgrade --reuse-values` from a pre-auth release has no
+## `auth` key at all, and a bare .Values.auth.mode nil-pointers there.
 - name: AUTH_MODE
-  value: {{ .Values.auth.mode | default $auto | quote }}
+  value: {{ (.Values.auth).mode | default $auto | quote }}
 {{- if .Values.superadminPassword }}
 - name: SUPERADMIN_PASSWORD
   valueFrom:

--- a/charts/sinas/templates/pgbouncer.yaml
+++ b/charts/sinas/templates/pgbouncer.yaml
@@ -20,8 +20,10 @@ spec:
       containers:
         - name: pgbouncer
           image: edoburu/pgbouncer:latest
+          {{- with (.Values.pgbouncer).resources }}
           resources:
-            {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: DATABASE_PASSWORD
               valueFrom:

--- a/charts/sinas/templates/postgres.yaml
+++ b/charts/sinas/templates/postgres.yaml
@@ -21,8 +21,10 @@ spec:
       containers:
         - name: postgres
           image: postgres:16-alpine
+          {{- with (.Values.postgres).resources }}
           resources:
-            {{- toYaml .Values.postgres.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.user | quote }}

--- a/charts/sinas/templates/redis.yaml
+++ b/charts/sinas/templates/redis.yaml
@@ -21,8 +21,10 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
+          {{- with (.Values.redis).resources }}
           resources:
-            {{- toYaml .Values.redis.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - redis-server
             - --appendonly


### PR DESCRIPTION
## Problem
`helm upgrade --reuse-values` reuses the previous release's values verbatim and does **not** merge in new chart defaults, so keys introduced after the installed release are simply absent. Upgrading rc.4 → rc.5 in place fails:

```
_helpers.tpl:131: executing "sinas.backendEnv" at <.Values.auth.mode>:
  nil pointer evaluating interface {}.mode
```

Reported independently from two live upgrades. Any operator upgrading in place hits this.

## Fix
- `(.Values.auth).mode` — the parenthesised form yields nil instead of panicking on a missing parent (same pattern already used for `(.Values.jwt).*`).
- `with`-guard the three datastore `resources:` blocks so an absent key omits the field instead of rendering `resources: null`.

Audit of everything new since rc.1: only `auth` (map, crash) and `superadminPassword` (top-level scalar, nil-safe) were added; `egressNamespaces` range-over-nil is a no-op.

## Verification
- `helm lint` clean
- Reuse simulation: template with `auth=null`, all three `resources=null`, `egressNamespaces=null` → renders, AUTH_MODE="otp", no `null` artifacts
- Auth matrix unchanged: explicit override, password, password+otp, superadminEmail fail-fast guard

## Release-notes upgrade note (to include with the tag)
- Upgrading with `--reuse-values` from pre-rc.5 now works; still recommend `-f your-values.yaml` over `--reuse-values` so new defaults apply.
- If you previously set AUTH_MODE or SUPERADMIN_PASSWORD via `extraEnv`, remove them before upgrading — the chart now emits them natively and duplicate env keys are rejected by server-side apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)