### PR TITLE
fix(config): repair AUTO_APPLY_CONFIG for LLM providers/DB connections, fix dev console API URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ console/node_modules/
 console/dist/
 console/.env.local
 console/.env.*.local
+
+# Backend (backend/)
+backend/config/*.yaml

--- a/backend/app/services/config_apply/data_sources.py
+++ b/backend/app/services/config_apply/data_sources.py
@@ -84,7 +84,7 @@ async def apply_llm_providers(
                         )
                     existing.is_default = provider_config.isDefault
                     if provider_config.apiKey:
-                        existing.api_key = EncryptionService.encrypt(provider_config.apiKey)
+                        existing.api_key = EncryptionService().encrypt(provider_config.apiKey)
                     existing.config_checksum = config_hash
                     existing.updated_at = datetime.utcnow()
 
@@ -95,7 +95,7 @@ async def apply_llm_providers(
                 if not dry_run:
                     encrypted_key = None
                     if provider_config.apiKey:
-                        encrypted_key = EncryptionService.encrypt(provider_config.apiKey)
+                        encrypted_key = EncryptionService().encrypt(provider_config.apiKey)
 
                     if provider_config.isDefault:
                         await db.execute(
@@ -193,7 +193,7 @@ async def apply_database_connections(
                     existing.ssl_mode = conn_config.sslMode
                     existing.config = conn_config.config
                     if conn_config.password:
-                        existing.password = EncryptionService.encrypt(conn_config.password)
+                        existing.password = EncryptionService().encrypt(conn_config.password)
                     existing.config_checksum = config_hash
                     existing.updated_at = datetime.utcnow()
 
@@ -204,7 +204,7 @@ async def apply_database_connections(
                 if not dry_run:
                     encrypted_password = None
                     if conn_config.password:
-                        encrypted_password = EncryptionService.encrypt(
+                        encrypted_password = EncryptionService().encrypt(
                             conn_config.password
                         )
 

--- a/backend/app/services/config_apply/service.py
+++ b/backend/app/services/config_apply/service.py
@@ -333,7 +333,7 @@ class ConfigApplyService:
                     await self.flush_notifications()
 
             return ConfigApplyResponse(
-                success=True,
+                success=len(self.errors) == 0,
                 summary=self.summary,
                 changes=self.changes,
                 errors=self.errors,

--- a/backend/config/mistral-provider.yaml.tmpl
+++ b/backend/config/mistral-provider.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: sinas.co/v1
+kind: SinasConfig
+metadata:
+  name: mistral-provider
+  description: Mistral AI LLM provider, injected by deploy.sh from MISTRAL_API_KEY
+
+spec:
+  llmProviders:
+    - name: Mistral
+      type: mistral
+      apiKey: __MISTRAL_API_KEY__
+      defaultModel: mistral-large-latest
+      isDefault: true

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -4,6 +4,10 @@ FROM node:20-alpine AS builder
 # Set to "true" to use a locally built @sinas/sdk instead of npm
 ARG USE_LOCAL_PACKAGES=false
 
+# Backend URL baked into the build (skips the same-origin auto-detect fallback)
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+
 WORKDIR /app
 
 # Copy package.json only (lockfile has file: paths that get rewritten)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,6 +100,7 @@ services:
       context: ./console
       args:
         USE_LOCAL_PACKAGES: ${USE_LOCAL_PACKAGES:-false}
+        VITE_API_URL: ${VITE_API_URL:-}
     ports:
       - "51245:80"
 


### PR DESCRIPTION
## EncryptionService called as an unbound method
apply_llm_providers/apply_database_connections called
EncryptionService.encrypt(value) instead of EncryptionService().encrypt(value),
raising a TypeError on every call. The exception was caught internally and
never surfaced, so config-apply silently failed to save any API key or DB
password. Fixed all four call sites.

## ConfigApplyResponse.success ignored errors
apply_config() always returned success=True regardless of self.errors,
which is why the bug above went unnoticed — logs said "applied successfully"
with an empty summary. Now success = len(self.errors) == 0.

## Console dev-mode API URL
docker-compose.dev.yml disables Caddy and splits console/backend onto
separate ports, breaking the same-origin fallback written for production.
VITE_API_URL already existed as a frontend override (#92) but was never
wired through the Docker build — now it is. Production unaffected (prebuilt
image, Caddy always on).

## Mistral provider template
Adds backend/config/mistral-provider.yaml.tmpl for AUTO_APPLY_CONFIG, key
left as a placeholder. Generated backend/config/*.yaml is gitignored.

## Testing
Verified on a live deploy: provider registers end-to-end, apply failures
now surface, console loads over IP instead of just localhost.