### PR TITLE
fix(chart): route /info to the backend so the console learns the auth mode

### DIFF
--- a/charts/sinas/templates/ingress.yaml
+++ b/charts/sinas/templates/ingress.yaml
@@ -5,6 +5,14 @@
 ##
 ## Console uses window.location.hostname as the API base, so both services
 ## must share the same hostname.
+##
+## The prefix list below has to track the runtime API's route table by hand.
+## A missing prefix does not fail loudly: the catch-all serves index.html with
+## HTTP 200, so the caller gets HTML where it expected JSON. That is how /info
+## was lost — the console reads auth_mode from it before login, could not parse
+## the HTML, and fell back to its 'otp' default, rendering an OTP form on a
+## password-mode instance. Check this list against /openapi.json when adding a
+## top-level route.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -31,7 +39,7 @@ spec:
     - host: {{ .Values.domain | quote }}
       http:
         paths:
-          {{- range list "/api" "/adapters" "/auth" "/files" "/stores" "/webhooks" "/agents" "/chats" "/functions" "/executions" "/manifests" "/components" "/queries" "/skills" "/collections" "/states" "/jobs" "/templates" "/health" "/docs" "/openapi.json" }}
+          {{- range list "/api" "/adapters" "/auth" "/files" "/stores" "/webhooks" "/agents" "/chats" "/functions" "/executions" "/manifests" "/components" "/queries" "/skills" "/collections" "/states" "/jobs" "/templates" "/health" "/docs" "/openapi.json" "/info" "/userinfo" "/batches" "/pipelines" }}
           - path: {{ . }}
             pathType: Prefix
             backend:


### PR DESCRIPTION
## What

Adds `/info`, `/userinfo`, `/batches`, `/pipelines` to the ingress prefix list that routes to `backend:8000`.

## Why

`charts/sinas/templates/ingress.yaml` allowlists backend prefixes and sends everything else to the console SPA via a catch-all `/`. `/info` was not in the list, so `GET /info` returns `index.html` with HTTP 200 instead of JSON.

`/info` is the endpoint the console reads *before login* to decide which form to render — its own description: "instance-level configuration that clients (custom frontends, JS/Python SDKs, the official console) need before login. Unauthenticated by design." It returns `auth_mode` (`otp | password | password+otp`).

`console/src/lib/auth-context.tsx` handles the failure like this:

```js
client.auth.getInfo()
  .then((info) => setInstanceInfo(toInstanceInfo(info)))
  .catch((err) => {
    // Fall back to OTP if /info is unreachable (older backend)
    setInstanceInfo({ auth_mode: 'otp', version: 'unknown', features: {} });
  });
```

On an **otp**-mode instance that fallback is accidentally correct, which is why this went unnoticed. On a **password**-mode instance the console renders an OTP form that can never complete — and where SMTP is not configured, nobody can log into the console at all.

## Observed

On a live 0.4.0-rc.7 deployment configured with `auth.mode: password`:

| Request | Result |
|---|---|
| `GET /info` | `200 text/html` — the console SPA |
| `POST /auth/login` (wrong password) | `401 {"detail":"Invalid email or password."}` — backend really is in password mode |
| Console `/login` | renders the OTP form |

The API is unaffected — `/auth/*` is routed correctly, so API clients can still authenticate. Only the console is broken.

## Scope

`/userinfo`, `/batches`, `/pipelines` were missing for the same reason. Found by diffing all 59 paths in the runtime `/openapi.json` against the allowlist; those four were the complete set.

## Verification

```
helm template ... -s templates/ingress.yaml | grep path:
```

→ `/api /adapters /auth /files /stores /webhooks /agents /chats /functions /executions /manifests /components /queries /skills /collections /states /jobs /templates /health /docs /openapi.json /info /userinfo /batches /pipelines /`

## Note

The list is hand-maintained against the runtime route table and fails silently when it drifts — a missing prefix serves HTML with a 200 rather than erroring. I added a comment saying so. Inverting the rule (known SPA paths to the console, everything else to the backend) would remove the failure mode, but that is a larger change than this fix warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)