### PR TITLE
feat(metering): sinas.metering/v2 — Platform-issued periods via POST-only handshake (SIN-640)

### DIFF
--- a/backend/alembic/versions/m1e2t3v4p5d6_metering_v2_platform_periods.py
+++ b/backend/alembic/versions/m1e2t3v4p5d6_metering_v2_platform_periods.py
@@ -1,0 +1,46 @@
+"""metering v2: platform-issued periods
+
+Revision ID: m1e2t3v4p5d6
+Revises: p1w2d3r4s5t6
+Create Date: 2026-08-31
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "m1e2t3v4p5d6"
+down_revision = "p1w2d3r4s5t6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "metering_platform_period",
+        sa.Column("instance_id", sa.String(length=255), primary_key=True),
+        sa.Column("period_id", sa.String(length=64), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    # Platform period ids are ULID-ish and not bounded to the "YYYY-MM" shape
+    op.alter_column(
+        "usage_periods", "period_id", type_=sa.String(length=64), existing_nullable=False
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "usage_periods", "period_id", type_=sa.String(length=20), existing_nullable=False
+    )
+    op.drop_table("metering_platform_period")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -378,12 +378,16 @@ class Settings(BaseSettings):
     # Operations metering (managed SaaS). Default-off; when enabled, every
     # operation (function/code/query/agent/upload/tool) increments a Redis
     # counter, the scheduler snapshots it to usage_periods, and a heartbeat
-    # pushes the CUMULATIVE period total to metering_endpoint. Pure emission:
-    # nothing is enforced on the instance and nothing is pulled down. A dead
-    # endpoint or Redis blip never affects platform behavior.
+    # POSTs the CUMULATIVE period total to the Platform (sinas.metering/v2).
+    # The Platform is the period authority: period id and boundaries arrive
+    # exclusively in POST responses (no context endpoint) — first report is
+    # sent under canonical_period_id "init". Pure emission: nothing is
+    # enforced on the instance and nothing is pulled down. A dead endpoint
+    # or Redis blip never affects platform behavior. With the platform
+    # settings unset, counting stays local and no report is ever attempted.
     metering_enabled: bool = False
-    metering_endpoint: str = ""  # e.g. https://ops.example.com/v1/usage
-    metering_api_key: str = ""  # sent as Authorization: Bearer <key>
+    platform_report_url: str = ""  # e.g. https://platform.example.com/api/sinas/metering/v1/reports
+    platform_api_key: str = ""  # opaque instance token, sent as Authorization: Bearer — never logged
     metering_instance_id: str = ""  # defaults to `domain`; set explicitly in SaaS
     metering_snapshot_minutes: int = 5  # Redis -> usage_periods cadence
     metering_push_minutes: int = 15  # heartbeat cadence (jittered per instance)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -30,7 +30,7 @@ from .store import Store
 from .table_annotation import TableAnnotation
 from .template import Template
 from .tool_call_result import ToolCallResult
-from .usage import UsagePeriod
+from .usage import MeteringPlatformPeriod, UsagePeriod
 from .user import (
     APIKey,
     APIKeyRole,
@@ -94,5 +94,6 @@ __all__ = [
     "TableAnnotation",
     "ToolCallResult",
     "JWTSigningKey",
+    "MeteringPlatformPeriod",
     "UsagePeriod",
 ]

--- a/backend/app/models/usage.py
+++ b/backend/app/models/usage.py
@@ -38,3 +38,24 @@ class UsagePeriod(Base):
     __table_args__ = (
         Index("uq_usage_periods_instance_period", "instance_id", "period_id", unique=True),
     )
+
+
+class MeteringPlatformPeriod(Base):
+    """The Platform-issued billing period this instance is currently
+    reporting under (sinas.metering/v2). One row per instance_id.
+
+    Populated exclusively from POST /reports responses — there is no context
+    endpoint. Absent row = not yet bootstrapped: reports go out under
+    canonical_period_id "init" until the Platform's ack supplies the period.
+    A changed period id in a later response replaces this row and resets the
+    period's counters (the accepted MVP rollover gap)."""
+
+    __tablename__ = "metering_platform_period"
+
+    instance_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    period_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    created_at: Mapped[created_at]
+    updated_at: Mapped[updated_at]

--- a/backend/app/services/metering.py
+++ b/backend/app/services/metering.py
@@ -42,7 +42,15 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-SCHEMA = "sinas.metering/v1"
+SCHEMA = "sinas.metering/v2"
+
+# First-report sentinel: sent while no Platform period is cached. The
+# Platform applies an "init" report to the then-current billing period and
+# returns that period in the ack; Core then adopts it WITHOUT resetting —
+# the applied counts are the period's baseline, and a reset would make the
+# next report's counters regress (tripping the Platform's counter_regression
+# check). Reset happens only on a subsequent period CHANGE.
+INIT_PERIOD_ID = "init"
 
 # Old-period Redis keys are kept briefly after their final push, then expire.
 _ROLLED_OVER_KEY_TTL = int(timedelta(days=7).total_seconds())
@@ -91,6 +99,20 @@ def _key(pid: str, suffix: str) -> str:
     return f"usage:{instance_id()}:{pid}:{suffix}"
 
 
