### PR TITLE
feat(console): serve the console under /ui; ingress routes by namespace, not allowlist

### DIFF
--- a/charts/sinas/templates/NOTES.txt
+++ b/charts/sinas/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Sinas has been deployed to namespace {{ .Release.Namespace }}.
 
-  Console:  https://{{ .Values.domain }}/
+  Console:  https://{{ .Values.domain }}/ui/
   API:      https://{{ .Values.domain }}/api/v1
   Health:   https://{{ .Values.domain }}/health
 

--- a/charts/sinas/templates/ingress.yaml
+++ b/charts/sinas/templates/ingress.yaml
@@ -1,18 +1,19 @@
 {{- if .Values.ingress.enabled }}
-## Path-based routing:
-##   Backend API paths → backend:8000
-##   Everything else   → console:80 (SPA)
+## Path-based routing, by namespace rather than allowlist:
+##   /ui  → console:80 (SPA, built with Vite base '/ui/')
+##   /    → console:80 (Exact: nginx 302s to /ui/, preserving the path)
+##   /    → backend:8000 (Prefix: every API route, current and future)
+##
+## The console living under /ui is what makes this possible: console page
+## paths and runtime API paths used to share the domain root, so the chart
+## kept a hand-maintained allowlist of backend prefixes. That list drifted
+## silently in both directions — /info went missing (breaking console login
+## on password-mode instances) while /states and /jobs outlived their
+## routes. With the app namespaced, new API routes work on day one and the
+## SPA owns exactly one prefix.
 ##
 ## Console uses window.location.hostname as the API base, so both services
 ## must share the same hostname.
-##
-## The prefix list below has to track the runtime API's route table by hand.
-## A missing prefix does not fail loudly: the catch-all serves index.html with
-## HTTP 200, so the caller gets HTML where it expected JSON. That is how /info
-## was lost — the console reads auth_mode from it before login, could not parse
-## the HTML, and fell back to its 'otp' default, rendering an OTP form on a
-## password-mode instance. Check this list against /openapi.json when adding a
-## top-level route.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -39,21 +40,27 @@ spec:
     - host: {{ .Values.domain | quote }}
       http:
         paths:
-          {{- range list "/api" "/adapters" "/auth" "/files" "/stores" "/webhooks" "/agents" "/chats" "/functions" "/executions" "/manifests" "/components" "/queries" "/skills" "/collections" "/states" "/jobs" "/templates" "/health" "/docs" "/openapi.json" "/info" "/userinfo" "/batches" "/pipelines" }}
-          - path: {{ . }}
-            pathType: Prefix
-            backend:
-              service:
-                name: backend
-                port:
-                  number: 8000
-          {{- end }}
-          ## Catch-all → console SPA
-          - path: /
+          - path: /ui
             pathType: Prefix
             backend:
               service:
                 name: console
                 port:
                   number: 80
+          ## Bare domain → console, which redirects to /ui/
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: console
+                port:
+                  number: 80
+          ## Everything else is the API
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
 {{- end }}

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -38,7 +38,7 @@ RUN npm run build
 FROM nginx:alpine
 
 # Copy built files from builder
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/dist /usr/share/nginx/html/ui
 
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/console/nginx.conf
+++ b/console/nginx.conf
@@ -5,6 +5,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Emit path-only Location headers ("/ui/...") so redirects survive
+    # non-standard ports (dev serves this container on :51245 directly;
+    # nginx's default absolute redirect drops the port).
+    absolute_redirect off;
+
     # Gzip compression
     gzip on;
     gzip_vary on;
