### PR TITLE
feat(deploy): all-in-one lite profile — one sinas container instead of five

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,7 +1,8 @@
 name: Build & Push Docker Images
 
-# Builds the four Sinas images (backend, builder, executor, console) and pushes them to
-# GHCR. See RELEASING.md for the full versioning/release flow.
+# Builds the five Sinas images (backend, builder, executor, console, and lite —
+# backend + console SPA for the all-in-one profile) and pushes them to GHCR.
+# See RELEASING.md for the full versioning/release flow.
 #
 # Triggers & resulting image tags:
 #   push to dev            -> :dev            (+ :sha-…)      integration builds
@@ -118,11 +119,83 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           platforms: ${{ env.PLATFORMS }}
 
+  # Lite image: the backend image + the console's built SPA, for the all-in-one
+  # single-container profile (docker-compose.lite.yml / values-lite.yaml).
+  # Built AFTER the matrix from the backend and console images this run pushed.
+  lite:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Resolve base image tag
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.image_tag }}"
+            [ -z "$TAG" ] && TAG="${{ github.event.inputs.ref }}"
+            TAG=$(printf '%s' "$TAG" | sed 's#[^a-zA-Z0-9._-]#-#g' | cut -c1-120)
+          elif [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            TAG=edge
+          elif [ "${GITHUB_REF}" = "refs/heads/dev" ]; then
+            TAG=dev
+          else
+            TAG="${GITHUB_REF_NAME}"   # semver tag builds
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/lite
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=sha,prefix=,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value=${{ steps.base.outputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile.lite
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/backend:${{ steps.base.outputs.tag }}
+            CONSOLE_IMAGE=${{ env.IMAGE_PREFIX }}/console:${{ steps.base.outputs.tag }}
+          cache-from: type=gha,scope=lite
+          cache-to: type=gha,mode=max,scope=lite
+          platforms: ${{ env.PLATFORMS }}
+
   # On a version tag, publish a GitHub Release with a ready-to-run, version-pinned
   # docker-compose.yml and the packaged Helm chart attached, then push the chart to
   # GHCR as an OCI artifact. Prerelease flag is set automatically for -rc tags.
   release:
-    needs: build
+    needs: [build, lite]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -140,6 +213,7 @@ jobs:
           # Pin the image tag to this release; the registry default already points at GHCR,
           # so the file runs as-is (users still supply their own .env for secrets/config).
           sed "s/\${IMAGE_TAG:-latest}/${VERSION}/g" docker-compose.yml > "docker-compose-${VERSION}.yml"
+          sed "s/\${IMAGE_TAG:-latest}/${VERSION}/g" docker-compose.lite.yml > "docker-compose-lite-${VERSION}.yml"
 
       - name: Package Helm chart
         run: |
@@ -153,6 +227,7 @@ jobs:
         with:
           files: |
             docker-compose-${{ github.ref_name }}.yml
+            docker-compose-lite-${{ github.ref_name }}.yml
             Caddyfile
             sinas-${{ github.ref_name }}.tgz
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -130,7 +130,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -151,13 +151,13 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -165,7 +165,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_PREFIX }}/lite
           tags: |
@@ -177,7 +177,7 @@ jobs:
             type=raw,value=${{ steps.base.outputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./backend
           file: ./backend/Dockerfile.lite
@@ -228,6 +228,7 @@ jobs:
           files: |
             docker-compose-${{ github.ref_name }}.yml
             docker-compose-lite-${{ github.ref_name }}.yml
+            docker-compose.lite.exec.yml
             Caddyfile
             sinas-${{ github.ref_name }}.tgz
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -71,9 +71,14 @@ jobs:
       - name: Resolve dispatch image tag
         if: github.event_name == 'workflow_dispatch'
         id: disp
+        # Inputs reach the shell via env, never expression interpolation —
+        # interpolating them into the script body would let a crafted
+        # dispatch input execute in this packages:write job.
+        env:
+          IN_TAG: ${{ github.event.inputs.image_tag }}
+          IN_REF: ${{ github.event.inputs.ref }}
         run: |
-          TAG="${{ github.event.inputs.image_tag }}"
-          [ -z "$TAG" ] && TAG="${{ github.event.inputs.ref }}"
+          TAG="${IN_TAG:-$IN_REF}"
           # Sanitize to a valid, readable image tag.
           TAG=$(printf '%s' "$TAG" | sed 's#[^a-zA-Z0-9._-]#-#g' | cut -c1-120)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -136,10 +141,15 @@ jobs:
 
       - name: Resolve base image tag
         id: base
+        # Inputs reach the shell via env, never expression interpolation —
+        # interpolating them into the script body would let a crafted
+        # dispatch input execute in this packages:write job.
+        env:
+          IN_TAG: ${{ github.event.inputs.image_tag }}
+          IN_REF: ${{ github.event.inputs.ref }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.image_tag }}"
-            [ -z "$TAG" ] && TAG="${{ github.event.inputs.ref }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${IN_TAG:-$IN_REF}"
             TAG=$(printf '%s' "$TAG" | sed 's#[^a-zA-Z0-9._-]#-#g' | cut -c1-120)
           elif [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             TAG=edge

--- a/backend/Dockerfile.lite
+++ b/backend/Dockerfile.lite
@@ -1,0 +1,25 @@
+# Lite image — the backend image plus the console's built SPA, for the
+# all-in-one single-container profile (docker-compose.lite.yml /
+# values-lite.yaml). Built FROM the already-published backend and console
+# images so it adds one COPY layer, not a rebuild:
+#
+#   docker build -f Dockerfile.lite \
+#     --build-arg BASE_IMAGE=ghcr.io/sinas-platform/sinas/backend:TAG \
+#     --build-arg CONSOLE_IMAGE=ghcr.io/sinas-platform/sinas/console:TAG \
+#     -t ghcr.io/sinas-platform/sinas/lite:TAG .
+ARG BASE_IMAGE=ghcr.io/sinas-platform/sinas/backend:latest
+ARG CONSOLE_IMAGE=ghcr.io/sinas-platform/sinas/console:latest
+
+FROM ${CONSOLE_IMAGE} AS console
+
+FROM ${BASE_IMAGE}
+
+# The console image ships its Vite build (base '/ui/') at html/ui.
+COPY --from=console /usr/share/nginx/html/ui /app/console-dist
+
+# All-in-one: queue workers, scheduler and CDC run inside the API process.
+# The scheduler/CDC loops are singletons — exactly ONE uvicorn worker.
+ENV ALL_IN_ONE=true \
+    SERVE_CONSOLE=true
+
+CMD alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1

--- a/backend/app/cdc/service.py
+++ b/backend/app/cdc/service.py
@@ -12,10 +12,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [cdc] %(levelname)s %(name)s: %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 CDC_CHANNEL = "sinas:cdc:triggers"
@@ -375,8 +371,14 @@ async def _listen_for_trigger_changes(manager: CDCManager, stop_event: asyncio.E
         await pubsub.aclose()
 
 
-async def main() -> None:
-    from app.core.redis import close_redis, get_redis
+async def run(stop_event: asyncio.Event) -> None:
+    """CDC service body: startup, run until stop_event, graceful stop.
+
+    Factored out of main() so the all-in-one profile can run it as a task
+    inside the API process. Owns everything except signal handling and the
+    shared Redis client's lifecycle (the caller closes that).
+    """
+    from app.core.redis import get_redis
 
     # --- Redis ---
     redis = await get_redis()
@@ -385,18 +387,13 @@ async def main() -> None:
 
     # --- CDC Manager ---
     manager = CDCManager()
+    manager._stop_event = stop_event
     await manager.start()
 
     # --- Pub/sub listener for live trigger changes ---
-    stop_event = manager._stop_event
     listener_task = asyncio.create_task(_listen_for_trigger_changes(manager, stop_event))
 
-    print("🚀 CDC service running — press Ctrl+C or send SIGTERM to stop")
-
-    # Block until shutdown signal
-    loop = asyncio.get_running_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, stop_event.set)
+    print("🚀 CDC service running")
     await stop_event.wait()
 
     # --- Graceful shutdown ---
@@ -407,8 +404,26 @@ async def main() -> None:
     except asyncio.CancelledError:
         pass
     await manager.stop()
-    await close_redis()
     print("👋 CDC service stopped")
+
+
+async def main() -> None:
+    from app.core.redis import close_redis
+
+    # Standalone process only — embedded (all-in-one) mode inherits the API
+    # process's logging config instead of installing this one at import time.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [cdc] %(levelname)s %(name)s: %(message)s",
+    )
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop_event.set)
+    try:
+        await run(stop_event)
+    finally:
+        await close_redis()
 
 
 if __name__ == "__main__":

--- a/backend/app/core/allinone.py
+++ b/backend/app/core/allinone.py
@@ -1,0 +1,110 @@
+"""All-in-one ("lite") runtime: queue workers, scheduler and CDC inside the API process.
+
+Started from the FastAPI lifespan when ALL_IN_ONE=true. Each embedded service
+is the same code that runs as a dedicated container in the full profile —
+arq workers built from the existing WorkerSettings classes, and the
+scheduler/CDC service bodies factored into run(stop_event) coroutines.
+
+Constraints (enforced by deployment, documented here):
+- Single uvicorn worker (UVICORN_WORKERS=1) and a single backend replica —
+  the scheduler and CDC loops are singletons.
+- Redis and Postgres are still external processes; only the five sinas
+  Python processes collapse into one.
+"""
+import asyncio
+import logging
+
+from arq.worker import Worker, create_worker
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class AllInOneRuntime:
+    """Owns the embedded service tasks for the all-in-one profile."""
+
+    def __init__(self) -> None:
+        self._workers: list[Worker] = []
+        self._tasks: list[asyncio.Task] = []
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        from app.cdc import service as cdc_service
+        from app.queue.worker import (
+            AgentWorkerSettings,
+            PipelineWorkerSettings,
+            SubAgentWorkerSettings,
+            WorkerSettings,
+        )
+        from app.scheduler import service as scheduler_service
+
+        # Scheduler first: it owns config apply, sandbox image pre-build and
+        # pool creation. The tasks still start concurrently, but the pool
+        # singletons are per-process — with docker_pool the workers' startup
+        # discovery shares this process's pool object, so the cross-process
+        # empty-pool race of the full profile cannot occur here.
+        self._tasks.append(
+            asyncio.create_task(
+                self._supervise("scheduler", scheduler_service.run(self._stop_event))
+            )
+        )
+        self._tasks.append(
+            asyncio.create_task(
+                self._supervise("cdc", cdc_service.run(self._stop_event))
+            )
+        )
+
+        worker_settings: list[type] = [
+            WorkerSettings,
+            AgentWorkerSettings,
+            PipelineWorkerSettings,
+        ]
+        if settings.agent_subagent_queue:
+            worker_settings.append(SubAgentWorkerSettings)
+
+        for settings_cls in worker_settings:
+            # handle_signals=False: signal handling belongs to uvicorn here.
+            worker = create_worker(settings_cls, handle_signals=False)
+            self._workers.append(worker)
+            self._tasks.append(
+                asyncio.create_task(
+                    self._supervise(settings_cls.__name__, worker.async_run())
+                )
+            )
+
+        logger.info(
+            "All-in-one runtime started: scheduler, cdc and %d queue workers "
+            "embedded in the API process",
+            len(self._workers),
+        )
+
+    async def _supervise(self, name: str, coro) -> None:
+        try:
+            await coro
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # An embedded service dying must be loud: in the full profile the
+            # container would crash and restart. Here we log and let the
+            # remaining services run; the operator's health signal is the log.
+            logger.exception("Embedded service %r crashed", name)
+
+    async def stop(self) -> None:
+        self._stop_event.set()  # scheduler + cdc shut down gracefully
+
+        for worker in self._workers:
+            try:
+                await worker.close()  # waits for in-flight jobs, runs on_shutdown
+            except Exception:
+                logger.exception("Error closing embedded arq worker")
+
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._workers.clear()
+        self._tasks.clear()
+        logger.info("All-in-one runtime stopped")
+
+
+runtime = AllInOneRuntime()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -258,6 +258,18 @@ class Settings(BaseSettings):
     tool_result_max_inline: int = int(os.getenv("TOOL_RESULT_MAX_INLINE", "5"))  # Last N results kept inline
     tool_result_max_size: int = int(os.getenv("TOOL_RESULT_MAX_SIZE", "102400"))  # 100KB truncation limit
 
+    # All-in-one ("lite") deployment. When enabled, the API process also runs
+    # the queue workers, scheduler and CDC poller as asyncio tasks — one
+    # container instead of five. The scheduler and CDC loops are singletons,
+    # so this REQUIRES a single uvicorn worker (UVICORN_WORKERS=1) and a
+    # single backend replica.
+    all_in_one: bool = False
+    # Serve the console SPA from console_dist_path at /ui, replacing the
+    # separate console container. Independent of all_in_one; skipped with a
+    # warning when the directory doesn't exist.
+    serve_console: bool = False
+    console_dist_path: str = "/app/console-dist"
+
     # Redis & Queue
     redis_url: str = "redis://redis:6379/0"
     queue_function_concurrency: int = 10

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -103,9 +103,22 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         print(f"⚠️  ClickHouse storage migration skipped: {e}")
 
+    # All-in-one ("lite") profile: run queue workers, scheduler and CDC as
+    # tasks in this process instead of dedicated containers. Requires a
+    # single uvicorn worker and a single replica (singleton loops).
+    if settings.all_in_one:
+        from app.core.allinone import runtime as allinone_runtime
+
+        await allinone_runtime.start()
+
     yield
 
     # Shutdown
+    if settings.all_in_one:
+        from app.core.allinone import runtime as allinone_runtime
+
+        await allinone_runtime.stop()
+
     from app.services.database_pool import DatabasePoolManager
 
     await DatabasePoolManager.get_instance().close_all()
@@ -194,6 +207,28 @@ app.mount("/adapters/openai", adapters_openai_app)
 
 # Include runtime API routes (root level)
 app.include_router(runtime_router)
+
+# Console SPA served from this process (lite profile — replaces the console
+# container). app.frontend() is only consulted when no API route matched, so
+# the runtime routes above keep priority; the console owning exactly the /ui
+# prefix (Vite base '/ui/', see #169) is what makes cohabitation safe.
+if settings.serve_console:
+    from pathlib import Path
+
+    from fastapi.responses import RedirectResponse
+
+    if Path(settings.console_dist_path).is_dir():
+        app.frontend("/ui", directory=settings.console_dist_path)
+
+        @app.get("/", include_in_schema=False)
+        async def _console_redirect():
+            # Same behavior as the console nginx: bare domain → /ui/
+            return RedirectResponse(url="/ui/", status_code=302)
+    else:
+        logger.warning(
+            "SERVE_CONSOLE=true but %s does not exist — console not served",
+            settings.console_dist_path,
+        )
 
 
 # Dynamic OpenAPI endpoint for runtime API

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -32,10 +32,6 @@ from app.services.container_pool import container_pool
 from app.services.scheduler import scheduler
 from app.services.shared_worker_manager import shared_worker_manager
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [scheduler] %(levelname)s %(name)s: %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 SCHEDULER_CHANNEL = "sinas:scheduler:jobs"
@@ -169,7 +165,13 @@ async def _listen_for_job_changes(stop_event: asyncio.Event) -> None:
         await pubsub.aclose()
 
 
-async def main() -> None:
+async def run(stop_event: asyncio.Event) -> None:
+    """Scheduler service body: startup, run until stop_event, graceful stop.
+
+    Factored out of main() so the all-in-one profile can run it as a task
+    inside the API process. Owns everything except signal handling and the
+    shared Redis client's lifecycle (the caller closes that).
+    """
     # --- Redis ---
     redis = await get_redis()
     await redis.ping()
@@ -391,15 +393,9 @@ async def main() -> None:
         )
 
     # --- Pub/sub listener for live job changes ---