+def _platform_pid_key() -> str:
+    return f"usage:{instance_id()}:platform_period"
+
+
+async def current_pid(redis) -> str:
+    """Period id live counters are keyed by: the Platform-issued period once
+    the POST handshake has supplied one, the local monthly fallback before
+    that (and always, in offline/self-hosted mode)."""
+    pid = await redis.get(_platform_pid_key())
+    if isinstance(pid, bytes):
+        pid = pid.decode()
+    return pid or period_id()
+
+
 def push_jitter_seconds(interval_minutes: int) -> int:
     """Deterministic per-instance offset so fleet pushes spread across the
     window instead of aligning to the wall clock."""
@@ -112,7 +134,7 @@ async def record(kind: OperationKind, n: int = 1) -> None:
         from app.core.redis import get_redis
 
         redis = await get_redis()
-        pid = period_id()
+        pid = await current_pid(redis)
         pipe = redis.pipeline(transaction=False)
         pipe.incrby(_key(pid, "total"), n)
         pipe.incrby(_key(pid, f"kind:{kind.value}"), n)
@@ -152,9 +174,16 @@ async def snapshot(db: AsyncSession) -> None:
     from app.models import UsagePeriod
 
     redis = await get_redis()
-    current = period_id()
+    state = await _load_platform_state(db)
+    if state is not None:
+        # Platform-period mode: one current period, bounds from the handshake.
+        # No previous-period finalization — rollover discards (MVP contract).
+        pids = (state.period_id,)
+    else:
+        current = period_id()
+        pids = (current, _previous_period_id(current))
 
-    for pid in (current, _previous_period_id(current)):
+    for pid in pids:
         counters = await _read_redis_counters(redis, pid)
         if counters is None:
             continue
@@ -169,7 +198,10 @@ async def snapshot(db: AsyncSession) -> None:
         ).scalar_one_or_none()
 
         if row is None:
-            start, end = period_bounds(pid)
+            if state is not None and pid == state.period_id:
+                start, end = state.period_start, state.period_end
+            else:
+                start, end = period_bounds(pid)
             row = UsagePeriod(
                 instance_id=instance_id(),
                 period_id=pid,
@@ -191,10 +223,36 @@ async def snapshot(db: AsyncSession) -> None:
     await db.commit()
 
 
+async def _load_platform_state(db: AsyncSession):
+    """Current Platform-issued period for this instance, or None before the
+    first successful POST handshake (and always in offline mode)."""
+    from app.models import MeteringPlatformPeriod
+
+    return (
+        await db.execute(
+            select(MeteringPlatformPeriod).where(
+                MeteringPlatformPeriod.instance_id == instance_id()
+            )
+        )
+    ).scalar_one_or_none()
+
+
 async def seed_redis_from_db(db: AsyncSession) -> None:
     """On startup: restore the current period's count into Redis, taking the
     max of both sides so neither a Redis restart nor a stale snapshot can
     move the count backwards."""
+    from app.core.redis import get_redis
+
+    state = await _load_platform_state(db)
+    pid = state.period_id if state else period_id()
+    if state is not None:
+        # Restore the shared pointer record()/current_pid() key by
+        try:
+            redis = await get_redis()
+            await redis.set(_platform_pid_key(), state.period_id)
+        except Exception:
+            pass
+
     from app.core.redis import get_redis
     from app.models import UsagePeriod
 
@@ -202,7 +260,7 @@ async def seed_redis_from_db(db: AsyncSession) -> None:
         await db.execute(
             select(UsagePeriod).where(
                 UsagePeriod.instance_id == instance_id(),
-                UsagePeriod.period_id == period_id(),
+                UsagePeriod.period_id == pid,
             )
         )
     ).scalar_one_or_none()
@@ -224,31 +282,125 @@ async def seed_redis_from_db(db: AsyncSession) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Push: cumulative heartbeat to the platform
+# Push: cumulative heartbeat to the Platform (sinas.metering/v2)
+#
+# The POST is also the period handshake — there is no context endpoint.
+# Every response carries the current Platform period; Core persists it and
+# keys its counters by it. Three situations:
+#
+#   bootstrap  no cached period → report canonical_period_id "init". The
+#              Platform applies it to the then-current period and returns
+#              that period. Core ADOPTS AND MIGRATES its local counters to
+#              the new id (no reset — the applied counts are the baseline;
+#              a reset would regress the next report's counters).
+#   steady     ack period == cached period → mark reported.
+#   rollover   ack period != cached period (200 grace-window apply), or a
+#              409 period_mismatch / period_context_required → adopt the
+#              new period and RESET counters + snapshot_seq to zero. Ops
+#              accumulated in between are discarded (accepted MVP gap).
 # ---------------------------------------------------------------------------
 
 
