### PR TITLE
feat(auth): API keys scoped by roles + live permission intersection; packages ship roles

### DIFF
--- a/backend/alembic/versions/a1p2i3k4r5l6_api_key_roles.py
+++ b/backend/alembic/versions/a1p2i3k4r5l6_api_key_roles.py
@@ -1,0 +1,48 @@
+"""api_key_roles link table (API keys scoped by roles)
+
+Revision ID: a1p2i3k4r5l6
+Revises: r1u2n3o4u5t6
+Create Date: 2026-08-24
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "a1p2i3k4r5l6"
+down_revision = "r1u2n3o4u5t6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_key_roles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "api_key_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("api_keys.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "role_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("roles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_api_key_roles_api_key_id", "api_key_roles", ["api_key_id"])
+    op.create_index("ix_api_key_roles_role_id", "api_key_roles", ["role_id"])
+    op.create_index(
+        "ix_api_key_role_unique", "api_key_roles", ["api_key_id", "role_id"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_key_roles")

--- a/backend/app/api/v1/endpoints/api_keys.py
+++ b/backend/app/api/v1/endpoints/api_keys.py
@@ -7,11 +7,45 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import generate_api_key, get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
-from app.core.permissions import check_permission
-from app.models import APIKey
-from app.schemas.api_key import APIKeyCreate, APIKeyCreated, APIKeyResponse
+from app.core.permissions import check_permission, validate_permission_subset
+from app.models import APIKey, APIKeyRole, Role
+from app.schemas.api_key import APIKeyCreate, APIKeyCreated, APIKeyResponse, APIKeyRoleRef
 
 router = APIRouter()
+
+
+async def _roles_by_key(db: AsyncSession, key_ids: list) -> dict[str, list[APIKeyRoleRef]]:
+    """Role refs for a set of API keys, one query."""
+    if not key_ids:
+        return {}
+    result = await db.execute(
+        select(APIKeyRole.api_key_id, Role.id, Role.name)
+        .join(Role, Role.id == APIKeyRole.role_id)
+        .where(APIKeyRole.api_key_id.in_(key_ids))
+    )
+    by_key: dict[str, list[APIKeyRoleRef]] = {}
+    for api_key_id, role_id, role_name in result.all():
+        by_key.setdefault(str(api_key_id), []).append(APIKeyRoleRef(id=role_id, name=role_name))
+    return by_key
+
+
+def _key_response(key: APIKey, roles: list[APIKeyRoleRef]) -> APIKeyResponse:
+    # Built explicitly (not from_attributes): the `roles` relationship is an
+    # APIKeyRole list, not the {id, name} refs the schema carries, and lazy
+    # loading it here would fail in async context anyway.
+    return APIKeyResponse(
+        id=key.id,
+        user_id=key.user_id,
+        name=key.name,
+        key_prefix=key.key_prefix,
+        permissions=key.permissions,
+        roles=roles,
+        is_active=key.is_active,
+        last_used_at=key.last_used_at,
+        expires_at=key.expires_at,
+        created_at=key.created_at,
+        revoked_at=key.revoked_at,
+    )
 
 
 @router.post("/api-keys", response_model=APIKeyCreated, status_code=status.HTTP_201_CREATED)
@@ -25,6 +59,11 @@ async def create_api_key(
     Create a new API key for the current user.
 
     The plain API key is returned only once - store it securely!
+
+    Scope the key with explicit `permissions` (validated as a subset of your
+    own), with `role_ids` linking it to roles (the key then tracks the roles
+    as they are edited), or both. Either way, effective permissions are capped
+    by the owner's live permissions on every request.
     """
     user_id, permissions = current_user_data
 
@@ -32,6 +71,31 @@ async def create_api_key(
         set_permission_used(http_request, "sinas.api_keys.create:own", has_perm=False)
         raise HTTPException(status_code=403, detail="Not authorized to create API keys")
     set_permission_used(http_request, "sinas.api_keys.create:own")
+
+    # Explicit grants must be a subset of the creator's own permissions
+    if request_data.permissions:
+        is_valid, violations = validate_permission_subset(request_data.permissions, permissions)
+        if not is_valid:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "API key permissions exceed your role permissions. "
+                    f"Violations: {', '.join(violations)}"
+                ),
+            )
+
+    # Resolve linked roles (existence only — effective permissions are capped
+    # by the owner's live permissions at request time, so a role the owner
+    # does not hold contributes nothing until they are assigned it)
+    roles: list[Role] = []
+    if request_data.role_ids:
+        result = await db.execute(select(Role).where(Role.id.in_(request_data.role_ids)))
+        roles = list(result.scalars().all())
+        missing = {str(r) for r in request_data.role_ids} - {str(r.id) for r in roles}
+        if missing:
+            raise HTTPException(
+                status_code=400, detail=f"Unknown role ids: {', '.join(sorted(missing))}"
+            )
 
     # Generate API key
     plain_key, key_hash, key_prefix = generate_api_key()