-    stop_event = asyncio.Event()
     listener_task = asyncio.create_task(_listen_for_job_changes(stop_event))
 
-    print("🚀 Scheduler service running — press Ctrl+C or send SIGTERM to stop")
-
-    # Block until shutdown signal
-    loop = asyncio.get_running_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, stop_event.set)
+    print("🚀 Scheduler service running")
     await stop_event.wait()
 
     # --- Graceful shutdown ---
@@ -411,8 +407,24 @@ async def main() -> None:
         pass
     await scheduler.stop()
     await container_pool.shutdown()
-    await close_redis()
     print("👋 Scheduler service stopped")
+
+
+async def main() -> None:
+    # Standalone process only — embedded (all-in-one) mode inherits the API
+    # process's logging config instead of installing this one at import time.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [scheduler] %(levelname)s %(name)s: %(message)s",
+    )
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop_event.set)
+    try:
+        await run(stop_event)
+    finally:
+        await close_redis()
 
 
 if __name__ == "__main__":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "fastapi>=0.104.0",
+    "fastapi>=0.138.0",
     "uvicorn[standard]>=0.24.0",
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",

--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -131,8 +131,16 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
 {{- end }}
 - name: REDIS_URL
   value: "redis://redis:6379/0"
+{{/* `| default true` can't express default-on booleans (false is "empty"), hence hasKey. */}}
+{{- if or (not (hasKey (.Values.builder | default dict) "enabled")) .Values.builder.enabled }}
 - name: BUILDER_URL
   value: "http://builder:3000"