-def _build_payload(row) -> dict[str, Any]:
+def _build_payload(row, canonical_pid: str) -> dict[str, Any]:
+    by_kind = {k.value: int((row.by_kind or {}).get(k.value, 0)) for k in OperationKind}
+    # The Platform validates total == sum(by_kind) with an explicit "other";
+    # counters can drift apart across a Redis blip, so compute the remainder.
+    other = max(0, int(row.total or 0) - sum(by_kind.values()))
     return {
         "schema": SCHEMA,
         "instance_id": row.instance_id,
         "platform_version": __version__,
-        "period_id": row.period_id,
-        "period_start": row.period_start.isoformat(),
-        "period_end": row.period_end.isoformat(),
-        # Cumulative period-to-date — never a delta. The platform takes
-        # max(total) per (instance_id, period_id); a missed or duplicated
-        # beat self-heals.
-        "total": row.total,
-        "by_kind": row.by_kind or {},
+        "canonical_period_id": canonical_pid,
+        # Decimal strings throughout: the Platform is TypeScript + Postgres
+        # BigInt, and IEEE doubles corrupt large counters.
+        "cumulative": {
+            "total": str(int(row.total or 0)),
+            "by_kind": {**{k: str(v) for k, v in by_kind.items()}, "other": str(other)},
+        },
+        "snapshot_seq": str(int(row.snapshot_seq)),
         "last_op_at": row.last_op_at.isoformat() if row.last_op_at else None,
-        "snapshot_seq": row.snapshot_seq,
         "sent_at": datetime.now(UTC).isoformat(),
     }
 
 
