### PR TITLE
fix(ci): attach Caddyfile to release assets

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           files: |
             docker-compose-${{ github.ref_name }}.yml
+            Caddyfile
             sinas-${{ github.ref_name }}.tgz
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
The release job attaches a version-pinned `docker-compose.yml` whose own comment calls it ready-to-run — but the file bind-mounts `./Caddyfile:ro`, which was not among the attached assets. Anyone downloading only the release assets hit a missing-mount failure on the caddy service; the compose path only worked from a repo clone.

One line: add `Caddyfile` to the release `files:` list.

Workflow-only — no image, chart, or runtime impact; takes effect on the next tag (i.e. the GA release, which is the one strangers will actually download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)