+{{- else }}
+## Builder disabled: point at a shared builder (builder.url) or leave empty —
+## Component builds then fail with a clear connect error, everything else works.
+- name: BUILDER_URL
+  value: {{ (.Values.builder).url | default "" | quote }}
+{{- end }}
 ## Executor selection — k8s-native: sandbox code runs in ephemeral pods
 ## created via the Kubernetes API (no Docker socket anywhere).
 - name: SANDBOX_EXECUTOR

--- a/charts/sinas/templates/backend.yaml
+++ b/charts/sinas/templates/backend.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "sinas.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
 spec:
-  replicas: {{ .Values.backend.replicas }}
+  ## allInOne pins one replica: the embedded scheduler/CDC are singletons.
+  replicas: {{ ternary 1 (.Values.backend.replicas | int) (.Values.allInOne | default false) }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
@@ -28,16 +29,26 @@ spec:
       {{- end }}
       containers:
         - name: backend
-          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          ## allInOne uses the lite image: backend + the console's built SPA
+          ## (served at /ui by the process itself).
+          image: {{ .Values.image.registry }}/{{ ternary "lite" "backend" (.Values.allInOne | default false) }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
             - -c
-            - "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+            - "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1"
           ports:
             - containerPort: 8000
           env:
             {{- include "sinas.backendEnv" . | nindent 12 }}
+            {{- if .Values.allInOne }}
+            ## Queue workers, scheduler and CDC run inside this process.
+            ## Singleton loops: exactly one replica, one uvicorn worker.
+            - name: ALL_IN_ONE
+              value: "true"
+            - name: SERVE_CONSOLE
+              value: "true"
+            {{- end }}
             - name: SUPERADMIN_EMAIL
               value: {{ .Values.superadminEmail | quote }}
             - name: SMTP_HOST

--- a/charts/sinas/templates/builder.yaml
+++ b/charts/sinas/templates/builder.yaml
@@ -1,3 +1,4 @@
+{{- if or (not (hasKey (.Values.builder | default dict) "enabled")) .Values.builder.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,3 +54,4 @@ spec:
   ports:
     - port: 3000
       targetPort: 3000
+{{- end }}

--- a/charts/sinas/templates/console.yaml
+++ b/charts/sinas/templates/console.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.allInOne }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,3 +54,4 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+{{- end }}

--- a/charts/sinas/templates/ingress.yaml
+++ b/charts/sinas/templates/ingress.yaml
@@ -40,6 +40,17 @@ spec:
     - host: {{ .Values.domain | quote }}
       http:
         paths:
+          {{- if .Values.allInOne }}
+          ## allInOne: the backend serves the console at /ui itself (and
+          ## 302s the bare domain to /ui/) — one rule covers everything.
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          {{- else }}
           - path: /ui
             pathType: Prefix
             backend:
@@ -63,4 +74,5 @@ spec:
                 name: backend
                 port:
                   number: 8000
+          {{- end }}
 {{- end }}

--- a/charts/sinas/templates/workers.yaml
+++ b/charts/sinas/templates/workers.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.allInOne }}
 ## queue-worker
 apiVersion: apps/v1
 kind: Deployment
@@ -146,3 +147,4 @@ spec:
             {{- include "sinas.backendEnv" . | nindent 12 }}
           resources:
             {{- toYaml .Values.cdcWorker.resources | nindent 12 }}
+{{- end }}

--- a/charts/sinas/values-lite.yaml
+++ b/charts/sinas/values-lite.yaml
@@ -1,0 +1,62 @@
+# Sinas lite — the small-footprint managed/free-tier preset.
+#
+#   helm install my-tenant charts/sinas -f charts/sinas/values-lite.yaml \
+#     --set domain=... --set secrets.secretKey=... --set secrets.encryptionKey=... \
+#     --set postgres.password=... --set superadminEmail=...
+#
+# One sinas pod (API + queue workers + scheduler + CDC + console at /ui),
+# postgres, redis, pgbouncer. No ClickHouse (request logging off), no
+# builder (set builder.url to a shared one to enable Component builds), no
+# console pod. Sandbox code still runs in ephemeral hardened pods; there is
+# no warm trusted pool — set executor.trusted to k8s_shared to bring it back.
+#
+# For fleet hosting, also point postgres.external.host at a shared cluster
+# (database per tenant) and clickhouse/builder at shared services.
+
+allInOne: true
+
+clickhouse:
+  enabled: false
+
+builder:
+  enabled: false
+  url: ""
+
+executor:
+  sandbox: "k8s_pod"
+  ## No warm trusted pods on the free tier. NOT "inprocess": metered/billable
+  ## instances must keep trusted code out of the credential-bearing process
+  ## (meter-integrity invariant) — k8s_shared spawns pods on demand.
+  trusted: "k8s_shared"
+  trustedWorkers: 1
+
+backend:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "150m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+postgres:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 384Mi
+
+redis:
+  maxmemory: "128mb"
+  resources:
+    requests:
+      cpu: 25m
+      memory: 192Mi
+
+pgbouncer:
+  defaultPoolSize: 10
+  minPoolSize: 2
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -17,6 +17,16 @@ ingress:
     enabled: false
     secretName: ""  # existing TLS secret; leave empty when using cert-manager annotations
 
+## All-in-one ("lite") profile. When true, the queue workers, scheduler and
+## CDC poller run inside the backend process (as asyncio tasks), the console
+## SPA is served by the backend at /ui, and the queue-worker, queue-agent,
+## scheduler, cdc-worker and console Deployments are not rendered. The
+## backend is pinned to 1 replica / 1 uvicorn worker (the embedded
+## scheduler/CDC loops are singletons) and uses the `lite` image (backend +
+## console build). Pair with values-lite.yaml for the full small-footprint
+## preset (no ClickHouse, no builder, small resource requests).
+allInOne: false
+
 ## Secrets (required — provide via --set or a secrets values file)
 secrets:
   secretKey: ""
@@ -202,8 +212,13 @@ scheduling:
   tolerations: []
   affinity: {}
 
-## Builder (Node.js esbuild server)
+## Builder (Node.js esbuild server). enabled=false skips the Deployment;
+## set url to a shared builder to keep Component builds working, or leave it
+## empty to have builds fail with a clear connect error (nothing else is
+## affected — the builder is only used when someone builds a Component).
 builder:
+  enabled: true
+  url: ""
   resources:
     requests:
       cpu: "50m"

--- a/docker-compose.lite.exec.yml
+++ b/docker-compose.lite.exec.yml
@@ -1,0 +1,16 @@
+# Additive override for the lite profile: enables code execution by
+# mounting the host Docker socket and switching on the Docker executors
+# (ephemeral sandbox containers, shared trusted workers on demand).
+# The base lite file mounts no socket and disables execution, so the
+# privilege only exists when this file is explicitly included:
+#
+#   docker compose -f docker-compose.lite.yml -f docker-compose.lite.exec.yml up -d
+
+services:
+  sinas:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      CODE_EXECUTION_ENABLED: ${CODE_EXECUTION_ENABLED:-true}
+      SANDBOX_EXECUTOR: ${SANDBOX_EXECUTOR:-docker_ephemeral}
+      TRUSTED_EXECUTOR: ${TRUSTED_EXECUTOR:-docker_shared}

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -8,11 +8,13 @@
 # enable Component builds), no caddy (the sinas container terminates HTTP —
 # put your own TLS proxy or ingress in front).
 #
-# Code execution runs in ephemeral containers via the host Docker socket
-# (SANDBOX_EXECUTOR=docker_ephemeral); set CODE_EXECUTION_ENABLED=false to
-# drop the socket mount entirely.
+# Code execution is OFF by default and the host Docker socket is NOT
+# mounted — the container holds no host privileges. To enable code
+# execution (ephemeral sandbox containers via the host socket), add the
+# additive override, which mounts the socket and flips the executors on:
 #
-#   docker compose -f docker-compose.lite.yml up -d
+#   docker compose -f docker-compose.lite.yml up -d                                # no code execution
+#   docker compose -f docker-compose.lite.yml -f docker-compose.lite.exec.yml up -d  # with code execution
 #
 # Requires the same .env as the full profile (SECRET_KEY, ENCRYPTION_KEY).
 
@@ -52,7 +54,6 @@ services:
     ports:
       - "${BACKEND_PORT:-8000}:8000"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - file_storage:/var/sinas/files
     env_file:
       - .env
@@ -68,10 +69,11 @@ services:
       # Empty host = explicit disable: no retries, log queries return empty.
       CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-}
       REDIS_URL: redis://redis:6379/0
