### PR TITLE
feat(chart): external PostgreSQL support (Cloud SQL et al.)

### DIFF
--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -43,14 +43,28 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
+Database password secretKeyRef body — release secret by default, or the
+operator's pre-created secret when postgres.external.existingSecret is set.
+Shared by backendEnv and pgbouncer.
+*/}}
+{{- define "sinas.dbPasswordRef" -}}
+{{- if ((.Values.postgres).external).existingSecret -}}
+name: {{ .Values.postgres.external.existingSecret }}
+key: {{ .Values.postgres.external.existingSecretKey | default "password" }}
+{{- else -}}
+name: {{ .Release.Name }}-secrets
+key: database-password
+{{- end }}
+{{- end }}
+
+{{/*
 Backend environment — shared by backend, all workers, scheduler, cdc-worker
 */}}
 {{- define "sinas.backendEnv" -}}
 - name: DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Release.Name }}-secrets
-      key: database-password
+      {{- include "sinas.dbPasswordRef" . | nindent 6 }}
 - name: DATABASE_USER
   value: {{ .Values.postgres.user | quote }}
 - name: DATABASE_HOST
@@ -62,7 +76,7 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
 - name: DATABASE_URL
   value: "postgresql://{{ .Values.postgres.user }}:$(DATABASE_PASSWORD)@pgbouncer:5432/{{ .Values.postgres.database }}"
 - name: DATABASE_DIRECT_HOST
-  value: postgres
+  value: {{ ((.Values.postgres).external).host | default "postgres" | quote }}
 {{- if .Values.clickhouse.enabled }}
 - name: CLICKHOUSE_HOST
   value: clickhouse

