### PR TITLE
feat(auth): PATCH api-keys, inline role permissions, chat-without-read advisory, Retry-After

### DIFF
--- a/backend/app/api/v1/endpoints/api_keys.py
+++ b/backend/app/api/v1/endpoints/api_keys.py
@@ -2,14 +2,20 @@
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import generate_api_key, get_current_user_with_permissions, set_permission_used
 from app.core.database import get_db
 from app.core.permissions import check_permission, validate_permission_subset
 from app.models import APIKey, APIKeyRole, Role
-from app.schemas.api_key import APIKeyCreate, APIKeyCreated, APIKeyResponse, APIKeyRoleRef
+from app.schemas.api_key import (
+    APIKeyCreate,
+    APIKeyCreated,
+    APIKeyResponse,
+    APIKeyRoleRef,
+    APIKeyUpdate,
+)
 
 router = APIRouter()
 
@@ -214,6 +220,68 @@ async def get_api_key(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")
 
     set_permission_used(http_request, "sinas.api_keys.read")
+
+    roles_by_key = await _roles_by_key(db, [api_key.id])
+    return _key_response(api_key, roles_by_key.get(str(api_key.id), []))
+
+
+@router.patch("/api-keys/{key_id}", response_model=APIKeyResponse)
+async def update_api_key(
+    key_id: str,
+    request_data: APIKeyUpdate,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """
+    Update an API key's name, explicit permissions, or linked roles in place —
+    the key value never changes, so no rotation. Omitted fields are left
+    unchanged; provided permission/role sets REPLACE the previous ones.
+    """
+    user_id, permissions = current_user_data
+
+    api_key = await APIKey.get_with_permissions(
+        db=db,
+        user_id=user_id,
+        permissions=permissions,
+        action="update",
+        resource_id=key_id,
+    )
+    set_permission_used(http_request, "sinas.api_keys.update")
+
+    if request_data.permissions is not None and request_data.permissions:
+        # Same mint-time guard as create: the updater cannot grant beyond
+        # their own permissions (the live cap bounds requests regardless)
+        is_valid, violations = validate_permission_subset(request_data.permissions, permissions)
+        if not is_valid:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "API key permissions exceed your role permissions. "
+                    f"Violations: {', '.join(violations)}"
+                ),
+            )
+
+    roles: list[Role] = []
+    if request_data.role_ids is not None:
+        if request_data.role_ids:
+            result = await db.execute(select(Role).where(Role.id.in_(request_data.role_ids)))
+            roles = list(result.scalars().all())
+            missing = {str(r) for r in request_data.role_ids} - {str(r.id) for r in roles}
+            if missing:
+                raise HTTPException(
+                    status_code=400, detail=f"Unknown role ids: {', '.join(sorted(missing))}"
+                )
+        await db.execute(delete(APIKeyRole).where(APIKeyRole.api_key_id == api_key.id))
+        for role in roles:
+            db.add(APIKeyRole(api_key_id=api_key.id, role_id=role.id))
+
+    if request_data.name is not None:
+        api_key.name = request_data.name
+    if request_data.permissions is not None:
+        api_key.permissions = request_data.permissions
+
+    await db.flush()
 
     roles_by_key = await _roles_by_key(db, [api_key.id])
     return _key_response(api_key, roles_by_key.get(str(api_key.id), []))

--- a/backend/app/api/v1/endpoints/roles.py
+++ b/backend/app/api/v1/endpoints/roles.py
@@ -26,10 +26,26 @@ router = APIRouter(prefix="/roles", tags=["roles"])
 @router.post("", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
 async def create_role(
     role_data: RoleCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
-    user_id: str = Depends(require_permission("sinas.roles.create:own")),
+    current_user_data=Depends(get_current_user_with_permissions),
 ):
-    """Create a new role. Requires admin permission."""
+    """Create a new role, optionally with its initial permission map in one call."""
+    user_id, permissions = current_user_data
+
+    if not check_permission(permissions, "sinas.roles.create:own"):
+        set_permission_used(request, "sinas.roles.create:own", has_perm=False)
+        raise HTTPException(status_code=403, detail="Not authorized to create roles")
+    set_permission_used(request, "sinas.roles.create:own")
+
+    # Inline permissions are the same operation as POST /{name}/permissions,
+    # so they require the same admin permission
+    if role_data.permissions and not check_permission(
+        permissions, "sinas.roles.manage_permissions:all"
+    ):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to manage role permissions"
+        )
 
     # Check if role name already exists
     result = await db.execute(select(Role).where(Role.name == role_data.name))
