### PR TITLE
fix(providers): migrate to anthropic SDK 1.0.0 and bound the dependency

### DIFF
--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -35,10 +35,13 @@ class AnthropicProvider(BaseLLMProvider):
         # Convert OpenAI-style messages to Anthropic format
         system_message, filtered_messages = self._convert_messages_to_anthropic(messages)
 
+        # SDK >=1.0.0 removed the sampling knobs (temperature/top_p/top_k) from
+        # the Messages API entirely — passing them is a TypeError. The
+        # `temperature` argument is kept for provider-interface compatibility
+        # and deliberately ignored.
         params = {
             "model": model,
             "messages": filtered_messages,
-            "temperature": temperature if temperature is not None else 1.0,  # Anthropic requires valid number
             "max_tokens": max_tokens or 16384,  # Anthropic requires max_tokens
         }
 
@@ -140,10 +143,11 @@ class AnthropicProvider(BaseLLMProvider):
         # Convert OpenAI-style messages to Anthropic format
         system_message, filtered_messages = self._convert_messages_to_anthropic(messages)
 
+        # temperature deliberately not passed — removed from the SDK >=1.0.0
+        # (see complete())
         params = {
             "model": model,
             "messages": filtered_messages,
-            "temperature": temperature if temperature is not None else 1.0,  # Anthropic requires valid number
             "max_tokens": max_tokens or 16384,
         }
 
@@ -536,11 +540,11 @@ class AnthropicProvider(BaseLLMProvider):
         system_message, filtered_messages = self._convert_messages_to_anthropic(
             request["messages"]
         )
-        temperature = request.get("temperature")
+        # temperature deliberately not passed — removed from the SDK >=1.0.0
+        # (see complete()); batch items use the same params schema
         params: dict[str, Any] = {
             "model": request["model"],
             "messages": filtered_messages,
-            "temperature": temperature if temperature is not None else 1.0,
             "max_tokens": request.get("max_tokens") or 16384,
         }
         if system_message:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,7 +30,11 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "bcrypt (>=4.1.0)",
     "openai>=1.3.0",
-    "anthropic>=0.8.0",
+    # Bounded to the major we code against: the image build installs from
+    # this file (not the lock), and 1.0.0 removed the sampling kwargs
+    # (temperature/top_p/top_k) — an unbounded range let images resolve a
+    # breaking major ahead of the code (every agent invoke 500'd).
+    "anthropic>=1.0.0,<2",
     "sse-starlette>=1.8.0",
     "websockets>=12.0",
     "cryptography (>=46.0.3,<47.0.0)",

--- a/backend/tests/unit/test_provider_batch.py
+++ b/backend/tests/unit/test_provider_batch.py
@@ -127,7 +127,10 @@ async def test_anthropic_submit_batch_builds_params():
     assert request["custom_id"] == "exec-1"
     params = request["params"]
     assert params["model"] == "claude-sonnet-5"
-    assert params["temperature"] == 0.3
+    # SDK >=1.0.0 removed sampling knobs from the Messages API; a requested
+    # temperature must be dropped, not forwarded (forwarding is a TypeError
+    # on create() and a 400 on batch items)
+    assert "temperature" not in params
     assert params["max_tokens"] == 512
     assert "tools" not in params
     # System extracted from messages and cache-marked (caching stacks with batch)


### PR DESCRIPTION
Fixes the rc.5 deployment blocker: every agent invoke 500s with `TypeError: AsyncMessages.create() got an unexpected keyword argument 'temperature'`.

## Root cause
The Dockerfile installs from pyproject (`pip install -e .`), not the lock, and `anthropic>=0.8.0` had no upper bound — so the rc.5 image resolved SDK **1.0.0**, which removed the sampling kwargs (`temperature`/`top_p`/`top_k`) from the Messages API entirely: `create()`, `stream()`, and batch item params all reject them. Local dev sat on a working 0.99.0, which is why nothing caught it before the image build.

## Fix (migrate forward, per Kjeld)
- `anthropic>=1.0.0,<2` — bounded to the major the code targets; comment explains the bound is load-bearing because images resolve from this file.
- `temperature` no longer forwarded from `complete()`, `stream()`, or `_build_batch_params()`. The parameter stays in the provider-interface signatures and is deliberately ignored (the API no longer has the knob; `output_config.effort` is its successor).
- Batch param test updated to assert the drop.

Not changed: the forced-tool structured-outputs path — 1.0.0's native `output_config.format` is a future simplification, not an rc change.

## Verification
- Full suite 412 passed on SDK 1.0.0 (same 7 known Redis-env failures)
- Live: SDK 1.0.0 installed into the running backend + queue-agent containers, then `POST /agents/sgr/evidence-check-agent/invoke` against a real Anthropic provider → `{"reply": "OK"}` — the exact call shape that failed on the reported deployment
- Signature audit of 1.0.0: `create`/`stream`/batch-item params all checked; nothing else we pass was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)