-      # Ephemeral sandboxes, no warm pool, shared trusted workers on demand.
-      SANDBOX_EXECUTOR: ${SANDBOX_EXECUTOR:-docker_ephemeral}
-      TRUSTED_EXECUTOR: ${TRUSTED_EXECUTOR:-docker_shared}
-      CODE_EXECUTION_ENABLED: ${CODE_EXECUTION_ENABLED:-true}
+      # Off by default (no Docker socket in this file); the lite.exec
+      # override mounts the socket and enables the Docker executors.
+      SANDBOX_EXECUTOR: ${SANDBOX_EXECUTOR:-disabled}
+      TRUSTED_EXECUTOR: ${TRUSTED_EXECUTOR:-disabled}
+      CODE_EXECUTION_ENABLED: ${CODE_EXECUTION_ENABLED:-false}
       DOCKER_NETWORK: ${DOCKER_NETWORK:-auto}
       FUNCTION_CONTAINER_IMAGE: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/executor:${IMAGE_TAG:-latest}
       # No embedded builder — Component builds need a shared one.

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -1,0 +1,96 @@
+# Sinas lite — the all-in-one single-container profile.
+#
+# Three containers instead of ~22: postgres, redis, and one sinas process
+# that runs the API, queue workers, scheduler, CDC poller AND serves the
+# console at /ui. No pgbouncer (one process needs no cross-process pooling),
+# no clickhouse (request logging off; point CLICKHOUSE_HOST at a shared
+# instance to re-enable), no builder (set BUILDER_URL at a shared one to
+# enable Component builds), no caddy (the sinas container terminates HTTP —
+# put your own TLS proxy or ingress in front).
+#
+# Code execution runs in ephemeral containers via the host Docker socket
+# (SANDBOX_EXECUTOR=docker_ephemeral); set CODE_EXECUTION_ENABLED=false to
+# drop the socket mount entirely.
+#
+#   docker compose -f docker-compose.lite.yml up -d
+#
+# Requires the same .env as the full profile (SECRET_KEY, ENCRYPTION_KEY).
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: sinas-lite-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:?DATABASE_PASSWORD must be set in .env file}
+      POSTGRES_DB: ${DATABASE_NAME:-sinas}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    container_name: sinas-lite-redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes --maxmemory ${REDIS_MAXMEMORY:-128mb} --maxmemory-policy allkeys-lru
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+
+  sinas:
+    image: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/lite:${IMAGE_TAG:-latest}
+    container_name: sinas-lite
+    restart: unless-stopped
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - file_storage:/var/sinas/files
+    env_file:
+      - .env
+    environment:
+      ALL_IN_ONE: "true"
+      SERVE_CONSOLE: "true"
+      DATABASE_USER: ${DATABASE_USER:-postgres}
+      DATABASE_HOST: postgres
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: ${DATABASE_NAME:-sinas}
+      DATABASE_URL: postgresql://${DATABASE_USER:-postgres}:${DATABASE_PASSWORD}@postgres:5432/${DATABASE_NAME:-sinas}
+      DATABASE_DIRECT_HOST: postgres
+      # Empty host = explicit disable: no retries, log queries return empty.
+      CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-}
+      REDIS_URL: redis://redis:6379/0
+      # Ephemeral sandboxes, no warm pool, shared trusted workers on demand.
+      SANDBOX_EXECUTOR: ${SANDBOX_EXECUTOR:-docker_ephemeral}
+      TRUSTED_EXECUTOR: ${TRUSTED_EXECUTOR:-docker_shared}
+      CODE_EXECUTION_ENABLED: ${CODE_EXECUTION_ENABLED:-true}
+      DOCKER_NETWORK: ${DOCKER_NETWORK:-auto}
+      FUNCTION_CONTAINER_IMAGE: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/executor:${IMAGE_TAG:-latest}
+      # No embedded builder — Component builds need a shared one.
+      BUILDER_URL: ${BUILDER_URL:-}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set in .env file}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set in .env file}
+      SUPERADMIN_EMAIL: ${SUPERADMIN_EMAIL:-}
+    deploy:
+      resources:
+        limits:
+          cpus: "${APP_CPU_LIMIT:-2.0}"
+          memory: ${APP_MEMORY_LIMIT:-1G}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:
+  file_storage:


### PR DESCRIPTION
## Why

We want to offer free managed Sinas deployments cheaply: many instances per VPS instead of a dedicated ~€15/month footprint each. The full profile runs five Python processes (backend, queue-worker, queue-agent, scheduler, cdc-worker) plus console/nginx — this PR collapses all of that into **one container** as an opt-in profile. **Full stays the default**; the rendered manifests for the default profile are unchanged (verified via `helm template` diff).

## What

### All-in-one runtime (`ALL_IN_ONE=true`)
- New [`app/core/allinone.py`](backend/app/core/allinone.py): the backend lifespan starts the scheduler, CDC poller, and all four arq queue workers (functions, agents, sub-agents, pipelines) as asyncio tasks in the API process — built from the existing `WorkerSettings` classes via `create_worker(..., handle_signals=False)`.
- The scheduler/CDC service bodies are factored into `run(stop_event)` coroutines; their standalone `__main__` entrypoints keep signal handling, Redis lifecycle, and their process-level `logging.basicConfig` (moved out of import time so embedded mode doesn't hijack the API process's log format).
- Requires 1 uvicorn worker / 1 replica (the scheduler/CDC loops are singletons) — enforced by the packaging below.
- Side benefit: the cross-process empty-pool startup race can't occur in this mode — all consumers share the scheduler's in-process pool object.

