### PR TITLE
feat(lite): cap embedded worker concurrency — enforce the per-client burst envelope

### DIFF
--- a/charts/sinas/values-lite.yaml
+++ b/charts/sinas/values-lite.yaml
@@ -60,3 +60,20 @@ pgbouncer:
     requests:
       cpu: 25m
       memory: 32Mi
+
+## Embedded worker concurrency, capped for one small process (the full
+## profile spreads these across dedicated worker containers; in all-in-one
+## they share the backend pod and its memory limit — notably pipelines,
+## which default to 50 in their dedicated worker). Worst-case sandbox
+## memory ≈ (FUNCTION + AGENT + AGENT_SUB) × MAX_FUNCTION_MEMORY, and the
+## sandboxes are SEPARATE pods — budget them per client, not in this pod's
+## limit.
+extraEnv:
+  - name: QUEUE_FUNCTION_CONCURRENCY
+    value: "5"
+  - name: QUEUE_AGENT_CONCURRENCY
+    value: "3"
+  - name: QUEUE_AGENT_SUB_CONCURRENCY
+    value: "3"
+  - name: QUEUE_PIPELINE_CONCURRENCY
+    value: "5"

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -76,6 +76,15 @@ services:
       CODE_EXECUTION_ENABLED: ${CODE_EXECUTION_ENABLED:-false}
       DOCKER_NETWORK: ${DOCKER_NETWORK:-auto}
       FUNCTION_CONTAINER_IMAGE: ${IMAGE_REGISTRY:-ghcr.io/sinas-platform/sinas}/executor:${IMAGE_TAG:-latest}
+      # Embedded worker concurrency, capped for one small process. The full
+      # profile spreads these across dedicated worker containers; here they
+      # all share the API process and its memory limit. Worst-case sandbox
+      # memory ≈ (FUNCTION + AGENT + AGENT_SUB) × MAX_FUNCTION_MEMORY,
+      # spawned OUTSIDE this container — size the host for it.
+      QUEUE_FUNCTION_CONCURRENCY: ${QUEUE_FUNCTION_CONCURRENCY:-5}
+      QUEUE_AGENT_CONCURRENCY: ${QUEUE_AGENT_CONCURRENCY:-3}
+      QUEUE_AGENT_SUB_CONCURRENCY: ${QUEUE_AGENT_SUB_CONCURRENCY:-3}
+      QUEUE_PIPELINE_CONCURRENCY: ${QUEUE_PIPELINE_CONCURRENCY:-5}
       # No embedded builder — Component builds need a shared one.
       BUILDER_URL: ${BUILDER_URL:-}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set in .env file}


### PR DESCRIPTION
Found while doing the per-client sizing Ihor asked for: the lite profile embeds the queue workers at **full-profile defaults** — function 10, agent 5, sub 5, **pipeline 50**. Pipeline concurrency is sized for its dedicated worker process; in all-in-one it shares the API process and its 1Gi limit, and in-process pipeline steps are the one path that can balloon that process.

## Change
Capped embedded concurrency, overridable, in both surfaces:

| knob | full profile | lite default |
|---|---|---|
| function | 10 | **5** |
| agent | 5 | **3** |
| sub-agent | 5 | **3** |
| pipeline | 50 | **5** |

- `docker-compose.lite.yml`: env defaults (`${QUEUE_…:-N}`)
- `values-lite.yaml`: `extraEnv` (any Settings knob, no chart change needed)

## Why it matters for shared-fleet sizing
This turns the per-client worst case into an **enforced envelope**: concurrent sandboxes ≤ function+agent+sub = 11 × `MAX_FUNCTION_MEMORY` (512MB), spawned **outside** the lite process — the comments now direct operators to budget sandbox memory per client rather than inside the pod limit. Measured basis: the lite process itself is load-invariant (175→179MiB under a 30-deep execution burst); all burst memory lives in sandboxes and postgres.

## Verification
helm lint + template renders the caps; local lite restarted and picks up 5/3/3/5 via settings; sandbox execution still green post-restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)