@@ -50,6 +114,10 @@ async def create_api_key(
 
     db.add(api_key)
     await db.flush()
+
+    for role in roles:
+        db.add(APIKeyRole(api_key_id=api_key.id, role_id=role.id))
+    await db.flush()
     await db.refresh(api_key)
 
     # Return response with plain key (only time it's shown)
@@ -59,6 +127,7 @@ async def create_api_key(
         key=plain_key,  # Plain key - only shown once!
         key_prefix=api_key.key_prefix,
         permissions=api_key.permissions,
+        roles=[APIKeyRoleRef(id=r.id, name=r.name) for r in roles],
         expires_at=api_key.expires_at,
         created_at=api_key.created_at,
     )
@@ -106,14 +175,16 @@ async def list_api_keys(
     # Sort by created_at desc
     api_keys_sorted = sorted(api_keys, key=lambda k: k.created_at, reverse=True)
 
+    roles_by_key = await _roles_by_key(db, key_ids)
+
     # Build response with user email for admins
     responses = []
     for key in api_keys_sorted:
-        response_data = APIKeyResponse.model_validate(key).model_dump()
+        response = _key_response(key, roles_by_key.get(str(key.id), []))
         # Add user email if viewing with :all scope (admin)
         if key.user:
-            response_data["user_email"] = key.user.email
-        responses.append(APIKeyResponse(**response_data))
+            response.user_email = key.user.email
+        responses.append(response)
 
     return responses
 
@@ -144,7 +215,8 @@ async def get_api_key(
 
     set_permission_used(http_request, "sinas.api_keys.read")
 
-    return APIKeyResponse.model_validate(api_key)
+    roles_by_key = await _roles_by_key(db, [api_key.id])
+    return _key_response(api_key, roles_by_key.get(str(api_key.id), []))
 
 
 @router.delete("/api-keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/endpoints/packages.py
+++ b/backend/app/api/v1/endpoints/packages.py
@@ -36,7 +36,12 @@ async def install_package(
 
     service = PackageService(db)
     try:
-        package, apply_result = await service.install(body.source, user_id, variables=body.variables)
+        package, apply_result = await service.install(
+            body.source,
+            user_id,
+            variables=body.variables,
+            allow_broad_role_permissions=body.allowBroadRolePermissions,
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -25,6 +25,7 @@ from app.core.permissions import (
 )
 from app.models import (
     APIKey,
+    APIKeyRole,
     OTPSession,
     PasswordResetToken,
     RefreshToken,
@@ -558,6 +559,41 @@ async def create_api_key(
     return api_key, plain_key
 
 
+async def resolve_api_key_permissions(
+    db: AsyncSession, api_key: APIKey, user: User
+) -> dict[str, bool]:
+    """
+    Effective permissions for an API key at request time.
+
+    Union of the linked roles' permissions, overlaid with the key's explicit
+    grants, then capped by the owner's LIVE role permissions: a granted entry
+    survives only while the owner currently holds it. Keys therefore track
+    role edits and owner demotions instead of freezing a mint-time snapshot —
+    revoking a permission from a role or user revokes it from their keys too.
+    """
+    perms: dict[str, bool] = {}
+
+    # Union of linked roles' permissions (same OR logic as user roles)
+    result = await db.execute(
+        select(RolePermission)
+        .join(APIKeyRole, APIKeyRole.role_id == RolePermission.role_id)
+        .where(APIKeyRole.api_key_id == api_key.id)
+    )
+    for perm in result.scalars().all():
+        if perm.permission_value or perm.permission_key not in perms:
+            perms[perm.permission_key] = perm.permission_value
+
+    # Explicit grants override role-derived entries (an explicit False is a
+    # deliberate denial on this key)
+    perms.update(api_key.permissions or {})
+
+    if not any(perms.values()):
+        return perms
+
+    owner_perms = await get_user_permissions(db, str(user.id))
+    return {k: v for k, v in perms.items() if not v or check_permission(owner_perms, k)}
+
+
 async def validate_api_key(db: AsyncSession, key: str) -> Optional[tuple[User, dict[str, bool]]]:
     """
     Validate an API key and return the user and permissions.
@@ -598,7 +634,7 @@ async def validate_api_key(db: AsyncSession, key: str) -> Optional[tuple[User, d
     user.last_login_at = datetime.now(UTC)
     await db.commit()
 
-    return user, api_key.permissions
+    return user, await resolve_api_key_permissions(db, api_key, user)
 
 
 # Authentication Dependencies

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -33,6 +33,7 @@ from .tool_call_result import ToolCallResult
 from .usage import UsagePeriod
 from .user import (
     APIKey,
+    APIKeyRole,
     OTPSession,
     PasswordResetToken,
     RefreshToken,
@@ -63,6 +64,7 @@ __all__ = [
     "RolePermission",
     "OTPSession",
     "APIKey",
+    "APIKeyRole",
     "RefreshToken",
     "PasswordResetToken",
     "Chat",

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -190,6 +190,32 @@ class APIKey(Base, PermissionMixin):
 
     # Relationships
     user: Mapped["User"] = relationship("User", back_populates="api_keys", foreign_keys=[user_id])
+    roles: Mapped[list["APIKeyRole"]] = relationship(
+        "APIKeyRole", back_populates="api_key", cascade="all, delete-orphan"
+    )
+
+
+class APIKeyRole(Base):
+    """Links an API key to a role. A linked key's effective permissions are
+    the union of its roles' permissions (plus any explicit grants), capped at
+    request time by the owner's live permissions — so keys track role edits
+    instead of freezing a snapshot."""
+
+    __tablename__ = "api_key_roles"
+    __table_args__ = (Index("ix_api_key_role_unique", "api_key_id", "role_id", unique=True),)
+
+    id: Mapped[uuid_pk]
+    api_key_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("api_keys.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    role_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("roles.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_at: Mapped[created_at]
+
+    # Relationships
+    api_key: Mapped["APIKey"] = relationship("APIKey", back_populates="roles")
+    role: Mapped["Role"] = relationship("Role")
 
 
 class RefreshToken(Base):

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -6,6 +6,16 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 
+class APIKeyRoleRef(BaseModel):
+    """A role linked to an API key."""
+
+    id: uuid.UUID
+    name: str
+
+    class Config:
+        from_attributes = True
+
+
 class APIKeyCreate(BaseModel):
     """Request to create a new API key."""
 
@@ -14,7 +24,18 @@ class APIKeyCreate(BaseModel):
     )
     permissions: dict[str, bool] = Field(
         default_factory=dict,
-        description="Permission overrides (empty = inherit from user's groups)",
+        description=(
+            "Explicit permission grants. Must be a subset of your own permissions; "
+            "also capped by the owner's live permissions on every request."
+        ),
+    )
+    role_ids: list[uuid.UUID] = Field(
+        default_factory=list,
+        description=(
+            "Roles to link this key to. The key's permissions follow the roles as "
+            "they are edited (union of role permissions plus explicit grants, "
+            "capped by the owner's live permissions on every request)."
+        ),
     )
     expires_at: Optional[datetime] = Field(None, description="Optional expiration date")
 
@@ -28,6 +49,7 @@ class APIKeyResponse(BaseModel):
     name: str
     key_prefix: str  # e.g., "sk-abc..."
     permissions: dict[str, bool]
+    roles: list[APIKeyRoleRef] = Field(default_factory=list)
     is_active: bool
     last_used_at: Optional[datetime]
     expires_at: Optional[datetime]
@@ -46,6 +68,7 @@ class APIKeyCreated(BaseModel):
     key: str  # Plain API key - only returned once on creation
     key_prefix: str
     permissions: dict[str, bool]
+    roles: list[APIKeyRoleRef] = Field(default_factory=list)
     expires_at: Optional[datetime]
     created_at: datetime
 

--- a/backend/app/schemas/package.py
+++ b/backend/app/schemas/package.py
@@ -10,6 +10,13 @@ class PackageInstallRequest(BaseModel):
     """Request to install a package from YAML content."""
     source: str = Field(..., description="YAML content of the SinasPackage")
     variables: Optional[dict[str, Any]] = Field(None, description="Install-time variable values")
+    allowBroadRolePermissions: bool = Field(
+        False,
+        description=(
+            "Accept package roles whose granted permissions reach outside the "
+            "package's own namespaces (listed by preview). Off by default."
+        ),
+    )
 
 
 class PackagePreviewRequest(BaseModel):

--- a/backend/app/services/config_apply/identity.py
+++ b/backend/app/services/config_apply/identity.py
@@ -34,12 +34,18 @@ async def apply_roles(
             result = await db.execute(stmt)
             existing = result.scalar_one_or_none()
 
-            # Calculate hash
+            # Calculate hash. Permissions are part of it: without them, a
+            # permission-only change hits the checksum-unchanged `continue`
+            # below and is silently never applied (package upgrades are
+            # mostly permission changes).
             config_hash = calculate_hash(
                 {
                     "name": role_config.name,
                     "description": role_config.description,
                     "email_domain": role_config.emailDomain,
+                    "permissions": sorted(
+                        (p.key, p.value) for p in (role_config.permissions or [])
+                    ),
                 }
             )
 

--- a/backend/app/services/config_parser.py
+++ b/backend/app/services/config_parser.py
@@ -95,10 +95,6 @@ class ConfigParser:
 
         # Add warnings for SinasPackage with environment-specific resources
         if config.kind == "SinasPackage":
-            if config.spec.roles:
-                validation.warnings.append(
-                    "SinasPackage includes roles — these are environment-specific and will be skipped during install"
-                )
             if config.spec.users:
                 validation.warnings.append(
                     "SinasPackage includes users — these are environment-specific and will be skipped during install"

--- a/backend/app/services/package_service.py
+++ b/backend/app/services/package_service.py
@@ -2,6 +2,7 @@
 Package service for installing, uninstalling, and managing integration packages.
 """
 import logging
+import re
 from typing import Any, Optional
 
 import yaml
@@ -21,6 +22,7 @@ from app.models.schedule import ScheduledJob
 from app.models.skill import Skill
 from app.models.store import Store
 from app.models.template import Template
+from app.models.user import APIKeyRole, Role, RolePermission, UserRole
 from app.models.webhook import Webhook
 from app.schemas.config import ConfigApplyResponse, SinasConfig
 from app.services.config_apply import ConfigApplyService
@@ -45,11 +47,64 @@ from app.services.resource_serializers import (
 
 logger = logging.getLogger(__name__)
 
-# Resource types that packages cannot include (environment-specific)
-PACKAGE_SKIP_TYPES = {"roles", "users", "llmProviders", "databaseConnections"}
+# Resource types that packages cannot include (environment-specific).
+# Roles are deliberately NOT here: a package may DEFINE roles (its own
+# least-privilege permission surface) but never BIND them — assignment to
+# users stays an operator act, and emailDomain (auto-membership) is rejected.
+PACKAGE_SKIP_TYPES = {"users", "llmProviders", "databaseConnections"}
+
+# Permission keys shaped sinas.<resource>/<namespace>/... — anything else
+# (non-namespaced or non-sinas keys) counts as broad for package roles.
+NAMESPACED_PERM_RE = re.compile(r"^sinas\.[a-z_]+/(?P<ns>[^/]+)/")
 
 # Models that support managed_by
 MANAGED_MODELS = [Agent, Connector, Manifest, Component, Collection, DatabaseTrigger, Function, Query, ScheduledJob, Skill, Store, Template, Webhook]
+
+
+def _package_namespaces(config: SinasConfig) -> set[str]:
+    """Namespaces the package installs resources into."""
+    namespaces: set[str] = set()
+    for field in type(config.spec).model_fields:
+        value = getattr(config.spec, field, None)
+        if isinstance(value, list):
+            for item in value:
+                ns = getattr(item, "namespace", None)
+                if isinstance(ns, str) and ns:
+                    namespaces.add(ns)
+    return namespaces
+
+
+def package_role_violations(config: SinasConfig) -> tuple[list[str], list[str]]:
+    """
+    Governance checks for roles shipped by a package.
+
+    Returns (hard_errors, broad_permissions):
+    - hard_errors: things a package may never do — bind users (emailDomain is
+      auto-membership). Always rejected.
+    - broad_permissions: granted keys reaching outside the namespaces the
+      package itself installs into (non-namespaced keys, foreign or wildcard
+      namespaces). Rejected unless the operator explicitly consents.
+    """
+    hard: list[str] = []
+    broad: list[str] = []
+    roles = getattr(config.spec, "roles", None) or []
+    if not roles:
+        return hard, broad
+
+    namespaces = _package_namespaces(config)
+    for role in roles:
+        if role.emailDomain:
+            hard.append(
+                f"role '{role.name}' sets emailDomain — packages define roles, "
+                "never bind them to users"
+            )
+        for perm in role.permissions:
+            if not perm.value:
+                continue  # denials can't widen anything
+            m = NAMESPACED_PERM_RE.match(perm.key)
+            if not m or m.group("ns") == "*" or m.group("ns") not in namespaces:
+                broad.append(f"role '{role.name}': {perm.key}")
+    return hard, broad
 
 
 def detach_if_package_managed(resource) -> bool:
@@ -78,6 +133,7 @@ class PackageService:
         yaml_content: str,
         user_id: str,
         variables: Optional[dict[str, Any]] = None,
+        allow_broad_role_permissions: bool = False,
     ) -> tuple[Package, ConfigApplyResponse]:
         """
         Install a package from YAML content.
@@ -86,6 +142,8 @@ class PackageService:
             yaml_content: YAML string with kind: SinasPackage
             user_id: ID of the user installing the package
             variables: Install-time variable values (keyed by variable name)
+            allow_broad_role_permissions: accept package roles whose granted
+                permissions reach outside the package's own namespaces
 
         Returns:
             Tuple of (Package record, ConfigApplyResponse)
@@ -110,6 +168,16 @@ class PackageService:
         pkg_name = config.package.name
         managed_by = f"pkg:{pkg_name}"
 
+        hard, broad = package_role_violations(config)
+        if hard:
+            raise ValueError("Package roles rejected: " + "; ".join(hard))
+        if broad and not allow_broad_role_permissions:
+            raise ValueError(
+                "Package role permissions reach outside the package's own namespaces: "
+                + "; ".join(broad)
+                + ". Review them, then re-install with allowBroadRolePermissions=true to accept."
+            )
+
         # Check if already installed — upgrade in place if so
         existing_result = await self.db.execute(
             select(Package).where(Package.name == pkg_name)
@@ -133,6 +201,10 @@ class PackageService:
 
         # Add validation warnings to result
         result.warnings.extend(validation.warnings)
+        if broad:
+            result.warnings.append(
+                "Accepted broad role permissions (operator consent): " + "; ".join(broad)
+            )
 
         # Create or update package record
         if existing_package:
@@ -215,6 +287,16 @@ class PackageService:
 
         result = await apply_service.apply_config(config, dry_run=True)
         result.warnings.extend(validation.warnings)
+
+        hard, broad = package_role_violations(config)
+        for violation in hard:
+            result.errors.append(f"Package roles rejected: {violation}")
+        for perm in broad:
+            result.warnings.append(
+                "Broad role permission (install requires allowBroadRolePermissions=true): "
+                + perm
+            )
+
         return result, variable_declarations, requires_input
 
     async def uninstall(self, package_name: str) -> dict:
@@ -257,6 +339,16 @@ class PackageService:
             result = await self.db.execute(stmt)
             if result.rowcount > 0:
                 deleted_counts[type_name] = result.rowcount
+
+        # Package-managed roles: children first (their FKs have no ON DELETE),
+        # then the roles. User assignments vanish with the role — deliberate:
+        # an uninstalled package's authority should not linger anywhere.
+        role_ids = select(Role.id).where(Role.managed_by == managed_by).scalar_subquery()
+        for child in (RolePermission, UserRole, APIKeyRole):
+            await self.db.execute(delete(child).where(child.role_id.in_(role_ids)))
+        result = await self.db.execute(delete(Role).where(Role.managed_by == managed_by))
+        if result.rowcount > 0:
+            deleted_counts["roles"] = result.rowcount
 
         # Delete package record
         await self.db.delete(package)

--- a/backend/tests/unit/test_api_key_roles.py
+++ b/backend/tests/unit/test_api_key_roles.py
@@ -1,0 +1,217 @@
+"""API keys scoped by roles + live permission intersection.
+
+Keys used to return their stored permission dict verbatim at request time
+(mint-time snapshot), and the create endpoint never validated the requested
+dict against the creator's own permissions — any user who could create a key
+could mint one with arbitrary permissions. Both are fixed here:
+
+- mint: explicit grants must be a subset of the creator's permissions
+- request time: effective = (explicit ∪ union of linked roles) ∩ owner's LIVE
+  permissions, so role edits and owner demotions apply immediately
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import resolve_api_key_permissions, validate_api_key
+from app.models import APIKey, APIKeyRole
+from app.models.user import Role, RolePermission, User, UserRole
+
+from tests.conftest import auth_headers
+
+
+@pytest_asyncio.fixture
+async def key_user(db: AsyncSession) -> tuple[User, Role]:
+    """User whose role can manage API keys and read agents."""
+    role = Role(name=f"key-role-{uuid.uuid4().hex[:8]}")
+    db.add(role)
+    await db.flush()
+    for perm in [
+        "sinas.api_keys.create:own",
+        "sinas.api_keys/*/*.read:own",
+        "sinas.api_keys.read:own",
+        "sinas.agents/*/*.read:own",
+    ]:
+        db.add(RolePermission(role_id=role.id, permission_key=perm, permission_value=True))
+    user = User(email=f"key-{uuid.uuid4().hex[:8]}@example.com")
+    db.add(user)
+    await db.flush()
+    db.add(UserRole(role_id=role.id, user_id=user.id, active=True))
+    await db.flush()
+    return user, role
+
+
+@pytest_asyncio.fixture
+async def extra_role(db: AsyncSession) -> Role:
+    """A role NOT held by key_user, granting query read."""
+    role = Role(name=f"extra-role-{uuid.uuid4().hex[:8]}")
+    db.add(role)
+    await db.flush()
+    db.add(
+        RolePermission(
+            role_id=role.id, permission_key="sinas.queries/*/*.read:own", permission_value=True
+        )
+    )
+    await db.flush()
+    return role
+
+
+async def _get_key(db: AsyncSession, key_id) -> APIKey:
+    return (await db.execute(select(APIKey).where(APIKey.id == key_id))).scalar_one()
+
+
+class TestMint:
+    async def test_explicit_permissions_must_be_subset(self, client, key_user):
+        user, _ = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "escalate", "permissions": {"sinas.*:all": True}},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 400
+        assert "exceed" in resp.json()["detail"]
+
+    async def test_unknown_role_id_rejected(self, client, key_user):
+        user, _ = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "ghost", "role_ids": [str(uuid.uuid4())]},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 400
+        assert "Unknown role ids" in resp.json()["detail"]
+
+    async def test_linked_roles_returned_and_listed(self, client, db, key_user):
+        user, role = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "linked", "role_ids": [str(role.id)]},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert [r["name"] for r in body["roles"]] == [role.name]
+
+        listed = await client.get("/api/v1/api-keys", headers=auth_headers(user))
+        assert listed.status_code == 200
+        row = next(k for k in listed.json() if k["id"] == body["id"])
+        assert [r["name"] for r in row["roles"]] == [role.name]
+
+
+class TestResolution:
+    async def test_linked_key_gets_role_permissions(self, client, db, key_user):
+        user, role = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "linked", "role_ids": [str(role.id)]},
+            headers=auth_headers(user),
+        )
+        plain = resp.json()["key"]
+        resolved = await validate_api_key(db, plain)
+        assert resolved is not None
+        _, perms = resolved
+        assert perms.get("sinas.agents/*/*.read:own") is True
+
+    async def test_role_edit_applies_without_reminting(self, client, db, key_user):
+        user, role = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "tracked", "role_ids": [str(role.id)]},
+            headers=auth_headers(user),
+        )
+        plain = resp.json()["key"]
+        _, before = await validate_api_key(db, plain)
+        assert "sinas.functions/*/*.read:own" not in before
+
+        db.add(
+            RolePermission(
+                role_id=role.id,
+                permission_key="sinas.functions/*/*.read:own",
+                permission_value=True,
+            )
+        )
+        await db.flush()
+        _, after = await validate_api_key(db, plain)
+        assert after.get("sinas.functions/*/*.read:own") is True
+
+    async def test_role_not_held_by_owner_contributes_nothing(
+        self, client, db, key_user, extra_role
+    ):
+        user, _ = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "ambitious", "role_ids": [str(extra_role.id)]},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 201
+        plain = resp.json()["key"]
+        _, perms = await validate_api_key(db, plain)
+        # extra_role grants query read, but the owner does not hold it
+        assert "sinas.queries/*/*.read:own" not in perms
+        # ...until the owner is assigned the role
+        db.add(UserRole(role_id=extra_role.id, user_id=user.id, active=True))
+        await db.flush()
+        _, perms = await validate_api_key(db, plain)
+        assert perms.get("sinas.queries/*/*.read:own") is True
+
+    async def test_owner_demotion_caps_explicit_key_live(self, client, db, key_user):
+        user, role = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "explicit", "permissions": {"sinas.agents/*/*.read:own": True}},
+            headers=auth_headers(user),
+        )
+        plain = resp.json()["key"]
+        _, perms = await validate_api_key(db, plain)
+        assert perms.get("sinas.agents/*/*.read:own") is True
+
+        # Demote the owner: drop the granting permission from their role
+        await db.execute(
+            delete(RolePermission).where(
+                RolePermission.role_id == role.id,
+                RolePermission.permission_key == "sinas.agents/*/*.read:own",
+            )
+        )
+        await db.flush()
+        _, perms = await validate_api_key(db, plain)
+        assert "sinas.agents/*/*.read:own" not in perms
+
+    async def test_deleted_role_drops_off_key(self, client, db, key_user, extra_role):
+        user, _ = key_user
+        db.add(UserRole(role_id=extra_role.id, user_id=user.id, active=True))
+        await db.flush()
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "doomed", "role_ids": [str(extra_role.id)]},
+            headers=auth_headers(user),
+        )
+        plain = resp.json()["key"]
+        _, perms = await validate_api_key(db, plain)
+        assert perms.get("sinas.queries/*/*.read:own") is True
+
+        # Delete the role the way uninstall does: children first, then role
+        for child in (RolePermission, UserRole, APIKeyRole):
+            await db.execute(delete(child).where(child.role_id == extra_role.id))
+        await db.execute(delete(Role).where(Role.id == extra_role.id))
+        await db.flush()
+        _, perms = await validate_api_key(db, plain)
+        assert "sinas.queries/*/*.read:own" not in perms
+
+    async def test_explicit_denial_overrides_role_grant(self, client, db, key_user):
+        user, role = key_user
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={
+                "name": "narrowed",
+                "role_ids": [str(role.id)],
+                "permissions": {"sinas.agents/*/*.read:own": False},
+            },
+            headers=auth_headers(user),
+        )
+        plain = resp.json()["key"]
+        _, perms = await validate_api_key(db, plain)
+        assert perms.get("sinas.agents/*/*.read:own") is False