### Console served by the backend (`SERVE_CONSOLE=true`)
- FastAPI pin bumped `>=0.104` → `>=0.138` for `app.frontend()`: serves the console SPA at `/ui` (API routes always checked first) plus the bare-domain 302 → `/ui/` the console nginx used to do. Skipped with a warning when the dist directory is absent.

### Packaging
- `backend/Dockerfile.lite`: new `lite` image = published backend image + the console image's built SPA (one COPY layer). CI job `lite` builds it after the image matrix; releases attach a version-pinned `docker-compose-lite-<v>.yml`.
- `docker-compose.lite.yml`: postgres + redis + one sinas container. No pgbouncer/clickhouse/builder/caddy; `docker_ephemeral` sandboxes via the host socket.
- Chart: `allInOne` value (skips worker/console Deployments, pins 1 replica, routes all ingress to backend, uses the `lite` image), `builder.enabled`/`builder.url` (shared-builder option), and a `values-lite.yaml` preset (no ClickHouse, no builder, on-demand executors, small requests). `executor.trusted` stays `k8s_shared` — NOT `inprocess` — per the meter-integrity invariant for billable instances.

## Validation

- Live boot against a real Postgres/Redis: all four workers heartbeating in Redis, `/ui` served, `/` 302s, `/api/v1/docs` up, graceful SIGTERM shutdown clean.
- `helm template` rendered for both profiles: default output unchanged; lite renders backend+pgbouncer+postgres+redis only, single ingress rule, `lite` image, `ALL_IN_ONE`/`SERVE_CONSOLE` env.
- Unit suite green (same result with and without this change).
- SPA deep links: `app.frontend()`'s `auto` fallback serves `index.html` for `Accept: text/html` requests (verified with TestClient).

## Known gaps / follow-ups
- The `lite` Docker image build hasn't run locally (needs the published backend/console images); first CI run on this branch will exercise it.
- No dedicated unit tests for the all-in-one runtime yet; validation was the live boot above.
- No README/RELEASING docs section for the lite profile yet.
- FastAPI 0.104→0.141 is a large bump — unit suite + live boot exercised it, but watch the full profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)