### PR TITLE
feat(chart): nodeSelector/tolerations/affinity, with StatefulSets held back from global defaults

### DIFF
--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -43,6 +43,43 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
+Scheduling — nodeSelector / tolerations / affinity for one workload.
+
+Call with: (dict "values" (.Values.backend) "root" . "inherit" true)
+
+inherit=true  — stateless Deployments. Falls back to the global
+                .Values.scheduling defaults when the workload sets nothing,
+                so operators can move the whole stateless tier onto Spot /
+                preemptible capacity with one setting.
+inherit=false — StatefulSets (postgres / redis / clickhouse). Per-workload
+                settings ONLY: the global default must never reach them
+                implicitly. These sit on single-attach ReadWriteOnce
+                volumes, where a preemption is a database restart with a
+                volume reattach — not a rolling handoff. Placing them
+                deliberately requires setting postgres.nodeSelector (etc.)
+                by name.
+
+tolerations matter beyond Autopilot: GKE Autopilot injects the Spot
+toleration for you, GKE Standard and self-managed clusters do not.
+*/}}
+{{- define "sinas.scheduling" -}}
+{{- $w := .values | default dict }}
+{{- $g := ternary ((.root.Values).scheduling | default dict) dict .inherit }}
+{{- with ($w.nodeSelector | default $g.nodeSelector) }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with ($w.tolerations | default $g.tolerations) }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with ($w.affinity | default $g.affinity) }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Database password secretKeyRef body — release secret by default, or the
 operator's pre-created secret when postgres.external.existingSecret is set.
 Shared by backendEnv and pgbouncer.

--- a/charts/sinas/templates/backend.yaml
+++ b/charts/sinas/templates/backend.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/component: backend
     spec:
       serviceAccountName: {{ include "sinas.executorManagerSA" . }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.backend) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.smtp.ipv4 }}
       hostAliases:

--- a/charts/sinas/templates/builder.yaml
+++ b/charts/sinas/templates/builder.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/component: builder
     spec:
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.builder) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: builder
           image: {{ .Values.image.registry }}/builder:{{ .Values.image.tag }}

--- a/charts/sinas/templates/clickhouse.yaml
+++ b/charts/sinas/templates/clickhouse.yaml
@@ -150,6 +150,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 101
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.clickhouse) "root" . "inherit" false) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: clickhouse
           image: clickhouse/clickhouse-server:24-alpine

--- a/charts/sinas/templates/console.yaml
+++ b/charts/sinas/templates/console.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/component: console
     spec:
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.console) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: console
           image: {{ .Values.image.registry }}/console:{{ .Values.image.tag }}

--- a/charts/sinas/templates/pgbouncer.yaml
+++ b/charts/sinas/templates/pgbouncer.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: pgbouncer
     spec:
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.pgbouncer) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: pgbouncer
           image: edoburu/pgbouncer:latest

--- a/charts/sinas/templates/postgres.yaml
+++ b/charts/sinas/templates/postgres.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: postgres
     spec:
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.postgres) "root" . "inherit" false) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: postgres
           image: postgres:16-alpine

--- a/charts/sinas/templates/redis.yaml
+++ b/charts/sinas/templates/redis.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: redis
     spec:
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.redis) "root" . "inherit" false) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: redis
           image: redis:7-alpine

--- a/charts/sinas/templates/workers.yaml
+++ b/charts/sinas/templates/workers.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       serviceAccountName: {{ include "sinas.executorManagerSA" . }}
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.queueWorker) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: queue-worker
           image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
@@ -58,6 +59,7 @@ spec:
     spec:
       serviceAccountName: {{ include "sinas.executorManagerSA" . }}
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.queueAgent) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: queue-agent
           image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
@@ -96,6 +98,7 @@ spec:
     spec:
       serviceAccountName: {{ include "sinas.executorManagerSA" . }}
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.scheduler) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: scheduler
           image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
@@ -133,6 +136,7 @@ spec:
         app.kubernetes.io/component: cdc-worker
     spec:
       {{- include "sinas.imagePullSecrets" . | nindent 6 }}
+      {{- with (include "sinas.scheduling" (dict "values" (.Values.cdcWorker) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: cdc-worker
           image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -169,6 +169,39 @@ networkPolicy:
   ##       ports: [5432]
   egressCidrs: []
 
+## Scheduling — where the STATELESS workloads run (backend, builder,
+## console, pgbouncer, queue-worker, queue-agent, scheduler, cdc-worker).
+## The single biggest cost lever on managed Kubernetes: moving these onto
+## Spot/preemptible capacity has measured ~70% cheaper on GKE Autopilot,
+## and they tolerate preemption (they restart and resume).
+##
+##   scheduling:
+##     nodeSelector:
+##       cloud.google.com/gke-spot: "true"
+##     tolerations:
+##       - key: cloud.google.com/gke-spot
+##         operator: Equal
+##         value: "true"
+##         effect: NoSchedule
+##
+## tolerations are needed on GKE Standard and self-managed clusters; GKE
+## Autopilot injects the Spot toleration itself.
+##
+## IMPORTANT: these defaults deliberately do NOT reach postgres, redis or
+## clickhouse. Those are StatefulSets on single-attach ReadWriteOnce
+## volumes, where a preemption is a database restart with a volume
+## reattach rather than a rolling handoff — never put them on preemptible
+## capacity by accident. To place them, set their own keys explicitly
+## (postgres.nodeSelector / .tolerations / .affinity).
+##
+## Every workload accepts its own nodeSelector / tolerations / affinity
+## (e.g. queueAgent.nodeSelector), which REPLACES the global default for
+## that workload rather than merging with it.
+scheduling:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 ## Builder (Node.js esbuild server)
 builder:
   resources:


### PR DESCRIPTION
The chart exposed no scheduling controls at all, so putting Sinas on Spot/preemptible capacity meant `kubectl patch` on chart-owned Deployments — which creates the server-side-apply field-manager conflict that breaks the next `helm upgrade`, so it wasn't a viable workaround.

**Measured on a live rc.6 GKE Autopilot deployment:** moving the 8 stateless workloads to Spot took that tier from $56/month to $17/month (~70%), everything healthy through the transition.

## Shape
- **Global `scheduling`** (`nodeSelector` / `tolerations` / `affinity`) applied to the stateless workloads only: backend, builder, console, pgbouncer, queue-worker, queue-agent, scheduler, cdc-worker.
- **Per-workload keys** on every workload (`queueAgent.nodeSelector`, …), which **replace** the global for that workload rather than merging — mirroring how `resources` is already structured.
- **`tolerations` exposed alongside `nodeSelector`**: Autopilot injects the Spot toleration, Standard and self-managed clusters don't — without it the feature would be Autopilot-only.

## The safety property
`postgres`, `redis` and `clickhouse` **never inherit the global**. They're StatefulSets on single-attach ReadWriteOnce volumes, where a preemption is a database restart with a volume reattach, not a rolling handoff. Placing them requires naming them explicitly (`postgres.nodeSelector`). This is enforced in the helper (`inherit=false`), not left to a doc comment — so the first person to set a global Spot selector can't put their database on preemptible capacity without realising.

## Verification
- **Default render byte-identical to HEAD** — unset emits nothing at all, so zero risk to existing installs
- Global Spot lands on all 8 stateless workloads and **none** of the 3 StatefulSets (asserted per workload)
- Per-workload override replaces the global: `queueAgent` kept its GPU nodeSelector + toleration and stayed off Spot while the rest moved
- Explicit `postgres.nodeSelector: {disktype: ssd}` honoured, global Spot still ignored
- `scheduling=null` renders identically to unset (`--reuse-values` safe); `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)