@@ -45,6 +61,13 @@ async def create_role(
 
     db.add(role)
     await db.flush()
+
+    for perm_key, perm_value in (role_data.permissions or {}).items():
+        db.add(
+            RolePermission(
+                role_id=role.id, permission_key=perm_key, permission_value=perm_value
+            )
+        )
 
     # Add creator as first member
     member = UserRole(

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -23,9 +23,13 @@ async def check_rate_limit(key: str, max_requests: int, window_seconds: int) -> 
         await redis.expire(redis_key, window_seconds)
 
     if count > max_requests:
+        # Retry-After lets automation back off intelligently instead of
+        # hammering into the same window. TTL of the window key = seconds left.
+        ttl = await redis.ttl(redis_key)
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many requests. Please try again later.",
+            headers={"Retry-After": str(ttl if ttl and ttl > 0 else window_seconds)},
         )
 
 

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -40,6 +40,18 @@ class APIKeyCreate(BaseModel):
     expires_at: Optional[datetime] = Field(None, description="Optional expiration date")
 
 
+class APIKeyUpdate(BaseModel):
+    """Update an API key's scope in place — no rotation needed.
+
+    Omitted fields are left unchanged; role_ids/permissions replace the
+    previous set when provided.
+    """
+
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    permissions: Optional[dict[str, bool]] = None
+    role_ids: Optional[list[uuid.UUID]] = None
+
+
 class APIKeyResponse(BaseModel):
     """API key information (without the actual key)."""
 

--- a/backend/app/schemas/role.py
+++ b/backend/app/schemas/role.py
@@ -10,6 +10,13 @@ class RoleCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = None
     email_domain: Optional[str] = Field(None, max_length=255)
+    permissions: dict[str, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Optional initial permission map, set atomically with the role "
+            "(requires sinas.roles.manage_permissions:all)."
+        ),
+    )
 
 
 class RoleUpdate(BaseModel):

--- a/backend/app/services/package_service.py
+++ b/backend/app/services/package_service.py
@@ -74,22 +74,26 @@ def _package_namespaces(config: SinasConfig) -> set[str]:
     return namespaces
 
 
-def package_role_violations(config: SinasConfig) -> tuple[list[str], list[str]]:
+def package_role_violations(config: SinasConfig) -> tuple[list[str], list[str], list[str]]:
     """
     Governance checks for roles shipped by a package.
 
-    Returns (hard_errors, broad_permissions):
+    Returns (hard_errors, broad_permissions, advisories):
     - hard_errors: things a package may never do — bind users (emailDomain is
       auto-membership). Always rejected.
     - broad_permissions: granted keys reaching outside the namespaces the
       package itself installs into (non-namespaced keys, foreign or wildcard
       namespaces). Rejected unless the operator explicitly consents.
+    - advisories: known potholes surfaced as warnings — e.g. agents .chat
+      without .read (the chats endpoint checks read on the agent BEFORE the
+      chat permission, so a chat-only role 403s on the very first call).
     """
     hard: list[str] = []
     broad: list[str] = []
+    advisories: list[str] = []
     roles = getattr(config.spec, "roles", None) or []
     if not roles:
-        return hard, broad
+        return hard, broad, advisories
 
     namespaces = _package_namespaces(config)
     for role in roles:
@@ -98,13 +102,25 @@ def package_role_violations(config: SinasConfig) -> tuple[list[str], list[str]]:
                 f"role '{role.name}' sets emailDomain — packages define roles, "
                 "never bind them to users"
             )
-        for perm in role.permissions:
-            if not perm.value:
-                continue  # denials can't widen anything
-            m = NAMESPACED_PERM_RE.match(perm.key)
+        granted = [p.key for p in role.permissions if p.value]
+        for key in granted:
+            m = NAMESPACED_PERM_RE.match(key)
             if not m or m.group("ns") == "*" or m.group("ns") not in namespaces:
-                broad.append(f"role '{role.name}': {perm.key}")
-    return hard, broad
+                broad.append(f"role '{role.name}': {key}")
+
+        for key in granted:
+            m = re.match(r"^sinas\.agents/([^/]+)/.+\.chat:", key)
+            if m and not any(
+                g.startswith(f"sinas.agents/{m.group(1)}/") and ".read:" in g
+                for g in granted
+            ):
+                advisories.append(
+                    f"role '{role.name}' grants {key} without a matching "
+                    f"sinas.agents/{m.group(1)}/*.read permission — chatting with an "
+                    "agent also requires reading it, so this role will 403 on its "
+                    "first call"
+                )
+    return hard, broad, advisories
 
 
 def detach_if_package_managed(resource) -> bool:
@@ -168,7 +184,7 @@ class PackageService:
         pkg_name = config.package.name
         managed_by = f"pkg:{pkg_name}"
 
-        hard, broad = package_role_violations(config)
+        hard, broad, role_advisories = package_role_violations(config)
         if hard:
             raise ValueError("Package roles rejected: " + "; ".join(hard))
         if broad and not allow_broad_role_permissions:
@@ -205,6 +221,7 @@ class PackageService:
             result.warnings.append(
                 "Accepted broad role permissions (operator consent): " + "; ".join(broad)
             )
+        result.warnings.extend(role_advisories)
 
         # Create or update package record
         if existing_package:
@@ -288,7 +305,7 @@ class PackageService:
         result = await apply_service.apply_config(config, dry_run=True)
         result.warnings.extend(validation.warnings)
 
-        hard, broad = package_role_violations(config)
+        hard, broad, role_advisories = package_role_violations(config)
         for violation in hard:
             result.errors.append(f"Package roles rejected: {violation}")
         for perm in broad:
@@ -296,6 +313,7 @@ class PackageService:
                 "Broad role permission (install requires allowBroadRolePermissions=true): "
                 + perm
             )
+        result.warnings.extend(role_advisories)
 
         return result, variable_declarations, requires_input
 

--- a/backend/tests/unit/test_api_key_roles.py
+++ b/backend/tests/unit/test_api_key_roles.py
@@ -215,3 +215,119 @@ class TestResolution:
         plain = resp.json()["key"]
         _, perms = await validate_api_key(db, plain)
         assert perms.get("sinas.agents/*/*.read:own") is False