--- a/backend/tests/unit/test_package_roles.py
+++ b/backend/tests/unit/test_package_roles.py
@@ -1,0 +1,175 @@
+"""Packages shipping roles: define-only governance, namespace bounds, upgrades.
+
+Packages may DEFINE roles (their own least-privilege permission surface) but
+never BIND them: emailDomain (auto-membership) is a hard error, assignment
+stays an operator act. Granted permissions outside the package's own
+namespaces require explicit operator consent (allowBroadRolePermissions).
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import Role, RolePermission, UserRole
+from app.services.package_service import PackageService
+
+BASE_YAML = """
+apiVersion: sinas.co/v1
+kind: SinasPackage
+metadata:
+  name: {pkg}
+package:
+  name: {pkg}
+  version: "{version}"
+spec:
+  connectors:
+    - namespace: {ns}
+      name: probe
+      baseUrl: https://example.com
+  roles:
+    - name: {role}
+      description: service role
+      {email_domain}
+      permissions:
+{perms}
+"""
+
+
+def _yaml(pkg, ns, role, perms, version="1.0.0", email_domain=""):
+    perm_lines = "\n".join(
+        f"        - key: \"{k}\"\n          value: {str(v).lower()}" for k, v in perms
+    )
+    return BASE_YAML.format(
+        pkg=pkg, ns=ns, role=role, perms=perm_lines, version=version,
+        email_domain=email_domain or "# no emailDomain",
+    )
+
+
+async def _role(db: AsyncSession, name: str) -> Role | None:
+    return (await db.execute(select(Role).where(Role.name == name))).scalar_one_or_none()
+
+
+async def _role_perms(db: AsyncSession, role_id) -> dict[str, bool]:
+    rows = (
+        await db.execute(select(RolePermission).where(RolePermission.role_id == role_id))
+    ).scalars().all()
+    return {r.permission_key: r.permission_value for r in rows}
+
+
+class TestPackageRoles:
+    async def test_install_creates_managed_role_with_permissions(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        role_name = f"{pkg}-service"
+        yaml = _yaml(pkg, "pkgns", role_name, [("sinas.agents/pkgns/*.execute:all", True)])
+        package, result = await PackageService(db).install(yaml, str(admin_user.id))
+        assert result.success, result.errors
+
+        role = await _role(db, role_name)
+        assert role is not None
+        assert role.managed_by == f"pkg:{pkg}"
+        perms = await _role_perms(db, role.id)
+        assert perms == {"sinas.agents/pkgns/*.execute:all": True}
+
+    async def test_email_domain_is_hard_error(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(
+            pkg, "pkgns", f"{pkg}-service",
+            [("sinas.agents/pkgns/*.execute:all", True)],
+            email_domain="emailDomain: example.com",
+        )
+        with pytest.raises(ValueError, match="never bind"):
+            await PackageService(db).install(yaml, str(admin_user.id))
+
+    async def test_foreign_namespace_requires_consent(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        role_name = f"{pkg}-service"
+        yaml = _yaml(pkg, "pkgns", role_name, [("sinas.agents/otherns/*.execute:all", True)])
+        with pytest.raises(ValueError, match="allowBroadRolePermissions"):
+            await PackageService(db).install(yaml, str(admin_user.id))
+        assert await _role(db, role_name) is None
+
+        package, result = await PackageService(db).install(
+            yaml, str(admin_user.id), allow_broad_role_permissions=True
+        )
+        assert result.success
+        assert any("operator consent" in w for w in result.warnings)
+        assert await _role(db, role_name) is not None
+
+    async def test_non_namespaced_key_counts_as_broad(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(pkg, "pkgns", f"{pkg}-service", [("sinas.chats.create:own", True)])
+        with pytest.raises(ValueError, match="allowBroadRolePermissions"):
+            await PackageService(db).install(yaml, str(admin_user.id))
+
+    async def test_denials_are_never_broad(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(pkg, "pkgns", f"{pkg}-service", [
+            ("sinas.agents/pkgns/*.execute:all", True),
+            ("sinas.chats.create:own", False),
+        ])
+        package, result = await PackageService(db).install(yaml, str(admin_user.id))
+        assert result.success
+
+    async def test_upgrade_applies_permission_only_change(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        role_name = f"{pkg}-service"
+        svc = PackageService(db)
+        v1 = _yaml(pkg, "pkgns", role_name, [("sinas.agents/pkgns/*.execute:all", True)])
+        await svc.install(v1, str(admin_user.id))
+
+        # Same name/description — only the permission set changes. Before the
+        # checksum included permissions this hit the unchanged-shortcut and
+        # the new grant was silently never applied.
+        v2 = _yaml(
+            pkg, "pkgns", role_name,
+            [
+                ("sinas.agents/pkgns/*.execute:all", True),
+                ("sinas.queries/pkgns/*.read:all", True),
+            ],
+            version="1.1.0",
+        )
+        package, result = await svc.install(v2, str(admin_user.id))
+        assert result.success
+        role = await _role(db, role_name)
+        perms = await _role_perms(db, role.id)
+        assert perms.get("sinas.queries/pkgns/*.read:all") is True
+
+    async def test_existing_unmanaged_role_not_taken_over(self, db, admin_user):
+        role_name = f"operator-role-{uuid.uuid4().hex[:8]}"
+        db.add(Role(name=role_name, description="operator-owned"))
+        await db.flush()
+
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(pkg, "pkgns", role_name, [("sinas.agents/pkgns/*.execute:all", True)])
+        package, result = await PackageService(db).install(yaml, str(admin_user.id))
+        assert any("not managed by" in w for w in result.warnings)
+        role = await _role(db, role_name)
+        assert role.managed_by is None  # untouched
+
+    async def test_uninstall_removes_role_and_assignments(self, db, admin_user, test_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        role_name = f"{pkg}-service"
+        svc = PackageService(db)
+        yaml = _yaml(pkg, "pkgns", role_name, [("sinas.agents/pkgns/*.execute:all", True)])
+        await svc.install(yaml, str(admin_user.id))
+
+        role = await _role(db, role_name)
+        db.add(UserRole(role_id=role.id, user_id=test_user.id, active=True))
+        await db.flush()
+
+        counts = await svc.uninstall(pkg)
+        assert counts.get("roles") == 1
+        assert await _role(db, role_name) is None
+        assignments = (
+            await db.execute(select(UserRole).where(UserRole.role_id == role.id))
+        ).scalars().all()
+        assert assignments == []
+
+    async def test_preview_surfaces_role_governance(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(pkg, "pkgns", f"{pkg}-service", [("sinas.agents/otherns/*.execute:all", True)])
+        result, _, _ = await PackageService(db).preview(yaml, str(admin_user.id))
+        assert any("allowBroadRolePermissions" in w for w in result.warnings)
+        assert await _role(db, f"{pkg}-service") is None

--- a/console/src/pages/APIKeys.tsx
+++ b/console/src/pages/APIKeys.tsx
@@ -24,6 +24,15 @@ export function APIKeys() {
     retry: false,
   });
 
+  // For the linked-roles picker; non-admins may lack roles.read — degrade to
+  // explicit permissions only.
+  const { data: roles } = useQuery({
+    queryKey: ['roles'],
+    queryFn: () => apiClient.listRoles(),
+    retry: false,
+    enabled: showCreateModal,
+  });
+
   const filteredApiKeys = apiKeys?.filter(key => showInactive || key.is_active);
 
   const formatDate = (dateString: string) => {
@@ -50,7 +59,7 @@ export function APIKeys() {
       queryClient.invalidateQueries({ queryKey: ['apiKeys'] });
       setCreatedKey({ id: data.id, key: data.key });
       setShowCreateModal(false);
-      setFormData({ name: '', permissions: {} });
+      setFormData({ name: '', permissions: {}, role_ids: [] });
     },
   });
 
@@ -146,6 +155,19 @@ export function APIKeys() {
                         </>
                       )}
                     </div>
+                    {key.roles && key.roles.length > 0 && (
+                      <div className="mt-2 flex flex-wrap items-center gap-1">
+                        <span className="text-xs text-gray-500">Roles:</span>
+                        {key.roles.map((role) => (
+                          <span
+                            key={role.id}
+                            className="px-2 py-0.5 bg-purple-900/30 text-purple-300 text-xs rounded"
+                          >
+                            {role.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                     {key.permissions && Object.keys(key.permissions).length > 0 && (
                       <div className="mt-2">
                         <details className="text-xs">
@@ -233,7 +255,7 @@ export function APIKeys() {
             className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50"
             onClick={() => {
               setShowCreateModal(false);
-              setFormData({ name: '', permissions: {} });
+              setFormData({ name: '', permissions: {}, role_ids: [] });
             }}
           />
           <div className="fixed inset-0 flex items-center justify-center z-50 p-4 pointer-events-none">
@@ -244,7 +266,7 @@ export function APIKeys() {
                 <button
                   onClick={() => {
                     setShowCreateModal(false);
-                    setFormData({ name: '', permissions: {} });
+                    setFormData({ name: '', permissions: {}, role_ids: [] });
                   }}
                   className="text-gray-500 hover:text-gray-400"
                 >
@@ -290,6 +312,45 @@ export function APIKeys() {
                 </p>
               </div>
 
+              {roles && roles.length > 0 && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    Linked Roles (Optional)
+                  </label>
+                  <div className="max-h-40 overflow-y-auto border border-line rounded-lg divide-y divide-line-soft">
+                    {roles.map((role) => (
+                      <label
+                        key={role.id}
+                        className="flex items-center gap-2 px-3 py-2 text-sm text-gray-300 cursor-pointer hover:bg-surface-0"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={formData.role_ids?.includes(role.id) ?? false}
+                          onChange={(e) => {
+                            const current = formData.role_ids ?? [];
+                            setFormData({
+                              ...formData,
+                              role_ids: e.target.checked
+                                ? [...current, role.id]
+                                : current.filter((id) => id !== role.id),
+                            });
+                          }}
+                          className="rounded border-line text-primary-600 focus:ring-primary-500"
+                        />
+                        <span>{role.name}</span>
+                        {role.description && (
+                          <span className="text-xs text-gray-500 truncate">{role.description}</span>
+                        )}
+                      </label>
+                    ))}
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">
+                    The key follows linked roles as they change (no re-minting), always capped by
+                    your own live permissions.
+                  </p>
+                </div>
+              )}
+
               <PermissionEditor
                 mode="dict"
                 label="Permissions"
@@ -299,7 +360,8 @@ export function APIKeys() {
 
               {createMutation.isError && (
                 <div className="p-3 bg-red-900/20 border border-red-800/30 rounded-lg text-sm text-red-400">
-                  Failed to create API key. Please try again.
+                  {(createMutation.error as { response?: { data?: { detail?: string } } })?.response
+                    ?.data?.detail || 'Failed to create API key. Please try again.'}
                 </div>
               )}
 
@@ -308,7 +370,7 @@ export function APIKeys() {
                   type="button"
                   onClick={() => {
                     setShowCreateModal(false);
-                    setFormData({ name: '', permissions: {} });
+                    setFormData({ name: '', permissions: {}, role_ids: [] });
                   }}
                   className="btn btn-secondary"
                   disabled={createMutation.isPending}

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -66,6 +66,11 @@ export interface AdminCreateResetLinkResponse {
 }
 
 // API Keys
+export interface APIKeyRoleRef {
+  id: string;
+  name: string;
+}
+
 export interface APIKey {
   id: string;
   user_id: string;
@@ -73,6 +78,7 @@ export interface APIKey {
   name: string;
   key_prefix: string;
   permissions: Record<string, boolean>;
+  roles?: APIKeyRoleRef[];
   is_active: boolean;
   last_used_at: string | null;
   expires_at: string | null;
@@ -82,6 +88,7 @@ export interface APIKey {
 export interface APIKeyCreate {
   name: string;
   permissions: Record<string, boolean>;
+  role_ids?: string[];
   expires_at?: string;
 }
 


### PR DESCRIPTION
Closes the service-credential gap for packaged integrations: a package ships its own least-privilege role, operators assign it, and API keys linked to it track the package's permission surface across upgrades — no hand-assembled permission dicts, no re-minting.

## API keys
- `api_key_roles` link table (0..N roles per key), `role_ids` on create, roles in responses, console picker + chips.
- **Effective permissions at request time** = (explicit grants ∪ union of linked roles) **∩ the owner's live permissions**. Role edits, owner demotions and role deletions apply on the next request.
- **Two security fixes found while building this:**
  1. The create endpoint never validated the requested permission dict against the creator's permissions — any user with `api_keys.create:own` could mint a key with arbitrary permissions (privilege escalation). Mint-time subset validation restored; the live cap bounds every request regardless.
  2. Keys were mint-time snapshots: tightening a role left existing keys with their old, broader permissions. The live cap closes this for explicit keys too. *Behaviour change:* a key can now lose permissions when its owner does — which is the point.

## Packages ship roles
- `roles` removed from `PACKAGE_SKIP_TYPES`; applied via the existing config-apply path with `managed_by=pkg:*` ownership guards (existing operator roles are never taken over).
- Governance: packages **define, never bind** — `emailDomain` is a hard error; assignment stays an operator act. Granted permissions outside the package's own namespaces fail install unless `allowBroadRolePermissions=true` (preview lists them; consent is recorded as a warning in the apply result). Denials are never broad.
- Uninstall deletes the roles plus their permission rows, user assignments, and key links.
- Latent bug fixed: the role config checksum ignored permissions, so permission-only changes hit the unchanged-shortcut and were silently never applied on upgrade — exactly the package-upgrade case.

## Migration
One new table (`api_key_roles`), revision `a1p2i3k4r5l6` on head `r1u2n3o4u5t6`.

## Verification
- 18 new unit tests: mint guards (subset 400, unknown role 400), live intersection (role-follow without re-mint, owner demotion, role-not-held contributes nothing until assigned, deleted role drops off, explicit denial overrides role grant), package governance (managed create, emailDomain hard error, foreign-namespace consent flow, non-namespaced keys count as broad, upgrade applies permission-only change, unmanaged role not taken over, uninstall cleanup, preview surfacing).
- Full suite: 405 passed, 7 failures = the known Redis-env `test_auth` set, zero regressions. Console `tsc` clean.
- **Live on the local stack**: installed a package shipping a role → linked a superadmin-owned key to it → key reads agents (200) but not users (403) despite the owner holding `sinas.*:all` (the key is bounded by its roles, not its owner) → granting `users.read:all` to the role flipped the same key to 200 with no re-mint → revoking it flipped back to 403 → uninstall removed the role and cascade-cleaned the key links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)