--- a/charts/sinas/templates/networkpolicy.yaml
+++ b/charts/sinas/templates/networkpolicy.yaml
@@ -76,6 +76,32 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- $extHost := ((.Values.postgres).external).host }}
+    {{- if and $extHost (regexMatch "^(\\d{1,3}\\.){3}\\d{1,3}$" $extHost) }}
+    ## External postgres (postgres.external.host) — auto-allowed, because the
+    ## RFC1918 exclusion below would otherwise silently drop every database
+    ## connection to a private-IP managed instance. DNS hostnames cannot be
+    ## auto-derived; allowlist their range via egressCidrs instead.
+    - to:
+        - ipBlock:
+            cidr: {{ $extHost }}/32
+      ports:
+        - port: 5432
+          protocol: TCP
+    {{- end }}
+    {{- range .Values.networkPolicy.egressCidrs }}
+    ## Operator-allowlisted private-IP egress (external datastores etc.)
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+      {{- if .ports }}
+      ports:
+        {{- range .ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+      {{- end }}
+    {{- end }}
     ## External internet — except RFC1918 (blocks cross-namespace pod IPs).
     - to:
         - ipBlock:

--- a/charts/sinas/templates/pgbouncer.yaml
+++ b/charts/sinas/templates/pgbouncer.yaml
@@ -28,10 +28,9 @@ spec:
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
-                  key: database-password
+                  {{- include "sinas.dbPasswordRef" . | nindent 18 }}
             - name: DATABASE_URL
-              value: "postgres://{{ .Values.postgres.user }}:$(DATABASE_PASSWORD)@postgres:5432/{{ .Values.postgres.database }}"
+              value: "postgres://{{ .Values.postgres.user }}:$(DATABASE_PASSWORD)@{{ ((.Values.postgres).external).host | default "postgres" }}:5432/{{ .Values.postgres.database }}"
             - name: POOL_MODE
               value: {{ .Values.pgbouncer.poolMode | quote }}
             - name: MAX_CLIENT_CONN

--- a/charts/sinas/templates/postgres.yaml
+++ b/charts/sinas/templates/postgres.yaml
@@ -1,3 +1,4 @@
+{{- if not ((.Values.postgres).external).host }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -74,3 +75,4 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
+{{- end }}

--- a/charts/sinas/templates/secret.yaml
+++ b/charts/sinas/templates/secret.yaml
@@ -14,7 +14,9 @@ stringData:
   {{- if .Values.superadminPassword }}
   superadmin-password: {{ .Values.superadminPassword | quote }}
   {{- end }}
-  database-password: {{ required "postgres.password is required — set it via --set postgres.password=... or a values file (postgres refuses to start without a superuser password)" .Values.postgres.password | quote }}
+  {{- if not ((.Values.postgres).external).existingSecret }}
+  database-password: {{ required "postgres.password is required — set it via --set postgres.password=... or a values file (or point postgres.external.existingSecret at a pre-created Secret)" .Values.postgres.password | quote }}
+  {{- end }}
   {{- if .Values.clickhouse.enabled }}
   clickhouse-password: {{ .Values.clickhouse.password | quote }}
   {{- end }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -73,7 +73,28 @@ registry:
 postgres:
   user: postgres
   database: sinas
-  password: ""  # required — install fails if empty
+  password: ""  # required — install fails if empty (unless external.existingSecret)
+  ## External PostgreSQL (Cloud SQL, RDS, ...). Setting external.host skips
+  ## the in-cluster postgres pod and its PVC entirely; pgbouncer STAYS
+  ## in-cluster and pools against the external instance (managed databases
+  ## have hard connection limits — keep it in the path). The standard port
+  ## 5432 is assumed. Password comes from postgres.password as usual, or
+  ## point existingSecret at a pre-created Secret (key existingSecretKey) to
+  ## keep it out of values. The database and user must already exist; the
+  ## user needs CREATEDB unless features.builtinDatabase=false.
+  ## NOTE: private-IP instances live in RFC1918 space, which the default
+  ## NetworkPolicy blocks. When host is an IPv4 literal the chart
+  ## auto-allows egress to it on 5432; a DNS hostname resolving to a
+  ## private IP needs its range allowlisted in networkPolicy.egressCidrs,
+  ## or connections will TIME OUT, not be refused.
+  ## TLS: connections are negotiated opportunistically ("prefer" semantics
+  ## in pgbouncer and the drivers), which satisfies encrypt-only instances
+  ## (e.g. Cloud SQL ENCRYPTED_ONLY). Instances requiring CLIENT
+  ## CERTIFICATES are not supported.
+  external:
+    host: ""
+    existingSecret: ""
+    existingSecretKey: "password"
   storage: 5Gi
   ## Compute requests matter: without them, GKE Autopilot bills its platform
   ## default (0.5 vCPU / 2Gi PER POD) and standard clusters give the database
@@ -139,6 +160,14 @@ networkPolicy:
   ##     - namespace: sgr
   ##       ports: [8080]
   egressNamespaces: []
+  ## Private-IP (RFC1918) egress allowlist by CIDR, for destinations OUTSIDE
+  ## the cluster — e.g. a Cloud SQL or Memorystore private IP (see
+  ## postgres.external). Applies to the sinas services only, never sandbox
+  ## pods. ports optional (all ports when omitted):
+  ##   egressCidrs:
+  ##     - cidr: 10.23.96.3/32
+  ##       ports: [5432]
+  egressCidrs: []
 
 ## Builder (Node.js esbuild server)
 builder:


### PR DESCRIPTION
Blocker for the downstream GKE deployment: the client estate provisions all databases as Cloud SQL (PITR, backups, deletion protection) and the in-cluster StatefulSet on a single RWO PVC would be the only unbacked-up store in it.

## What
- `postgres.external.host` — skips the in-cluster postgres StatefulSet/Service/PVC; **pgbouncer stays** and pools against the external instance (managed DBs have hard connection limits). Migrations go direct (`DATABASE_DIRECT_HOST`).
- `postgres.external.existingSecret`/`existingSecretKey` — take the password from a pre-created Secret; the release secret then omits `database-password` and `postgres.password` is no longer required.
- **NetworkPolicy escape hatch** — the RFC1918 egress exclusion otherwise silently drops every connection to a private-IP managed instance (hangs, not refusals; independently diagnosed on the live GKE install for cross-namespace traffic). When `external.host` is an IPv4 literal, the services policy auto-allows `<host>/32:5432`. New `networkPolicy.egressCidrs` (`{cidr, ports?}`) covers DNS-named endpoints and other private-IP destinations (e.g. Memorystore later).

## Deliberate limits
- Port 5432 assumed: the backend reuses `DATABASE_PORT` for pooled *and* direct URLs, so an external-port knob would silently break migrations. Cloud SQL/RDS are 5432.
- TLS is opportunistic ("prefer" semantics in pgbouncer and drivers) — encrypt-only instances (Cloud SQL `ENCRYPTED_ONLY`) work; client-cert enforcement is not supported.
- The DB user needs `CREATEDB` unless `features.builtinDatabase: false` (documented in values).
- Redis/ClickHouse external: out of scope for 0.4.0.

## Verification
- Default render byte-identical to HEAD (modulo `value: "postgres"` quoting)
- External IP: no postgres pod/Service, pgbouncer upstream `@10.140.0.3:5432`, direct host set, auto `/32` egress rule present
- DNS host: no auto rule (as designed); existingSecret: both secretKeyRefs switch, no `database-password` in release secret, no required-password failure
- `egressCidrs` with ports; `--reuse-values` nil simulation (all new keys null); `helm lint` clean
- Live verification against a real Cloud SQL instance requested from the GKE deployment session before rc.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)