### PR TITLE
feat(api): runtime GET /pipelines — complete the discovery surface

### DIFF
--- a/backend/app/api/runtime/endpoints/discovery.py
+++ b/backend/app/api/runtime/endpoints/discovery.py
@@ -11,11 +11,13 @@ from app.core.database import get_db
 from app.models.agent import Agent
 from app.models.file import Collection
 from app.models.function import Function
+from app.models.pipeline import Pipeline
 from app.models.skill import Skill
 from app.models.template import Template
 from app.schemas.agent import AgentResponse
 from app.schemas.file import CollectionResponse
 from app.schemas.function import FunctionResponse
+from app.schemas.pipeline import PipelineResponse
 from app.schemas.skill import SkillResponse
 from app.schemas.template import TemplateResponse
 
@@ -185,3 +187,41 @@ async def list_templates(
 
     set_permission_used(request, "sinas.templates.read")
     return [TemplateResponse.model_validate(t) for t in templates]
+
+
+@router.get("/pipelines", response_model=list[PipelineResponse])
+async def list_pipelines(
+    request: Request,
+    x_application: Optional[str] = Header(None),
+    app_query: Optional[str] = Query(None, alias="app"),
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """List pipelines visible to the current user, optionally filtered by app context.
+
+    Completes the runtime discovery surface: run/replay/runs existed without a
+    way to learn which pipelines exist, forcing runtime consumers onto the
+    management plane (/api/v1) for discovery.
+    """
+    user_id, permissions = current_user_data
+
+    manifest = await get_manifest_context(db, x_application, app_query)
+    ns_filter = get_namespace_filter(manifest, "pipelines")
+    if ns_filter is not None and len(ns_filter) == 0:
+        set_permission_used(request, "sinas.pipelines.read")
+        return []
+
+    filters = Pipeline.is_active == True  # noqa: E712
+    if ns_filter is not None:
+        filters = and_(filters, Pipeline.namespace.in_(ns_filter))
+
+    pipelines = await Pipeline.list_with_permissions(
+        db=db,
+        user_id=user_id,
+        permissions=permissions,
+        action="read",
+        additional_filters=filters,
+    )
+
+    set_permission_used(request, "sinas.pipelines.read")
+    return [PipelineResponse.model_validate(p) for p in pipelines]

--- a/backend/tests/unit/test_runtime_pipeline_discovery.py
+++ b/backend/tests/unit/test_runtime_pipeline_discovery.py
@@ -1,0 +1,80 @@
+"""Runtime GET /pipelines — the discovery endpoint the runtime surface lacked.
+
+run/replay/runs existed without a way to learn which pipelines exist, forcing
+runtime consumers onto the management plane for discovery. Mirrors the
+agents/functions discovery contract: permission-filtered, active-only.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pipeline import Pipeline
+from app.models.user import Role, RolePermission, User, UserRole
+
+from tests.conftest import auth_headers
+
+
+async def _pipeline(db: AsyncSession, owner: User, ns: str, name: str, active: bool = True) -> Pipeline:
+    p = Pipeline(
+        user_id=owner.id,
+        namespace=ns,
+        name=name,
+        steps=[{"name": "s1", "type": "function", "function": f"{ns}/noop"}],
+        is_active=active,
+    )
+    db.add(p)
+    await db.flush()
+    return p
+
+
+class TestRuntimePipelineDiscovery:
+    async def test_admin_lists_pipelines(self, client, db, admin_user):
+        ns = f"disc{uuid.uuid4().hex[:6]}"
+        await _pipeline(db, admin_user, ns, "flow-a")
+        resp = await client.get("/pipelines", headers=auth_headers(admin_user))
+        assert resp.status_code == 200, resp.text
+        names = {(p["namespace"], p["name"]) for p in resp.json()}
+        assert (ns, "flow-a") in names
+
+    async def test_inactive_pipelines_hidden(self, client, db, admin_user):
+        ns = f"disc{uuid.uuid4().hex[:6]}"
+        await _pipeline(db, admin_user, ns, "dormant", active=False)
+        resp = await client.get("/pipelines", headers=auth_headers(admin_user))
+        assert resp.status_code == 200
+        assert (ns, "dormant") not in {(p["namespace"], p["name"]) for p in resp.json()}
+
+    async def test_no_pipeline_permission_sees_empty(self, client, db, admin_user, test_user):
+        # test_role grants agents/functions/queries but nothing on pipelines
+        ns = f"disc{uuid.uuid4().hex[:6]}"
+        await _pipeline(db, admin_user, ns, "hidden-flow")
+        resp = await client.get("/pipelines", headers=auth_headers(test_user))
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_namespace_scoped_read(self, client, db, admin_user):
+        ns_ok = f"disc{uuid.uuid4().hex[:6]}"
+        ns_no = f"disc{uuid.uuid4().hex[:6]}"
+        await _pipeline(db, admin_user, ns_ok, "visible")
+        await _pipeline(db, admin_user, ns_no, "invisible")
+
+        role = Role(name=f"pipe-reader-{uuid.uuid4().hex[:8]}")
+        db.add(role)
+        await db.flush()
+        db.add(RolePermission(
+            role_id=role.id,
+            permission_key=f"sinas.pipelines/{ns_ok}/*.read:all",
+            permission_value=True,
+        ))
+        user = User(email=f"reader-{uuid.uuid4().hex[:8]}@example.com")
+        db.add(user)
+        await db.flush()
+        db.add(UserRole(role_id=role.id, user_id=user.id, active=True))
+        await db.flush()
+
+        resp = await client.get("/pipelines", headers=auth_headers(user))
+        assert resp.status_code == 200
+        names = {(p["namespace"], p["name"]) for p in resp.json()}
+        assert (ns_ok, "visible") in names
+        assert (ns_no, "invisible") not in names


### PR DESCRIPTION
The runtime API can run/replay/list-runs a pipeline but had no way to discover which pipelines exist — the only runtime resource with execution endpoints and no discovery (agents, functions, skills, collections, templates all have a collection GET in `discovery.py`). Runtime consumers had to reach into `/api/v1/pipelines`, a different plane requiring management permissions a runtime key shouldn't hold.

Mirrors the existing discovery contract exactly: `Pipeline.list_with_permissions` (so namespace-scoped reads behave), `is_active` filter, manifest app-context filtering via the same generic `get_namespace_filter` key.

Pipelines are new in 0.4.0 — this is the launch surface, so the gap ships closed.

Tests: admin list, inactive hidden, permission-less user sees `[]`, namespace-scoped role sees only its namespace. Full pattern match with `list_agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)