+
+
+class TestUpdate:
+    async def test_attach_role_to_existing_key(self, client, db, key_user):
+        user, role = key_user
+        created = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "bind-later", "permissions": {"sinas.agents/*/*.read:own": True}},
+            headers=auth_headers(user),
+        )
+        key_id, plain = created.json()["id"], created.json()["key"]
+
+        # No PATCH permission in key_user's role yet — add the update grant
+        db.add(
+            RolePermission(
+                role_id=role.id,
+                permission_key="sinas.api_keys/*/*.update:own",
+                permission_value=True,
+            )
+        )
+        db.add(
+            RolePermission(
+                role_id=role.id, permission_key="sinas.api_keys.update:own", permission_value=True
+            )
+        )
+        await db.flush()
+
+        resp = await client.patch(
+            f"/api/v1/api-keys/{key_id}",
+            json={"role_ids": [str(role.id)]},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 200, resp.text
+        assert [r["name"] for r in resp.json()["roles"]] == [role.name]
+        # Existing explicit grant untouched, role grants now flow — same key value
+        _, perms = await validate_api_key(db, plain)
+        assert perms.get("sinas.api_keys.create:own") is True  # from role
+        assert perms.get("sinas.agents/*/*.read:own") is True  # explicit, kept
+
+        # Clearing roles with [] removes the links
+        resp = await client.patch(
+            f"/api/v1/api-keys/{key_id}", json={"role_ids": []}, headers=auth_headers(user)
+        )
+        assert resp.status_code == 200
+        assert resp.json()["roles"] == []
+        _, perms = await validate_api_key(db, plain)
+        assert "sinas.api_keys.create:own" not in perms
+
+    async def test_update_permissions_subset_enforced(self, client, db, key_user):
+        user, role = key_user
+        db.add(
+            RolePermission(
+                role_id=role.id, permission_key="sinas.api_keys.update:own", permission_value=True
+            )
+        )
+        await db.flush()
+        created = await client.post(
+            "/api/v1/api-keys", json={"name": "escalate-later"}, headers=auth_headers(user)
+        )
+        resp = await client.patch(
+            f"/api/v1/api-keys/{created.json()['id']}",
+            json={"permissions": {"sinas.*:all": True}},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 400
+        assert "exceed" in resp.json()["detail"]
+
+    async def test_update_requires_permission(self, client, db, key_user, test_user):
+        user, _ = key_user
+        created = await client.post(
+            "/api/v1/api-keys", json={"name": "not-yours"}, headers=auth_headers(user)
+        )
+        resp = await client.patch(
+            f"/api/v1/api-keys/{created.json()['id']}",
+            json={"name": "hijacked"},
+            headers=auth_headers(test_user),
+        )
+        assert resp.status_code == 403
+
+
+class TestRoleCreateInlinePermissions:
+    async def test_admin_creates_role_with_permissions_atomically(self, client, db, admin_user):
+        name = f"inline-{uuid.uuid4().hex[:8]}"
+        resp = await client.post(
+            "/api/v1/roles",
+            json={
+                "name": name,
+                "description": "one call",
+                "permissions": {"sinas.agents/pkg/*.chat:all": True},
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 201, resp.text
+        role_id = resp.json()["id"]
+        rows = (
+            await db.execute(select(RolePermission).where(RolePermission.role_id == role_id))
+        ).scalars().all()
+        assert {r.permission_key: r.permission_value for r in rows} == {
+            "sinas.agents/pkg/*.chat:all": True
+        }
+
+    async def test_inline_permissions_require_manage_permission(self, client, db, key_user):
+        user, role = key_user
+        db.add(
+            RolePermission(
+                role_id=role.id, permission_key="sinas.roles.create:own", permission_value=True
+            )
+        )
+        await db.flush()
+        resp = await client.post(
+            "/api/v1/roles",
+            json={"name": f"sneaky-{uuid.uuid4().hex[:8]}", "permissions": {"sinas.*:all": True}},
+            headers=auth_headers(user),
+        )
+        assert resp.status_code == 403
+        assert "manage role permissions" in resp.json()["detail"]

--- a/backend/tests/unit/test_package_roles.py
+++ b/backend/tests/unit/test_package_roles.py
@@ -173,3 +173,22 @@ class TestPackageRoles:
         result, _, _ = await PackageService(db).preview(yaml, str(admin_user.id))
         assert any("allowBroadRolePermissions" in w for w in result.warnings)
         assert await _role(db, f"{pkg}-service") is None
+
+
+class TestChatWithoutReadAdvisory:
+    async def test_chat_only_role_installs_with_advisory(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(pkg, "pkgns", f"{pkg}-service", [("sinas.agents/pkgns/*.chat:all", True)])
+        package, result = await PackageService(db).install(yaml, str(admin_user.id))
+        assert result.success
+        assert any("403 on its first call" in w for w in result.warnings)
+
+    async def test_chat_with_read_has_no_advisory(self, db, admin_user):
+        pkg = f"pkg-{uuid.uuid4().hex[:8]}"
+        yaml = _yaml(pkg, "pkgns", f"{pkg}-service", [
+            ("sinas.agents/pkgns/*.chat:all", True),
+            ("sinas.agents/pkgns/*.read:all", True),
+        ])
+        package, result = await PackageService(db).install(yaml, str(admin_user.id))
+        assert result.success
+        assert not any("403 on its first call" in w for w in result.warnings)


### PR DESCRIPTION
Follow-ups to #156 from field feedback (live GKE deployment hand-rolling this exact flow):

- **PATCH /api-keys/{id}** — bind roles / adjust permissions on an existing key without rotating the key value out to consumers. Keys were previously immutable (GET/DELETE only), so every permission change was a rotation.
- **POST /roles with inline `permissions`** — one call instead of N+1; requires `manage_permissions:all` (same as the per-permission endpoint), enforced.
- **Package role advisory** — a role granting `sinas.agents/<ns>/*.chat` without a matching `.read` 403s on its first call with a misleading error (the chats endpoint checks read first). Install/preview now warn about the pair instead of leaving it to docs.
- **Retry-After on 429** — rate-limit responses carry the window TTL so automation loops can back off.

Verification: 26 unit tests green across the two feature test files; full suite 412 passed (same 7 known Redis-env failures); live: inline-permissions role created in one call, bare key PATCH-bound to it, unbound again — same key value throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)