### PR TITLE
feat(api): runtime GET /queries — same discovery gap as pipelines

### DIFF
--- a/backend/app/api/runtime/endpoints/discovery.py
+++ b/backend/app/api/runtime/endpoints/discovery.py
@@ -12,12 +12,14 @@ from app.models.agent import Agent
 from app.models.file import Collection
 from app.models.function import Function
 from app.models.pipeline import Pipeline
+from app.models.query import Query as QueryModel
 from app.models.skill import Skill
 from app.models.template import Template
 from app.schemas.agent import AgentResponse
 from app.schemas.file import CollectionResponse
 from app.schemas.function import FunctionResponse
 from app.schemas.pipeline import PipelineResponse
+from app.schemas.query import QueryResponse
 from app.schemas.skill import SkillResponse
 from app.schemas.template import TemplateResponse
 
@@ -225,3 +227,42 @@ async def list_pipelines(
 
     set_permission_used(request, "sinas.pipelines.read")
     return [PipelineResponse.model_validate(p) for p in pipelines]
+
+
+@router.get("/queries", response_model=list[QueryResponse])
+async def list_queries(
+    request: Request,
+    x_application: Optional[str] = Header(None),
+    app_query: Optional[str] = Query(None, alias="app"),
+    db: AsyncSession = Depends(get_db),
+    current_user_data=Depends(get_current_user_with_permissions),
+):
+    """List queries visible to the current user, optionally filtered by app context.
+
+    Same discovery gap as pipelines (#168): POST /queries/{ns}/{name}/execute
+    existed with no way to learn which queries exist without the management
+    plane. Permission gate matches the management list (read), so this
+    exposes nothing a management-plane read could not already see.
+    """
+    user_id, permissions = current_user_data
+
+    manifest = await get_manifest_context(db, x_application, app_query)
+    ns_filter = get_namespace_filter(manifest, "queries")
+    if ns_filter is not None and len(ns_filter) == 0:
+        set_permission_used(request, "sinas.queries.read")
+        return []
+
+    filters = QueryModel.is_active == True  # noqa: E712
+    if ns_filter is not None:
+        filters = and_(filters, QueryModel.namespace.in_(ns_filter))
+
+    queries = await QueryModel.list_with_permissions(
+        db=db,
+        user_id=user_id,
+        permissions=permissions,
+        action="read",
+        additional_filters=filters,
+    )
+
+    set_permission_used(request, "sinas.queries.read")
+    return [QueryResponse.model_validate(q) for q in queries]

--- a/backend/tests/unit/test_runtime_query_discovery.py
+++ b/backend/tests/unit/test_runtime_query_discovery.py
@@ -1,0 +1,76 @@
+"""Runtime GET /queries — same discovery gap as pipelines (#168).
+
+execute existed with no way to learn which queries exist without the
+management plane. Mirrors the discovery contract: permission-filtered,
+active-only.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database_connection import DatabaseConnection
+from app.models.query import Query
+from app.models.user import User
+
+from tests.conftest import auth_headers
+
+
+async def _query(db: AsyncSession, owner: User, ns: str, name: str, active: bool = True) -> Query:
+    conn = DatabaseConnection(
+        name=f"conn-{uuid.uuid4().hex[:8]}",
+        connection_type="postgresql",
+        host="localhost",
+        port=5432,
+        database="x",
+        username="u",
+        password="enc",
+        is_active=True,
+    )
+    db.add(conn)
+    await db.flush()
+    q = Query(
+        user_id=owner.id,
+        namespace=ns,
+        name=name,
+        database_connection_id=conn.id,
+        operation="read",
+        sql="SELECT 1",
+        is_active=active,
+    )
+    db.add(q)
+    await db.flush()
+    return q
+
+
+class TestRuntimeQueryDiscovery:
+    async def test_admin_lists_queries(self, client, db, admin_user):
+        ns = f"qdisc{uuid.uuid4().hex[:6]}"
+        await _query(db, admin_user, ns, "lookup")
+        resp = await client.get("/queries", headers=auth_headers(admin_user))
+        assert resp.status_code == 200, resp.text
+        names = {(q["namespace"], q["name"]) for q in resp.json()}
+        assert (ns, "lookup") in names
+
+    async def test_inactive_hidden(self, client, db, admin_user):
+        ns = f"qdisc{uuid.uuid4().hex[:6]}"
+        await _query(db, admin_user, ns, "dormant", active=False)
+        resp = await client.get("/queries", headers=auth_headers(admin_user))
+        assert (ns, "dormant") not in {(q["namespace"], q["name"]) for q in resp.json()}
+
+    async def test_scoped_user_sees_only_permitted(self, client, db, admin_user, test_user):
+        # test_role grants sinas.queries/*/*.read:all — sees everything active;
+        # but a user with NO query grants must see [].
+        ns = f"qdisc{uuid.uuid4().hex[:6]}"
+        await _query(db, admin_user, ns, "visible")
+        resp = await client.get("/queries", headers=auth_headers(test_user))
+        assert resp.status_code == 200
+        assert (ns, "visible") in {(q["namespace"], q["name"]) for q in resp.json()}
+
+        loner = User(email=f"noq-{uuid.uuid4().hex[:8]}@example.com")
+        db.add(loner)
+        await db.flush()
+        resp = await client.get("/queries", headers=auth_headers(loner))
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
#168 claimed pipelines was the *only* runtime resource with execution endpoints and no discovery — wrong: queries had the identical gap (`POST /queries/{ns}/{name}/execute` with no collection GET). Kjeld caught it.

Mirrors the discovery contract exactly: `Query.list_with_permissions` (read action — the same gate as the management list, so the `sql` field in `QueryResponse` is shown only to callers a management-plane read would already show it to), `is_active` filter, manifest app-context filtering.

Tests: admin list, inactive hidden, permitted-vs-ungranted visibility.

**Sequencing note:** deliberately NOT merging yet — #175 (all-in-one-lite) is green and awaiting a scope decision; this merges after it (or whenever sequencing is settled) to avoid churning that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)