@@ -16,12 +21,14 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Main location - SPA fallback
-    location / {
-        try_files $uri $uri/ /index.html;
+    # The app lives under /ui (built with Vite base '/ui/', files at html/ui).
+    # This is what lets the ingress route by path with no per-endpoint
+    # allowlist: /ui -> console, everything else -> backend.
+    location /ui/ {
+        try_files $uri $uri/ /ui/index.html;
     }
 
-    # Cache static assets
+    # Cache static assets (root-based, so /ui/assets/* maps to html/ui/assets/*)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
@@ -32,5 +39,12 @@ server {
         access_log off;
         return 200 "OK\n";
         add_header Content-Type text/plain;
+    }
+
+    # Anything else reaching this container (the ingress Exact-/ rule, direct
+    # port access in dev, pre-/ui bookmarks) — send to the app, preserving the
+    # path so old console links like /agents land on their SPA route.
+    location / {
+        return 302 /ui$request_uri;
     }
 }

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -98,7 +98,7 @@ function App() {
       <ToastProvider>
         <APIErrorHandler>
           <AuthProvider>
-            <BrowserRouter>
+            <BrowserRouter basename="/ui">
           <Routes>
             <Route
               path="/login"

--- a/console/src/components/Layout.tsx
+++ b/console/src/components/Layout.tsx
@@ -123,7 +123,7 @@ export function Layout() {
         <div className="flex flex-col h-full">
           {/* Logo */}
           <div className="flex items-center justify-between h-16 px-6 border-b border-line-soft">
-            <><img src="/sinas-logo.svg" alt="sinas" className="h-8 light:hidden" /><img src="/sinas-logo-light.svg" alt="sinas" className="h-8 hidden light:block" /></>
+            <><img src={`${import.meta.env.BASE_URL}sinas-logo.svg`} alt="sinas" className="h-8 light:hidden" /><img src={`${import.meta.env.BASE_URL}sinas-logo-light.svg`} alt="sinas" className="h-8 hidden light:block" /></>
             <button
               onClick={() => setSidebarOpen(false)}
               className="lg:hidden text-gray-400 hover:text-gray-200"

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -244,7 +244,7 @@ class APIClient {
     localStorage.removeItem('auth_token');
     localStorage.removeItem('refresh_token');
     localStorage.removeItem('user');
-    window.location.href = '/login';
+    window.location.href = `${import.meta.env.BASE_URL}login`;
   }
 
   setErrorHandler(handler: (message: string) => void) {

--- a/console/src/pages/DbTableDetail.tsx
+++ b/console/src/pages/DbTableDetail.tsx
@@ -183,7 +183,7 @@ export function DbTableDetail() {
     mutationFn: () =>
       apiClient.dropDbTable(connectionName!, table!, schema, false),
     onSuccess: () => {
-      window.location.href = `/database-connections/${connectionName}`;
+      window.location.href = `${import.meta.env.BASE_URL}database-connections/${connectionName}`;
     },
   });
 

--- a/console/src/pages/Login.tsx
+++ b/console/src/pages/Login.tsx
@@ -77,7 +77,7 @@ export function Login() {
         {/* Logo and title */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center mb-4">
-            <><img src="/sinas-logo.svg" alt="sinas" className="h-16 light:hidden" /><img src="/sinas-logo-light.svg" alt="sinas" className="h-16 hidden light:block" /></>
+            <><img src={`${import.meta.env.BASE_URL}sinas-logo.svg`} alt="sinas" className="h-16 light:hidden" /><img src={`${import.meta.env.BASE_URL}sinas-logo-light.svg`} alt="sinas" className="h-16 hidden light:block" /></>
           </div>
           <h1 className="text-xl font-semibold text-gray-100 mb-2">Management Console</h1>
           <p className="text-gray-400">Sovereign Infrastructure for Native Agentic Systems</p>

--- a/console/src/pages/ResetPassword.tsx
+++ b/console/src/pages/ResetPassword.tsx
@@ -53,7 +53,7 @@ export function ResetPassword() {
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center mb-4">
-            <img src="/sinas-logo.svg" alt="sinas" className="h-16" />
+            <img src={`${import.meta.env.BASE_URL}sinas-logo.svg`} alt="sinas" className="h-16" />
           </div>
           <h1 className="text-xl font-semibold text-gray-100 mb-2">Reset password</h1>
           <p className="text-gray-400">Use the one-time link from your administrator</p>

--- a/console/src/pages/Users.tsx
+++ b/console/src/pages/Users.tsx
@@ -377,7 +377,7 @@ function ResetLinkResultModal({
   onClose: () => void;
 }) {
   const [copied, setCopied] = useState<'token' | 'url' | null>(null);
-  const resetUrl = `${window.location.origin}/reset-password?token=${encodeURIComponent(result.reset_token)}`;
+  const resetUrl = `${window.location.origin}${import.meta.env.BASE_URL}reset-password?token=${encodeURIComponent(result.reset_token)}`;
 
   const copy = async (value: string, kind: 'token' | 'url') => {
     try {

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // The console is served under /ui so the ingress can route by path with no
+  // per-endpoint allowlist: /ui -> console, everything else -> backend.
+  base: '/ui/',
   plugins: [react()],
   resolve: {
     dedupe: ['react', 'react-dom'],


### PR DESCRIPTION
## Problem
Console SPA routes and runtime API routes share the domain root. Twelve paths (`/agents`, `/chats`, `/pipelines`…) are simultaneously console pages **and** backend prefixes — so under the Helm ingress, F5/deep-link/bookmark on those pages hits the backend and renders 401 JSON. No allowlist tweak can fix identical strings, and the list itself drifted both ways: `/info` went missing (#165's login breaker) while `/states`/`/jobs` outlived their routes.

## Change
Console moves to `/ui`; the ingress collapses to **three rules** — `/ui` → console, Exact `/` → console (302 → `/ui/`), Prefix `/` → backend. The allowlist is deleted; every current and future API route works on day one.

- Vite `base: '/ui/'` + router `basename`; `BASE_URL` on absolute navigations and the `public/` logo JSX literals Vite doesn't rewrite; reset-link builder updated
- Image puts dist at `html/ui`; nginx redirects non-`/ui` paths to `/ui$request_uri` (old bookmarks keep their page), `absolute_redirect off` so Location headers survive dev's :51245
- Compose/Caddy untouched — console has its own port there, no clash ever existed
- `NOTES.txt` console URL → `/ui/`

## Why now
Exactly one Helm deployment exists and it's ours. Pre-GA is the only moment this URL move costs one message instead of a migration guide.

## Verification
tsc clean · helm lint + rendered ingress = 3 rules exactly · live container: `/`→`/ui/` and `/agents`→`/ui/agents` (path-preserving, port-preserving), deep links `/ui/agents` and `/ui/pipelines/ns/x` serve the SPA, asset cache headers intact, logo 200 · real browser: app boots to `/ui/login`, renders fully.

**Operator note (release notes):** console URL becomes `https://domain/ui/`; bare domain and old page URLs redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)