### PR TITLE
fix(auth): password_reset_tokens.created_at missing DB default (admin reset 500s)

### DIFF
--- a/backend/alembic/versions/p1w2d3r4s5t6_password_reset_created_at_default.py
+++ b/backend/alembic/versions/p1w2d3r4s5t6_password_reset_created_at_default.py
@@ -1,0 +1,41 @@
+"""password_reset_tokens.created_at: add missing server default
+
+The model maps created_at via the shared `created_at` alias
+(models/base.py), which carries server_default=func.now() — so SQLAlchemy
+omits the column from the INSERT and expects the database to supply it.
+The creating migration (p1r2e3s4t5k6) declared the column NOT NULL with no
+default, so every insert raised NotNullViolationError and admin
+password-reset link generation 500'd on any deployment that had never
+issued one.
+
+Revision ID: p1w2d3r4s5t6
+Revises: a1p2i3k4r5l6
+Create Date: 2026-08-25
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "p1w2d3r4s5t6"
+down_revision = "a1p2i3k4r5l6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "password_reset_tokens",
+        "created_at",
+        server_default=sa.text("now()"),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "password_reset_tokens",
+        "created_at",
+        server_default=None,
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+    )

--- a/backend/tests/unit/test_password_reset_token.py
+++ b/backend/tests/unit/test_password_reset_token.py
@@ -1,0 +1,54 @@
+"""Admin password-reset token creation.
+
+Field report from a fresh rc.6 install: POST /users/{id}/password-reset 500'd
+with NotNullViolationError on password_reset_tokens.created_at. The model maps
+created_at via the shared alias (server_default=func.now()), so SQLAlchemy
+omits it from the INSERT and expects the DB to supply it — but the creating
+migration declared the column NOT NULL with no default. Any deployment that
+had never issued a reset link hit it the first time an admin tried.
+
+These tests exercise the ORM insert path, so they fail against a schema whose
+default is missing regardless of how the column got that way.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import consume_password_reset_token, create_password_reset_token
+from app.models.user import PasswordResetToken, User
+
+
+class TestPasswordResetToken:
+    async def test_create_populates_created_at(self, db: AsyncSession, test_user: User):
+        plain, record = await create_password_reset_token(db, str(test_user.id))
+        assert plain
+        # The actual regression: this INSERT raised NotNullViolationError
+        assert record.created_at is not None
+
+    async def test_schema_supplies_the_default(self, db: AsyncSession):
+        """Guards the migration itself, not just the ORM behaviour."""
+        default = (
+            await db.execute(
+                text(
+                    "SELECT column_default FROM information_schema.columns "
+                    "WHERE table_name = 'password_reset_tokens' "
+                    "AND column_name = 'created_at'"
+                )
+            )
+        ).scalar_one()
+        assert default is not None, (
+            "password_reset_tokens.created_at has no DB default; the model omits "
+            "it from INSERTs, so every password-reset token creation will fail"
+        )
+
+    async def test_round_trip_consume(self, db: AsyncSession, test_user: User):
+        plain, record = await create_password_reset_token(db, str(test_user.id))
+        consumed = await consume_password_reset_token(db, plain)
+        assert consumed is not None
+        assert str(consumed.user_id) == str(test_user.id)
+        assert consumed.used_at is not None
+        # One-time: a second consume must fail
+        assert await consume_password_reset_token(db, plain) is None


### PR DESCRIPTION
Found on a fresh rc.6 install: `POST /users/{id}/password-reset` 500s with `NotNullViolationError` on `password_reset_tokens.created_at`. Any deployment that has never issued a reset link hits it the first time an admin tries.

## Cause
Model/migration mismatch. The model maps `created_at` via the shared alias in `models/base.py`, which carries `server_default=func.now()` — so SQLAlchemy **omits the column from the INSERT** and expects the DB to supply it. The creating migration (`p1r2e3s4t5k6`) declared it `NOT NULL` with no default.

## Fix
Migration ALTERs the column to `DEFAULT now()` — repairs existing tables and new installs alike.

## Sweep
Checked `information_schema` rather than grepping migration source, so it catches columns however they were created: **no other `created_at`/`updated_at` column is NOT NULL without a default.** `packages.updated_at` has no default but is `Optional` in both model and schema by design (NULLs already present and tolerated) — left alone rather than churned mid-RC.

## Verification
- Raw INSERT reproducing SQLAlchemy's exact statement shape fails with the reported error against the pre-fix schema
- 3 new tests (ORM insert path, schema-default guard, consume round-trip) **fail before the migration, pass after**
- Full suite 415 passed (same 7 known Redis-env failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)