+def _parse_period(body: Any) -> Optional[dict[str, Any]]:
+    """{"id", "start", "end"} from a response body, or None if absent/bad."""
+    try:
+        period = (body or {}).get("period") or {}
+        pid = str(period["id"])
+        start = datetime.fromisoformat(period["start"].replace("Z", "+00:00"))
+        end = datetime.fromisoformat(period["end"].replace("Z", "+00:00"))
+        return {"id": pid, "start": start, "end": end}
+    except Exception:
+        return None
+
+
+async def _persist_period(db: AsyncSession, period: dict[str, Any]) -> None:
+    from app.models import MeteringPlatformPeriod
+
+    state = await _load_platform_state(db)
+    if state is None:
+        state = MeteringPlatformPeriod(instance_id=instance_id())
+        db.add(state)
+    state.period_id = period["id"]
+    state.period_start = period["start"]
+    state.period_end = period["end"]
+
+
+async def _adopt_migrate(db: AsyncSession, redis, old_pid: str, period: dict[str, Any], row) -> None:
+    """Bootstrap adopt: the "init" report was applied to `period`, so local
+    counters move under the new id with their values intact."""
+    from app.models import UsagePeriod
+
+    await _persist_period(db, period)
+    new_pid = period["id"]
+
+    # Live counters: copy, then let the old keys age out. A record() racing
+    # this in another process may land on the old key and be lost — bounded
+    # by one op and covered by the accepted bootstrap gap.
+    counters = await _read_redis_counters(redis, old_pid)
+    if counters is not None:
+        pipe = redis.pipeline(transaction=False)
+        pipe.incrby(_key(new_pid, "total"), counters["total"])
+        for k, v in counters["by_kind"].items():
+            pipe.incrby(_key(new_pid, f"kind:{k}"), v)
+        await pipe.execute()
+        for k in OperationKind:
+            await redis.expire(_key(old_pid, f"kind:{k.value}"), _ROLLED_OVER_KEY_TTL)
+        await redis.expire(_key(old_pid, "total"), _ROLLED_OVER_KEY_TTL)
+    await redis.set(_platform_pid_key(), new_pid)
+
+    # Durable row: re-key under the Platform period, values and seq intact
+    # (seq continuity is what keeps the monotonic contract unbroken).
+    existing = (
+        await db.execute(
+            select(UsagePeriod).where(
+                UsagePeriod.instance_id == instance_id(),
+                UsagePeriod.period_id == new_pid,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        row.period_id = new_pid
+        row.period_start = period["start"]
+        row.period_end = period["end"]
+
+
+async def _adopt_reset(db: AsyncSession, redis, old_pid: str, period: dict[str, Any]) -> None:
+    """Rollover adopt: new period starts from zero; the old period's tail is
+    discarded (accepted MVP gap — no previous-period finalization)."""
+    await _persist_period(db, period)
+    await redis.set(_platform_pid_key(), period["id"])
+    for k in OperationKind:
+        await redis.expire(_key(old_pid, f"kind:{k.value}"), _ROLLED_OVER_KEY_TTL)
+    await redis.expire(_key(old_pid, "total"), _ROLLED_OVER_KEY_TTL)
+    # No usage_periods row yet: the next snapshot creates it at zero with
+    # snapshot_seq 0 once the first op of the new period lands.
+
+
 async def push(db: AsyncSession) -> int:
-    """POST every period row with unreported progress. Returns rows pushed.
+    """POST the current period's cumulative report and process the period
+    handshake in the response. Returns reports accepted.
 
     Failures are logged and abandoned until the next cycle — cumulative
     totals mean there is nothing to replay.
@@ -256,88 +408,103 @@ async def push(db: AsyncSession) -> int:
     from app.core.redis import get_redis
     from app.models import UsagePeriod
 
-    endpoint = settings.metering_endpoint.strip()
-    if not endpoint:
-        logger.warning("METERING_ENABLED but METERING_ENDPOINT is empty — nothing sent")
+    url = settings.platform_report_url.strip()
+    if not url:
+        logger.warning("METERING_ENABLED but PLATFORM_REPORT_URL is empty — nothing sent")
         return 0
 
-    rows = (
-        (
-            await db.execute(
-                select(UsagePeriod)
-                .where(UsagePeriod.instance_id == instance_id())
-                .order_by(UsagePeriod.period_start)
+    redis = await get_redis()
+    state = await _load_platform_state(db)
+    pid = state.period_id if state else period_id()
+    canonical = state.period_id if state else INIT_PERIOD_ID
+
+    row = (
+        await db.execute(
+            select(UsagePeriod).where(
+                UsagePeriod.instance_id == instance_id(),
+                UsagePeriod.period_id == pid,
             )
         )
-        .scalars()
-        .all()
-    )
-    to_send = [
-        r for r in rows if r.reported_at is None or r.updated_at > r.reported_at
-    ]
-    if not to_send:
+    ).scalar_one_or_none()
+    if row is None or (row.reported_at is not None and row.updated_at <= row.reported_at):
         return 0
 
     headers = {}
-    if settings.metering_api_key:
-        headers["Authorization"] = f"Bearer {settings.metering_api_key}"
+    if settings.platform_api_key:
+        # Never log this header or the settings value (SIN-649).
+        headers["Authorization"] = f"Bearer {settings.platform_api_key}"
+
+    row.snapshot_seq += 1
+    payload = _build_payload(row, canonical)
+    key = f"{row.instance_id}:{row.period_id}:{row.snapshot_seq}"
 
     pushed = 0
-    current = period_id()
     async with httpx.AsyncClient(timeout=15.0) as client:
-        for row in to_send:
-            row.snapshot_seq += 1
-            payload = _build_payload(row)
-            key = f"{row.instance_id}:{row.period_id}:{row.snapshot_seq}"
+        for attempt in range(_PUSH_ATTEMPTS):
+            try:
+                resp = await client.post(
+                    url, json=payload, headers={**headers, "Idempotency-Key": key}
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Metering push {key} failed "
+                    f"(attempt {attempt + 1}/{_PUSH_ATTEMPTS}): {e}"
+                )
+                resp = None
 
-            ok = False
-            for attempt in range(_PUSH_ATTEMPTS):
+            if resp is not None:
                 try:
-                    resp = await client.post(
-                        endpoint,
-                        json=payload,
-                        headers={**headers, "Idempotency-Key": key},
-                    )
-                    if 200 <= resp.status_code < 300:
-                        ok = True
-                        break
-                    logger.warning(
-                        f"Metering push {key}: HTTP {resp.status_code} "
-                        f"(attempt {attempt + 1}/{_PUSH_ATTEMPTS})"
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Metering push {key} failed "
-                        f"(attempt {attempt + 1}/{_PUSH_ATTEMPTS}): {e}"
-                    )
-                if attempt < _PUSH_ATTEMPTS - 1:
-                    import asyncio
+                    body = resp.json()
+                except Exception:
+                    body = {}
 
-                    # Backoff with jitter so a fleet retries out of phase
-                    await asyncio.sleep((2**attempt) + random.uniform(0, 1))
+                if 200 <= resp.status_code < 300:
+                    row.reported_at = datetime.now(UTC)
+                    pushed = 1
+                    period = _parse_period(body)
+                    if period and period["id"] != canonical:
+                        if canonical == INIT_PERIOD_ID:
+                            await _adopt_migrate(db, redis, pid, period, row)
+                        else:
+                            await _adopt_reset(db, redis, pid, period)
+                    break
 
-            if ok:
-                row.reported_at = datetime.now(UTC)
-                pushed += 1
-                if row.period_id != current:
-                    # Rolled-over period got its final push; let its Redis
-                    # keys age out instead of lingering forever.
-                    try:
-                        redis = await get_redis()
-                        for kind in OperationKind:
-                            await redis.expire(
-                                _key(row.period_id, f"kind:{kind.value}"),
-                                _ROLLED_OVER_KEY_TTL,
-                            )
-                        await redis.expire(
-                            _key(row.period_id, "total"), _ROLLED_OVER_KEY_TTL
+                if resp.status_code == 409:
+                    disposition = (body or {}).get("disposition")
+                    period = _parse_period(body)
+                    if (
+                        disposition in ("period_mismatch", "period_context_required")
+                        and period is not None
+                    ):
+                        # Rollover detected the hard way: adopt + reset. The
+                        # rejected counters are the discarded tail.
+                        await _adopt_reset(db, redis, pid, period)
+                        logger.info(
+                            f"Metering: period changed to {period['id']} "
+                            f"({disposition}); counters reset"
                         )
-                    except Exception:
-                        pass
-            await db.commit()
+                    else:
+                        # sequence_reused / counter_regression: retrying the
+                        # same payload cannot help — surface loudly.
+                        logger.error(
+                            f"Metering push {key} rejected: 409 {disposition}"
+                        )
+                    break
 
+                logger.warning(
+                    f"Metering push {key}: HTTP {resp.status_code} "
+                    f"(attempt {attempt + 1}/{_PUSH_ATTEMPTS})"
+                )
+
+            if attempt < _PUSH_ATTEMPTS - 1:
+                import asyncio
+
+                # Backoff with jitter so a fleet retries out of phase
+                await asyncio.sleep((2**attempt) + random.uniform(0, 1))
+
+    await db.commit()
     if pushed:
-        logger.info(f"Metering: pushed {pushed} period report(s)")
+        logger.info("Metering: pushed 1 period report")
     return pushed
 
 

--- a/backend/tests/fixtures/metering/README.md
+++ b/backend/tests/fixtures/metering/README.md
@@ -1,0 +1,20 @@
+# sinas.metering/v2 contract fixtures
+
+Shared fixtures for Platform contract tests (SIN-640). Contract decisions
+settled 2026-08-31 (supersede the Metering API Confluence page where they
+differ):
+
+- POST-only: no GET /context endpoint; period metadata arrives exclusively
+  in POST /reports responses.
+- Bootstrap sentinel is the literal string `"init"` (not `"0000"`). The
+  Platform APPLIES an init report to the then-current billing period and
+  returns that period. Core adopts it WITHOUT resetting counters (the
+  applied counts are the period baseline; a reset would trip
+  counter_regression on the next report). A missing or unknown period id
+  that is not "init" remains a 409.
+- Rollover is detected on BOTH paths and handled identically (adopt the
+  returned period + reset counters and snapshot_seq): a 200 ack whose
+  period.id differs from the reported canonical_period_id, and a 409
+  period_mismatch / period_context_required.
+- All counters and sequence values are decimal strings; by_kind carries an
+  explicit "other" so total == sum(by_kind) always holds.

--- a/backend/tests/fixtures/metering/ack_applied.json
+++ b/backend/tests/fixtures/metering/ack_applied.json
@@ -1,0 +1,16 @@
+{
+  "schema": "opensaas.metering-response/v1",
+  "accepted": true,
+  "disposition": "applied",
+  "period": {
+    "id": "01J5METERINGPERIOD",
+    "start": "2026-07-14T00:00:00Z",
+    "end": "2026-08-14T00:00:00Z"
+  },
+  "instance": {
+    "accepted_snapshot_seq": "118",
+    "accepted_total": "41230"
+  },
+  "next_report_after_seconds": 900,
+  "server_time": "2026-08-11T09:15:01Z"
+}

--- a/backend/tests/fixtures/metering/ack_duplicate.json
+++ b/backend/tests/fixtures/metering/ack_duplicate.json
@@ -1,0 +1,16 @@
+{
+  "schema": "opensaas.metering-response/v1",
+  "accepted": true,
+  "disposition": "duplicate",
+  "period": {
+    "id": "01J5METERINGPERIOD",
+    "start": "2026-07-14T00:00:00Z",
+    "end": "2026-08-14T00:00:00Z"
+  },
+  "instance": {
+    "accepted_snapshot_seq": "118",
+    "accepted_total": "41230"
+  },
+  "next_report_after_seconds": 900,
+  "server_time": "2026-08-11T09:15:02Z"
+}

--- a/backend/tests/fixtures/metering/ack_init_applied.json
+++ b/backend/tests/fixtures/metering/ack_init_applied.json
@@ -1,0 +1,16 @@
+{
+  "schema": "opensaas.metering-response/v1",
+  "accepted": true,
+  "disposition": "applied",
+  "period": {
+    "id": "01J5METERINGPERIOD",
+    "start": "2026-07-14T00:00:00Z",
+    "end": "2026-08-14T00:00:00Z"
+  },
+  "instance": {
+    "accepted_snapshot_seq": "1",
+    "accepted_total": "2"
+  },
+  "next_report_after_seconds": 900,
+  "server_time": "2026-08-11T09:15:01Z"
+}

--- a/backend/tests/fixtures/metering/request_init.json
+++ b/backend/tests/fixtures/metering/request_init.json
@@ -1,0 +1,21 @@
+{
+  "schema": "sinas.metering/v2",
+  "instance_id": "acme-prod",
+  "platform_version": "0.4.0",
+  "canonical_period_id": "init",
+  "cumulative": {
+    "total": "2",
+    "by_kind": {
+      "agent": "0",
+      "function": "2",
+      "query": "0",
+      "code": "0",
+      "upload": "0",
+      "tool": "0",
+      "other": "0"
+    }
+  },
+  "snapshot_seq": "1",
+  "last_op_at": "2026-08-10T16:31:00+00:00",
+  "sent_at": "2026-08-11T09:15:00+00:00"
+}

--- a/backend/tests/fixtures/metering/request_steady.json
+++ b/backend/tests/fixtures/metering/request_steady.json
@@ -1,0 +1,21 @@
+{
+  "schema": "sinas.metering/v2",
+  "instance_id": "acme-prod",
+  "platform_version": "0.4.0",
+  "canonical_period_id": "01J5METERINGPERIOD",
+  "cumulative": {
+    "total": "41230",
+    "by_kind": {
+      "agent": "12010",
+      "function": "20100",
+      "query": "8000",
+      "code": "450",
+      "upload": "320",
+      "tool": "350",
+      "other": "0"
+    }
+  },
+  "snapshot_seq": "118",
+  "last_op_at": "2026-08-10T16:31:00+00:00",
+  "sent_at": "2026-08-11T09:15:00+00:00"
+}

--- a/backend/tests/fixtures/metering/response_409_period_mismatch.json
+++ b/backend/tests/fixtures/metering/response_409_period_mismatch.json
@@ -1,0 +1,11 @@
+{
+  "schema": "opensaas.metering-response/v1",
+  "accepted": false,
+  "disposition": "period_mismatch",
+  "period": {
+    "id": "01J5PERIODNEXT",
+    "start": "2026-08-14T00:00:00Z",
+    "end": "2026-09-14T00:00:00Z"
+  },
+  "server_time": "2026-09-01T00:05:00Z"
+}

--- a/backend/tests/unit/test_metering.py
+++ b/backend/tests/unit/test_metering.py
@@ -192,9 +192,12 @@ class TestSnapshot:
 
 
 class _Resp:
-    def __init__(self, status_code, text=""):
+    def __init__(self, status_code, body=None):
         self.status_code = status_code
-        self.text = text
+        self._body = body if body is not None else {}
+
+    def json(self):
+        return self._body
 
 
 class _FakeClient:
@@ -216,10 +219,23 @@ class _FakeClient:
         return result
 
 
+P1 = {"id": "01J5PERIODONE", "start": "2026-07-14T00:00:00Z", "end": "2026-08-14T00:00:00Z"}
+P2 = {"id": "01J5PERIODTWO", "start": "2026-08-14T00:00:00Z", "end": "2026-09-14T00:00:00Z"}
+
+
+def _ack(period, disposition="applied"):
+    return {
+        "schema": "opensaas.metering-response/v1",
+        "accepted": True,
+        "disposition": disposition,
+        "period": period,
+    }
+
+
 @pytest.fixture
-def endpoint(monkeypatch):
-    monkeypatch.setattr(settings, "metering_endpoint", "https://ops.example.com/v1/usage")
-    monkeypatch.setattr(settings, "metering_api_key", "sekrit")
+def platform(monkeypatch):
+    monkeypatch.setattr(settings, "platform_report_url", "https://platform.example.com/api/sinas/metering/v1/reports")
+    monkeypatch.setattr(settings, "platform_api_key", "sekrit")
     # No real sleeping in retry backoff
     async def _no_sleep(_):
         pass
@@ -233,27 +249,168 @@ def _patch_client(monkeypatch, responses):
     return client
 
 
-class TestPush:
-    async def test_pushes_cumulative_total_with_idempotency_key(
-        self, db, metering_on, endpoint, monkeypatch
+async def _state(db):
+    from app.models import MeteringPlatformPeriod
+
+    return (
+        await db.execute(
+            select(MeteringPlatformPeriod).where(
+                MeteringPlatformPeriod.instance_id == INSTANCE
+            )
+        )
+    ).scalar_one_or_none()
+
+
+class TestPushV2:
+    async def test_init_bootstrap_adopts_and_migrates_without_reset(
+        self, db, metering_on, platform, monkeypatch
     ):
         await record(OperationKind.FUNCTION)
         await record(OperationKind.FUNCTION)
         await snapshot(db)
-        client = _patch_client(monkeypatch, [_Resp(200)])
+        client = _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
 
-        pushed = await metering.push(db)
-        assert pushed == 1
+        assert await metering.push(db) == 1
 
         post = client.posts[0]
         assert post["headers"]["Authorization"] == "Bearer sekrit"
         assert post["headers"]["Idempotency-Key"] == f"{INSTANCE}:{period_id()}:1"
         payload = post["json"]
-        assert payload["schema"] == SCHEMA
-        assert payload["total"] == 2  # cumulative, not a delta
-        assert payload["by_kind"] == {"function": 2}
-        assert payload["snapshot_seq"] == 1
+        assert payload["schema"] == "sinas.metering/v2"
+        assert payload["canonical_period_id"] == "init"
+        # Decimal strings, nested cumulative, explicit other
+        assert payload["cumulative"]["total"] == "2"
+        assert payload["cumulative"]["by_kind"]["function"] == "2"
+        assert payload["cumulative"]["by_kind"]["other"] == "0"
+        assert payload["snapshot_seq"] == "1"
 
+        # Adopted: state persisted, live counters MIGRATED (not reset)
+        state = await _state(db)
+        assert state is not None and state.period_id == P1["id"]
+        assert metering_on.store.get(_k("total", P1["id"])) == 2
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(
+                    UsagePeriod.instance_id == INSTANCE,
+                    UsagePeriod.period_id == P1["id"],
+                )
+            )
+        ).scalar_one()
+        assert row.total == 2  # baseline preserved — no counter regression
+        assert row.snapshot_seq == 1  # seq continuity
+        assert row.reported_at is not None
+
+    async def test_steady_state_reports_under_cached_period(
+        self, db, metering_on, platform, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
+        await metering.push(db)
+
+        await record(OperationKind.AGENT)
+        await snapshot(db)
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(
+                    UsagePeriod.instance_id == INSTANCE,
+                    UsagePeriod.period_id == P1["id"],
+                )
+            )
+        ).scalar_one()
+        row.updated_at = datetime.now(UTC) + timedelta(seconds=1)
+        await db.flush()
+
+        client = _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
+        assert await metering.push(db) == 1
+        payload = client.posts[0]["json"]
+        assert payload["canonical_period_id"] == P1["id"]
+        assert payload["cumulative"]["total"] == "2"  # still cumulative
+        assert payload["snapshot_seq"] == "2"
+
+    async def test_rollover_in_ack_adopts_and_resets(
+        self, db, metering_on, platform, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
+        await metering.push(db)
+
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(
+                    UsagePeriod.instance_id == INSTANCE,
+                    UsagePeriod.period_id == P1["id"],
+                )
+            )
+        ).scalar_one()
+        row.updated_at = datetime.now(UTC) + timedelta(seconds=1)
+        await db.flush()
+
+        # Grace-window apply: 200 whose period moved on
+        _patch_client(monkeypatch, [_Resp(200, _ack(P2))])
+        assert await metering.push(db) == 1
+
+        state = await _state(db)
+        assert state.period_id == P2["id"]
+        assert metering_on.store.get(metering._platform_pid_key()) == P2["id"]
+        # Old period's live keys age out; new period starts empty (reset)
+        assert _k("total", P1["id"]) in metering_on.expired
+        assert metering_on.store.get(_k("total", P2["id"])) is None
+
+    async def test_409_period_mismatch_resets_without_marking_reported(
+        self, db, metering_on, platform, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
+        await metering.push(db)
+
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        row = (
+            await db.execute(
+                select(UsagePeriod).where(
+                    UsagePeriod.instance_id == INSTANCE,
+                    UsagePeriod.period_id == P1["id"],
+                )
+            )
+        ).scalar_one()
+        row.updated_at = datetime.now(UTC) + timedelta(seconds=1)
+        reported_before = row.reported_at
+        await db.flush()
+
+        client = _patch_client(
+            monkeypatch,
+            [_Resp(409, {"disposition": "period_mismatch", "period": P2})],
+        )
+        assert await metering.push(db) == 0
+        assert len(client.posts) == 1  # no retry on contract 409s
+        state = await _state(db)
+        assert state.period_id == P2["id"]
+        assert row.reported_at == reported_before  # rejected report not marked
+
+    async def test_409_counter_regression_is_terminal_no_adopt(
+        self, db, metering_on, platform, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        client = _patch_client(
+            monkeypatch, [_Resp(409, {"disposition": "counter_regression"})]
+        )
+        assert await metering.push(db) == 0
+        assert len(client.posts) == 1
+        assert await _state(db) is None
+
+    async def test_duplicate_disposition_counts_as_acknowledged(
+        self, db, metering_on, platform, monkeypatch
+    ):
+        await record(OperationKind.FUNCTION)
+        await snapshot(db)
+        _patch_client(monkeypatch, [_Resp(200, _ack(P1, disposition="duplicate"))])
+        assert await metering.push(db) == 1
         row = (
             await db.execute(
                 select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
@@ -261,44 +418,17 @@ class TestPush:
         ).scalar_one()
         assert row.reported_at is not None
 
-    async def test_no_progress_means_no_push(self, db, metering_on, endpoint, monkeypatch):
+    async def test_no_progress_means_no_push(self, db, metering_on, platform, monkeypatch):
         await record(OperationKind.FUNCTION)
         await snapshot(db)
-        _patch_client(monkeypatch, [_Resp(200)])
+        _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
         assert await metering.push(db) == 1
 
         _patch_client(monkeypatch, [])
         assert await metering.push(db) == 0  # nothing changed since report
 
-    async def test_new_activity_pushes_again_with_next_seq(
-        self, db, metering_on, endpoint, monkeypatch
-    ):
-        await record(OperationKind.FUNCTION)
-        await snapshot(db)
-        _patch_client(monkeypatch, [_Resp(200)])
-        await metering.push(db)
-
-        await record(OperationKind.FUNCTION)
-        await snapshot(db)
-        # In-test transaction timestamps don't advance, so simulate the
-        # updated_at bump a later transaction would produce
-        row = (
-            await db.execute(
-                select(UsagePeriod).where(UsagePeriod.instance_id == INSTANCE)
-            )
-        ).scalar_one()
-        row.updated_at = datetime.now(UTC) + timedelta(seconds=1)
-        await db.flush()
-
-        client = _patch_client(monkeypatch, [_Resp(200)])
-        assert await metering.push(db) == 1
-        payload = client.posts[0]["json"]
-        assert payload["total"] == 2  # still cumulative
-        assert payload["snapshot_seq"] == 2
-        assert client.posts[0]["headers"]["Idempotency-Key"].endswith(":2")
-
     async def test_failed_push_retries_next_cycle_no_data_loss(
-        self, db, metering_on, endpoint, monkeypatch
+        self, db, metering_on, platform, monkeypatch
     ):
         await record(OperationKind.FUNCTION)
         await snapshot(db)
@@ -314,52 +444,32 @@ class TestPush:
         assert row.reported_at is None  # still owed
 
         # Next cycle succeeds; total is cumulative so nothing was lost
-        client = _patch_client(monkeypatch, [_Resp(200)])
+        client = _patch_client(monkeypatch, [_Resp(200, _ack(P1))])
         assert await metering.push(db) == 1
-        assert client.posts[0]["json"]["total"] == 1
+        assert client.posts[0]["json"]["cumulative"]["total"] == "1"
 
-    async def test_empty_endpoint_sends_nothing(self, db, metering_on, monkeypatch):
-        monkeypatch.setattr(settings, "metering_endpoint", "")
+    async def test_empty_url_sends_nothing(self, db, metering_on, monkeypatch):
+        monkeypatch.setattr(settings, "platform_report_url", "")
         await record(OperationKind.FUNCTION)
         await snapshot(db)
         assert await metering.push(db) == 0
 
 
-# ---------------------------------------------------------------------------
-# Rollover
-# ---------------------------------------------------------------------------
+class TestPayloadV2:
+    def test_other_absorbs_counter_drift(self):
+        from types import SimpleNamespace
 
-
-class TestRollover:
-    async def test_previous_period_finalized_and_keys_expired(
-        self, db, metering_on, endpoint, monkeypatch
-    ):
-        prev = metering._previous_period_id(period_id())
-        # Leftover counters from last month + fresh activity this month
-        metering_on.store[_k("total", prev)] = 40
-        metering_on.store[_k("kind:function", prev)] = 40
-        await record(OperationKind.AGENT)
-
-        await snapshot(db)
-        rows = (
-            (
-                await db.execute(
-                    select(UsagePeriod)
-                    .where(UsagePeriod.instance_id == INSTANCE)
-                    .order_by(UsagePeriod.period_start)
-                )
-            )
-            .scalars()
-            .all()
+        row = SimpleNamespace(
+            instance_id=INSTANCE,
+            total=10,
+            by_kind={"function": 3, "agent": 4},
+            snapshot_seq=7,
+            last_op_at=None,
         )
-        assert [r.period_id for r in rows] == [prev, period_id()]
-        assert rows[0].total == 40
-        assert rows[1].total == 1
-
-        client = _patch_client(monkeypatch, [_Resp(200), _Resp(200)])
-        assert await metering.push(db) == 2
-        # Old period got its final push; its Redis keys are set to expire
-        assert _k("total", prev) in metering_on.expired
+        payload = metering._build_payload(row, "init")
+        assert payload["cumulative"]["by_kind"]["other"] == "3"
+        assert payload["cumulative"]["total"] == "10"
+        assert payload["snapshot_seq"] == "7"
 
 
 # ---------------------------------------------------------------------------

--- a/docs-mint/getting-started/environment-variables.mdx
+++ b/docs-mint/getting-started/environment-variables.mdx
@@ -91,8 +91,8 @@ Default off. When enabled, every operation (function execution, code execution, 
 | Variable | Default | Description |
 |---|---|---|
 | `METERING_ENABLED` | `false` | Master switch. |
-| `METERING_ENDPOINT` | _(none)_ | Endpoint receiving heartbeat JSON (`sinas.metering/v1`), cumulative totals + `by_kind`, `Idempotency-Key` per push. |
-| `METERING_API_KEY` | _(none)_ | Sent as `Authorization: Bearer <key>`. |
+| `PLATFORM_REPORT_URL` | _(none)_ | Platform POST endpoint receiving heartbeat JSON (`sinas.metering/v2`): cumulative totals + `by_kind` as decimal strings, `Idempotency-Key` per push. The response carries the Platform-issued billing period (first report goes out as `canonical_period_id: "init"`). |
+| `PLATFORM_API_KEY` | _(none)_ | Opaque instance token, sent as `Authorization: Bearer <key>`. Never logged. |
 | `METERING_INSTANCE_ID` | `DOMAIN` | Identifier for this instance in reports. |
 | `METERING_SNAPSHOT_MINUTES` | `5` | Cadence of the durable Redis → Postgres snapshot. |
 | `METERING_PUSH_MINUTES` | `15` | Heartbeat cadence (jittered per instance so fleets don't push in sync). |


### PR DESCRIPTION
Implements SIN-640 (+ the config half of SIN-649) per the decisions settled with Kjeld on 2026-08-31 — these supersede the Metering API Confluence page where they differ:

1. **POST-only.** No GET /context; period metadata arrives exclusively in POST responses.
2. **Bootstrap sentinel is `"init"`** (not `"0000"`). Platform applies the init report to the then-current billing period and returns it. **Core adopts and MIGRATES — no reset** — because the applied counts are the period baseline; resetting would regress the next report into the Platform's own `counter_regression` check. Missing/garbage period ids that are not `"init"` stay 409.
3. **Both rollover paths handled identically**: 200 ack with a different `period.id` (grace-window apply) and 409 `period_mismatch`/`period_context_required` → adopt + reset counters and `snapshot_seq` to zero, tail discarded (accepted MVP gap).

## Mechanics
- `metering_platform_period` table (row per instance) + Redis pointer key so `record()` in every process keys counters by the adopted period; `usage_periods.period_id` widened to 64 (ULID-shaped ids). Migration `m1e2t3v4p5d6`.
- v2 serializer: nested `cumulative`, decimal strings throughout, computed explicit `other` so `total == sum(by_kind)` survives Redis counter drift.
- Terminal 409s (`sequence_reused`/`counter_regression`) log loudly and do not retry; transport errors keep the existing backoff+jitter.
- Config rename `PLATFORM_REPORT_URL`/`PLATFORM_API_KEY` (token never logged — SIN-649). Internal-only, default-off feature → no compat shim.
- **Offline unchanged**: URL unset → nothing sent, monthly fallback counting incl. previous-month finalization stays as in v1.
- Contract fixtures for Platform tests in `backend/tests/fixtures/metering/` (requests, acks, 409) with the decisions recorded in its README.

## Why 0.4.0
Metering exists solely for the internal Platform use case and needs a release to ship in; it is default-off, so zero risk to any other deployment — and shipping v1 wire format only to revamp it next release would create a compatibility ghost.

## Verification
19 metering tests: init migrate-not-reset (baseline + seq continuity asserted), steady-state, both rollover paths, 409 terminal dispositions not retried, duplicate=success, retry/no-data-loss, payload mapping incl. `other` drift absorption. Full suite 423 passed (same 7 known Redis-env failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)