### PR TITLE
Workbench: per-chat working tree unifying file tools and code execution

### DIFF
--- a/backend/alembic/versions/w1o2r3k4b5n6_collection_kind.py
+++ b/backend/alembic/versions/w1o2r3k4b5n6_collection_kind.py
@@ -1,0 +1,28 @@
+"""collections.kind: discriminate workbenches from user-facing collections
+
+Revision ID: w1o2r3k4b5n6
+Revises: m1e2t3v4p5d6
+Create Date: 2026-09-01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "w1o2r3k4b5n6"
+down_revision = "m1e2t3v4p5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # server_default keeps every existing row (and every writer that doesn't
+    # send the column) a plain collection — the field is purely additive.
+    op.add_column(
+        "collections",
+        sa.Column("kind", sa.String(length=20), nullable=False, server_default="collection"),
+    )
+    op.create_index("ix_collections_kind", "collections", ["kind"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_collections_kind", table_name="collections")
+    op.drop_column("collections", "kind")

--- a/backend/app/api/runtime/__init__.py
+++ b/backend/app/api/runtime/__init__.py
@@ -1,7 +1,7 @@
 """Runtime API - Data Plane for execution, authentication, and runtime state."""
 from fastapi import APIRouter
 
-from app.api.runtime.endpoints import batches, manifests, authentication, chats, components, discovery, executions, files, functions, info, oidc, pipelines, queries, stores, templates, webhooks
+from app.api.runtime.endpoints import batches, manifests, authentication, chats, components, discovery, executions, files, functions, info, oidc, pipelines, queries, stores, templates, webhooks, workbench
 
 runtime_router = APIRouter()
 
@@ -17,6 +17,9 @@ runtime_router.include_router(oidc.router, tags=["runtime-oidc"])
 
 # Chats - agent chat creation, message execution, and chat management
 runtime_router.include_router(chats.router, tags=["runtime-chats"])
+
+# Workbench - a chat's private working tree (uploads, browsing)
+runtime_router.include_router(workbench.router, tags=["runtime-workbench"])
 
 # Functions - function execution (sync and async)
 runtime_router.include_router(functions.router, tags=["runtime-functions"])

--- a/backend/app/api/runtime/endpoints/workbench.py
+++ b/backend/app/api/runtime/endpoints/workbench.py
@@ -1,0 +1,288 @@
+"""Runtime endpoints for a chat's workbench.
+
+The workbench is addressed exclusively through its chat — these endpoints
+are the only HTTP surface for it (workbench backing collections are fenced
+out of the collections/files APIs by kind). Authorization is chat
+ownership plus the agent chat permission, mirroring the other /chats
+endpoints; there is no collection permission involved.
+
+Front-ends use this to attach files to a conversation (uploads land in the
+workbench, not a collection — promote publishes them later) and to browse
+the tree the agent is working in.
+"""
+import base64
+import uuid as uuid_lib
+from datetime import datetime
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user_with_permissions, set_permission_used
+from app.core.config import settings
+from app.core.database import get_db
+from app.core.permissions import check_permission
+from app.models.chat import Chat
+from app.models.file import File, FileVersion
+from app.services.collection_tools import _infer_content_type
+from app.services.file_storage import get_storage
+from app.services.workbench import (
+    _validate_path,
+    _write_bytes,
+    get_or_create_workbench,
+    run_content_filter,
+)
+
+router = APIRouter(tags=["runtime-workbench"])
+
+
+class WorkbenchFileUpload(BaseModel):
+    """Upload into a chat's workbench. Unlike collection uploads, names are
+    relative paths ('data/input.csv') and visibility is always private."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    content_base64: str = Field(..., description="Base64-encoded file content")
+    content_type: Optional[str] = Field(None, max_length=255, description="Defaults to a guess from the extension")
+    file_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkbenchFileResponse(BaseModel):
+    name: str
+    content_type: str
+    current_version: int
+    size_bytes: Optional[int] = None
+    file_metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkbenchFileContent(BaseModel):
+    name: str
+    content_base64: str
+    content_type: str
+    version: int
+    file_metadata: dict[str, Any]
+
+
+async def _load_owned_chat(
+    chat_id: str,
+    http_request: Request,
+    db: AsyncSession,
+    current_user_data: tuple,
+) -> Chat:
+    """Resolve the chat, enforcing ownership + the agent chat permission."""
+    user_id, permissions = current_user_data
+    result = await db.execute(select(Chat).where(Chat.id == chat_id, Chat.user_id == user_id))
+    chat = result.scalar_one_or_none()
+    if not chat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found")
+
+    if chat.agent_namespace and chat.agent_name:
+        perm = f"sinas.agents/{chat.agent_namespace}/{chat.agent_name}.chat:all"
+        if not check_permission(permissions, perm):
+            set_permission_used(http_request, perm, has_perm=False)
+            raise HTTPException(
+                403, f"Not authorized to chat with agent '{chat.agent_namespace}/{chat.agent_name}'"
+            )
+        set_permission_used(http_request, perm)
+    return chat
+
+
+@router.get("/chats/{chat_id}/workbench/files", response_model=list[WorkbenchFileResponse])
+async def list_workbench_files(
+    chat_id: str,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """List the chat's workbench tree."""
+    chat = await _load_owned_chat(chat_id, http_request, db, current_user_data)
+    workbench = await get_or_create_workbench(db, chat)
+
+    rows = (
+        await db.execute(
+            select(File, FileVersion.size_bytes)
+            .outerjoin(
+                FileVersion,
+                (FileVersion.file_id == File.id)
+                & (FileVersion.version_number == File.current_version),
+            )
+            .where(File.collection_id == workbench.id)
+            .order_by(File.name)
+        )
+    ).all()
+    return [
+        WorkbenchFileResponse(
+            name=f.name,
+            content_type=f.content_type,
+            current_version=f.current_version,
+            size_bytes=size,
+            file_metadata=f.file_metadata or {},
+            created_at=f.created_at,
+            updated_at=f.updated_at,
+        )
+        for f, size in rows
+    ]
+
+
+@router.get("/chats/{chat_id}/workbench/files/{path:path}", response_model=WorkbenchFileContent)
+async def read_workbench_file(
+    chat_id: str,
+    path: str,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """Read one workbench file's current version (content as base64)."""
+    chat = await _load_owned_chat(chat_id, http_request, db, current_user_data)
+    workbench = await get_or_create_workbench(db, chat)
+
+    f = (
+        await db.execute(
+            select(File).where(File.collection_id == workbench.id, File.name == path)
+        )
+    ).scalar_one_or_none()
+    if not f:
+        raise HTTPException(status_code=404, detail=f"File '{path}' not found in workbench")
+    version = (
+        await db.execute(
+            select(FileVersion).where(
+                FileVersion.file_id == f.id,
+                FileVersion.version_number == f.current_version,
+            )
+        )
+    ).scalar_one_or_none()
+    if not version:
+        raise HTTPException(status_code=404, detail=f"File '{path}' has no stored version")
+    try:
+        content = await get_storage().read(version.storage_path)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Stored content for '{path}' is missing")
+    return WorkbenchFileContent(
+        name=f.name,
+        content_base64=base64.b64encode(content).decode(),
+        content_type=f.content_type,
+        version=f.current_version,
+        file_metadata=f.file_metadata or {},
+    )
+
+
+@router.post(
+    "/chats/{chat_id}/workbench/files",
+    response_model=WorkbenchFileResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_workbench_file(
+    chat_id: str,
+    file_data: WorkbenchFileUpload,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """Upload a file into the chat's workbench (always private).
+
+    When the deployment configures workbench_content_filter_function, the
+    filter runs before any bytes persist — the same guarantee collection
+    uploads have.
+    """
+    user_id, _permissions = current_user_data
+    chat = await _load_owned_chat(chat_id, http_request, db, current_user_data)
+
+    err = _validate_path(file_data.name)
+    if err:
+        raise HTTPException(status_code=400, detail=err)
+    try:
+        content = base64.b64decode(file_data.content_base64)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid base64 content: {e}")
+
+    # Metering leaf: same op as collection uploads
+    from app.services import metering
+
+    await metering.record(metering.OperationKind.UPLOAD)
+
+    content_type = file_data.content_type or _infer_content_type(file_data.name)
+
+    if settings.workbench_content_filter_function:
+        filter_err = await run_content_filter(
+            db,
+            settings.workbench_content_filter_function,
+            namespace="_chat",
+            collection_name=str(chat.id),
+            filename=file_data.name,
+            content=content,
+            content_type=content_type,
+            user_id=str(user_id),
+        )
+        if filter_err:
+            raise HTTPException(
+                status_code=422,
+                detail=filter_err.get("message") or filter_err.get("error", "Rejected by content filter"),
+            )
+
+    workbench = await get_or_create_workbench(db, chat)
+    result = await _write_bytes(
+        db,
+        get_storage(),
+        workbench,
+        filename=file_data.name,
+        content=content,
+        content_type=content_type,
+        user_id=str(user_id),
+        visibility="private",
+        file_metadata={**file_data.file_metadata, "origin": "upload"},
+    )
+    if "error" in result:
+        raise HTTPException(status_code=400, detail=result["error"])
+    await db.flush()
+
+    f = (
+        await db.execute(
+            select(File).where(File.collection_id == workbench.id, File.name == file_data.name)
+        )
+    ).scalar_one()
+    return WorkbenchFileResponse(
+        name=f.name,
+        content_type=f.content_type,
+        current_version=f.current_version,
+        size_bytes=len(content),
+        file_metadata=f.file_metadata or {},
+        created_at=f.created_at,
+        updated_at=f.updated_at,
+    )
+
+
+@router.delete("/chats/{chat_id}/workbench/files/{path:path}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_workbench_file(
+    chat_id: str,
+    path: str,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+):
+    """Delete a file from the chat's workbench."""
+    chat = await _load_owned_chat(chat_id, http_request, db, current_user_data)
+    workbench = await get_or_create_workbench(db, chat)
+
+    f = (
+        await db.execute(
+            select(File).where(File.collection_id == workbench.id, File.name == path)
+        )
+    ).scalar_one_or_none()
+    if not f:
+        raise HTTPException(status_code=404, detail=f"File '{path}' not found in workbench")
+
+    storage = get_storage()
+    versions = (
+        await db.execute(select(FileVersion).where(FileVersion.file_id == f.id))
+    ).scalars().all()
+    for ver in versions:
+        try:
+            await storage.delete(ver.storage_path)
+        except Exception:
+            pass
+    await db.delete(f)
+    await db.flush()
+    return None

--- a/backend/app/api/v1/endpoints/collections.py
+++ b/backend/app/api/v1/endpoints/collections.py
@@ -80,10 +80,11 @@ async def list_collections(
     """List all collections accessible to the user."""
     user_id, permissions = current_user_data
 
-    # Use mixin for permission-aware filtering
-    additional_filters = None
+    # Use mixin for permission-aware filtering. Workbenches (kind='workbench')
+    # are chat-scoped working trees, never listed here.
+    additional_filters = Collection.kind == "collection"
     if namespace:
-        additional_filters = Collection.namespace == namespace
+        additional_filters = and_(additional_filters, Collection.namespace == namespace)
 
     collections = await Collection.list_with_permissions(
         db=db,
@@ -119,6 +120,9 @@ async def get_collection(
         name=name,
     )
 
+    if collection.kind != "collection":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Collection not found")
+
     set_permission_used(request, f"sinas.collections/{namespace}/{name}.read")
 
     return CollectionResponse.model_validate(collection)
@@ -145,6 +149,9 @@ async def update_collection(
         namespace=namespace,
         name=name,
     )
+
+    if collection.kind != "collection":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Collection not found")
 
     set_permission_used(request, f"sinas.collections/{namespace}/{name}.update")
 
@@ -194,6 +201,9 @@ async def delete_collection(
         namespace=namespace,
         name=name,
     )
+
+    if collection.kind != "collection":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Collection not found")
 
     set_permission_used(request, f"sinas.collections/{namespace}/{name}.delete")
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -301,6 +301,10 @@ class Settings(BaseSettings):
     # than materialized; the total cap bounds one execution's transfer.
     workbench_sync_max_file_bytes: int = 2 * 1024 * 1024
     workbench_sync_max_total_bytes: int = 32 * 1024 * 1024
+    # Optional deployment-wide content filter ("namespace/name" of a Function)
+    # applied to workbench file uploads, mirroring collection content filters
+    # (e.g. the sensitive-image filter). Unset = uploads are not filtered.
+    workbench_content_filter_function: Optional[str] = None
 
     # Tool results above this many characters are truncated (structure-aware,
     # see services/tool_execution.truncate_tool_result) before they enter the

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -296,6 +296,12 @@ class Settings(BaseSettings):
     agent_job_timeout: int = 600  # Default timeout for agent jobs (10 minutes)
     code_execution_timeout: int = 120  # Default timeout for code execution (2 minutes)
 
+    # Workbench → sandbox sync caps (eager copy-in/copy-out per execution).
+    # Files above the per-file cap are reported to the code as skipped rather
+    # than materialized; the total cap bounds one execution's transfer.
+    workbench_sync_max_file_bytes: int = 2 * 1024 * 1024
+    workbench_sync_max_total_bytes: int = 32 * 1024 * 1024
+
     # Tool results above this many characters are truncated (structure-aware,
     # see services/tool_execution.truncate_tool_result) before they enter the
     # LLM context. Distinct from tool_result_max_size above, which caps what

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -305,6 +305,11 @@ class Settings(BaseSettings):
     # applied to workbench file uploads, mirroring collection content filters
     # (e.g. the sensitive-image filter). Unset = uploads are not filtered.
     workbench_content_filter_function: Optional[str] = None
+    # Lazy fetch: files above the eager cap materialize as stubs and are
+    # fetched on first read over the sandbox pause channel, bounded per fetch
+    # and per execution.
+    workbench_lazy_fetch_max_bytes: int = 64 * 1024 * 1024
+    workbench_lazy_fetch_max_calls: int = 100
 
     # Tool results above this many characters are truncated (structure-aware,
     # see services/tool_execution.truncate_tool_result) before they enter the

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -27,6 +27,13 @@ class Collection(Base, PermissionMixin):
         ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
+    # Discriminator: "collection" (user-facing, permission-governed) or
+    # "workbench" (a chat's working tree — reachable only via its chat,
+    # never through the collections API or collection permission grants).
+    kind: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="collection", server_default="collection", index=True
+    )
+
     # Metadata schema for files in this collection (JSON Schema format)
     metadata_schema: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict, nullable=False)
 
@@ -61,8 +68,14 @@ class Collection(Base, PermissionMixin):
 
     @classmethod
     async def get_by_name(cls, db: AsyncSession, namespace: str, name: str) -> Optional["Collection"]:
-        """Get collection by namespace and name."""
-        result = await db.execute(select(cls).where(cls.namespace == namespace, cls.name == name))
+        """Get a user-facing collection by namespace and name.
+
+        Workbench rows (kind='workbench') are never resolvable by name — they
+        are reached exclusively through their chat.
+        """
+        result = await db.execute(
+            select(cls).where(cls.namespace == namespace, cls.name == name, cls.kind == "collection")
+        )
         return result.scalar_one_or_none()
 
 

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -128,7 +128,8 @@ class AgentCreate(BaseModel):
             "Opt-in Sinas platform tools. Simple string for tools with no config, "
             "or {name, ...config} for tools that need parameters. "
             "Supported: 'codeExecution', 'packageManagement', 'configIntrospection', "
-            "'databaseIntrospection' (requires connections list)."
+            "'databaseIntrospection' (requires connections list), 'workbench' "
+            "(per-chat persistent working tree)."
         ),
     )
 

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -224,7 +224,8 @@ class AgentConfig(BaseModel):
         description=(
             "Opt-in Sinas platform tools. Simple string or {name, ...config}. "
             "Supported: 'codeExecution', 'packageManagement', 'configIntrospection', "
-            "'databaseIntrospection' (requires connections list)."
+            "'databaseIntrospection' (requires connections list), 'workbench' "
+            "(per-chat persistent working tree)."
         ),
     )
 

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -305,15 +305,46 @@ async def execute(
     # Default: a reusable container from the warm pool.
     from app.services.container_pool import container_pool
 
-    pc = await container_pool.acquire()
+    pc = await container_pool.acquire(chat_id=chat_id)
     logger.info(f"Acquired sandbox container {pc.name} for code execution (chat={chat_id})")
+
+    # Delta copy-in: blobs this container has already seen ride as cached
+    # references instead of bytes (a wiped cache degrades to lazy fetch in
+    # the wrapper, so this is purely an optimization).
+    shipped_hashes: set[str] = set()
+    eager_files = workbench_input.get("workbench_files") or []
+    if eager_files:
+        delta_files = []
+        for entry in eager_files:
+            sha = entry.get("sha256")
+            if sha:
+                shipped_hashes.add(sha)
+            if sha and sha in pc.known_hashes:
+                delta_files.append({"path": entry["path"], "sha256": sha, "cached": True})
+            else:
+                delta_files.append(entry)
+        payload["input_data"] = {**workbench_input, "workbench_files": delta_files}
+
+    pool_fetch_handler = fetch_handler
+    if fetch_handler is not None:
+
+        async def pool_fetch_handler(path: str) -> dict[str, Any]:
+            resp = await fetch_handler(path)
+            # The wrapper caches fetched blobs too — remember them so the
+            # next execution on this container ships a reference.
+            if resp.get("sha256"):
+                pc.known_hashes.add(resp["sha256"])
+            return resp
+
     tainted = False
     try:
         container = await asyncio.to_thread(container_pool.client.containers.get, pc.name)
         result = await _run_code_payload(
             container, payload, execution_id, effective_timeout, start_time,
-            fetch_handler=fetch_handler,
+            fetch_handler=pool_fetch_handler,
         )
+        if result.get("error") is None:
+            pc.known_hashes.update(shipped_hashes)
         # Discard the container if the run errored (avoid handing leaked state on).
         if result.get("error") is not None:
             tainted = True
@@ -482,16 +513,55 @@ def _build_wrapper(user_code: str, workbench: bool = False) -> str:
     _wb_lazy_unfetched = set()
     _wb_root = _tempfile.mkdtemp(prefix="workbench_")
     _wb_old_cwd = _os.getcwd()
+    _wb_cache_dir = "/tmp/wb_cache"
+
+    def _wb_cache_put(sha, data):
+        try:
+            _os.makedirs(_wb_cache_dir, exist_ok=True)
+            _cp = _os.path.join(_wb_cache_dir, sha)
+            if not _os.path.exists(_cp):
+                with _wb_real_open(_cp + ".tmp", "wb") as _fh:
+                    _fh.write(data)
+                _os.replace(_cp + ".tmp", _cp)
+            # Bounded cache: drop oldest blobs beyond 256 entries.
+            _entries = sorted(
+                (_os.path.join(_wb_cache_dir, _n) for _n in _os.listdir(_wb_cache_dir)),
+                key=lambda _e: _os.path.getmtime(_e),
+            )
+            for _old in _entries[:-256]:
+                try:
+                    _os.remove(_old)
+                except OSError:
+                    pass
+        except OSError:
+            pass  # cache is an optimization; never fail the run over it
+
+    _wb_real_open = _builtins.open
     for _f in _wb_files:
         _p = _os.path.join(_wb_root, _f["path"])
         _os.makedirs(_os.path.dirname(_p), exist_ok=True)
-        with open(_p, "wb") as _fh:
-            _fh.write(_b64.b64decode(_f["content_b64"]))
-        _wb_hashes[_f["path"]] = _f["sha256"]
+        if _f.get("cached"):
+            # Delta copy-in: the backend believes this container already
+            # holds the blob. A cache miss (restarted/wiped container)
+            # degrades to a lazy stub — fetched on first read.
+            _cp = _os.path.join(_wb_cache_dir, _f["sha256"])
+            if _os.path.exists(_cp):
+                _shutil.copyfile(_cp, _p)
+                _wb_hashes[_f["path"]] = _f["sha256"]
+            else:
+                with _wb_real_open(_p, "wb"):
+                    pass
+                _wb_lazy_unfetched.add(_f["path"])
+        else:
+            _data = _b64.b64decode(_f["content_b64"])
+            with _wb_real_open(_p, "wb") as _fh:
+                _fh.write(_data)
+            _wb_hashes[_f["path"]] = _f["sha256"]
+            _wb_cache_put(_f["sha256"], _data)
     for _f in _wb_lazy:
         _p = _os.path.join(_wb_root, _f["path"])
         _os.makedirs(_os.path.dirname(_p), exist_ok=True)
-        with open(_p, "wb"):
+        with _wb_real_open(_p, "wb"):
             pass  # stub — real bytes arrive on first read via workbench_fetch
         _wb_lazy_unfetched.add(_f["path"])
     _os.chdir(_wb_root)
@@ -529,12 +599,12 @@ def _build_wrapper(user_code: str, workbench: bool = False) -> str:
                     _fh.write(_bytes)
                 _os.replace(_full + ".tmp", _full)
                 _wb_lazy_unfetched.discard(_rel)
-                _wb_hashes[_rel] = _data.get("sha256") or _hashlib.sha256(_bytes).hexdigest()
+                _wb_sha = _data.get("sha256") or _hashlib.sha256(_bytes).hexdigest()
+                _wb_hashes[_rel] = _wb_sha
+                _wb_cache_put(_wb_sha, _bytes)
                 return path
             _time.sleep(0.1)
         raise TimeoutError("workbench fetch of '" + _rel + "' timed out")
-
-    _wb_real_open = _builtins.open
 
     def _wb_open(file, *args, **kwargs):
         _rel = None

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -116,8 +116,76 @@ async def execute(
         }
     start_time = time.time()
 
+    # Workbench sync (copy-in): when the chat's agent opted into the
+    # workbench, materialize its tree into this execution and persist
+    # changes back afterwards (see _finalize_workbench below).
+    workbench_input: dict[str, Any] = {}
+    workbench_skipped_in: list[dict[str, Any]] = []
+    workbench_chat_id: Optional[str] = None
+    if chat_id:
+        from sqlalchemy import select as _select
+
+        from app.core.database import AsyncSessionLocal as _SessionLocal
+        from app.models.chat import Chat as _Chat
+        from app.services import workbench as workbench_service
+
+        try:
+            async with _SessionLocal() as _db:
+                _chat = (
+                    await _db.execute(_select(_Chat).where(_Chat.id == chat_id))
+                ).scalar_one_or_none()
+                if _chat and await workbench_service.chat_has_workbench_enabled(_db, _chat):
+                    manifest = await workbench_service.build_sync_manifest(_db, _chat)
+                    await _db.commit()  # get_or_create may have inserted the workbench row
+                    workbench_chat_id = str(_chat.id)
+                    workbench_skipped_in = manifest["skipped"]
+                    workbench_input = {
+                        "workbench_files": manifest["files"],
+                        "workbench_limits": {
+                            "max_file_bytes": settings.workbench_sync_max_file_bytes,
+                            "max_total_bytes": settings.workbench_sync_max_total_bytes,
+                        },
+                    }
+        except Exception as e:
+            logger.error(f"Workbench copy-in failed for chat {chat_id}: {e}")
+
+    async def _finalize_workbench(res: dict[str, Any]) -> dict[str, Any]:
+        """Copy-out: persist created/changed files, strip the blob payload."""
+        if workbench_chat_id is None:
+            return res
+        inner = res.get("result")
+        if not isinstance(inner, dict):
+            return res
+        changes = inner.pop("workbench_changes", None)
+        return_skipped = inner.pop("workbench_return_skipped", None)
+        info: dict[str, Any] = {}
+        if changes:
+            try:
+                async with _SessionLocal() as _db:
+                    _chat = (
+                        await _db.execute(_select(_Chat).where(_Chat.id == workbench_chat_id))
+                    ).scalar_one_or_none()
+                    if _chat:
+                        sync = await workbench_service.apply_sync_changes(
+                            _db, _chat, str(_chat.user_id), changes
+                        )
+                        await _db.commit()
+                        info["synced"] = sync["synced"]
+                        if sync["rejected"]:
+                            info["rejected"] = sync["rejected"]
+            except Exception as e:
+                logger.error(f"Workbench copy-out failed for chat {workbench_chat_id}: {e}")
+                info["error"] = f"Failed to persist workbench changes: {e}"
+        if workbench_skipped_in:
+            info["not_materialized"] = workbench_skipped_in
+        if return_skipped:
+            info["not_synced_back"] = return_skipped
+        if info:
+            res["workbench"] = info
+        return res
+
     # Wrap the user code so we capture stdout and the last expression result.
-    wrapper_code = _build_wrapper(code)
+    wrapper_code = _build_wrapper(code, workbench=workbench_chat_id is not None)
 
     payload = {
         "action": "execute_inline",
@@ -126,7 +194,7 @@ async def execute(
         "function_namespace": "_code_execution",
         "function_name": "handler",
         "timeout": effective_timeout,
-        "input_data": {},
+        "input_data": workbench_input,
         "context": {
             "user_id": user_id or "",
             "user_email": "",
@@ -172,8 +240,8 @@ async def execute(
                 wire = await run_payload_in_pod(
                     name, namespace, payload, effective_timeout
                 )
-                return _shape_code_result(
-                    wire, int((time.time() - start_time) * 1000)
+                return await _finalize_workbench(
+                    _shape_code_result(wire, int((time.time() - start_time) * 1000))
                 )
             finally:
                 await delete_sandbox_pod(name, namespace)
@@ -194,8 +262,10 @@ async def execute(
                     db, execution_id=execution_id
                 )
             try:
-                return await _run_code_payload(
-                    container, payload, execution_id, effective_timeout, start_time
+                return await _finalize_workbench(
+                    await _run_code_payload(
+                        container, payload, execution_id, effective_timeout, start_time
+                    )
                 )
             finally:
                 await remove_ephemeral_container(container, name)
@@ -216,7 +286,7 @@ async def execute(
         # Discard the container if the run errored (avoid handing leaked state on).
         if result.get("error") is not None:
             tainted = True
-        return result
+        return await _finalize_workbench(result)
     except Exception as e:
         tainted = True
         return _error(e)
@@ -337,11 +407,74 @@ def _shape_code_result(
     }
 
 
-def _build_wrapper(user_code: str) -> str:
-    """Wrap user code to capture stdout and the last expression result."""
+def _build_wrapper(user_code: str, workbench: bool = False) -> str:
+    """Wrap user code to capture stdout and the last expression result.
+
+    With workbench=True the wrapper materializes the chat's workbench files
+    (passed via input_data) into a fresh temp directory, chdirs into it for
+    the user code, and afterwards reports created/changed files back (by
+    sha256 diff) as output["workbench_changes"] for the backend to persist.
+    The temp tree is always removed — pooled containers must not leak one
+    chat's files into the next execution.
+    """
     # The wrapper captures stdout and evaluates the code, trying to capture
     # the last expression as a result value.
     user_code_repr = repr(user_code)
+    workbench_setup = ""
+    workbench_teardown = ""
+    if workbench:
+        workbench_setup = '''
+    import os as _os, base64 as _b64, hashlib as _hashlib, shutil as _shutil, tempfile as _tempfile
+    _wb_files = (input_data or {}).get("workbench_files") or []
+    _wb_limits = (input_data or {}).get("workbench_limits") or {}
+    _wb_hashes = {}
+    _wb_root = _tempfile.mkdtemp(prefix="workbench_")
+    _wb_old_cwd = _os.getcwd()
+    for _f in _wb_files:
+        _p = _os.path.join(_wb_root, _f["path"])
+        _os.makedirs(_os.path.dirname(_p), exist_ok=True)
+        with open(_p, "wb") as _fh:
+            _fh.write(_b64.b64decode(_f["content_b64"]))
+        _wb_hashes[_f["path"]] = _f["sha256"]
+    _os.chdir(_wb_root)
+'''
+        workbench_teardown = '''
+    _wb_changes = []
+    _wb_return_skipped = []
+    try:
+        _max_file = int(_wb_limits.get("max_file_bytes") or 2 * 1024 * 1024)
+        _max_total = int(_wb_limits.get("max_total_bytes") or 32 * 1024 * 1024)
+        _total = 0
+        for _dirpath, _dirnames, _filenames in _os.walk(_wb_root):
+            _dirnames[:] = [_d for _d in _dirnames if not _d.startswith(".")]
+            for _fn in _filenames:
+                _full = _os.path.join(_dirpath, _fn)
+                _rel = _os.path.relpath(_full, _wb_root).replace(_os.sep, "/")
+                if _os.path.islink(_full):
+                    continue
+                _size = _os.path.getsize(_full)
+                if _size > _max_file or _total + _size > _max_total:
+                    _wb_return_skipped.append({"path": _rel, "size_bytes": _size})
+                    continue
+                with open(_full, "rb") as _fh:
+                    _data = _fh.read()
+                _digest = _hashlib.sha256(_data).hexdigest()
+                if _wb_hashes.get(_rel) == _digest:
+                    continue
+                _total += _size
+                _wb_changes.append({"path": _rel, "content_b64": _b64.b64encode(_data).decode()})
+    except Exception as _wb_exc:
+        _wb_return_skipped.append({"path": "<walk>", "error": str(_wb_exc)})
+    finally:
+        try:
+            _os.chdir(_wb_old_cwd)
+        except Exception:
+            _os.chdir("/tmp")
+        _shutil.rmtree(_wb_root, ignore_errors=True)
+    output["workbench_changes"] = _wb_changes
+    if _wb_return_skipped:
+        output["workbench_return_skipped"] = _wb_return_skipped
+'''
     return f'''
 import sys, io, json, traceback
 
@@ -356,7 +489,7 @@ def handler(input_data, context):
 
     result = None
     error = None
-
+{workbench_setup}
     try:
         user_code = {user_code_repr}
         # Try to split into statements and eval the last one for a result
@@ -383,6 +516,7 @@ def handler(input_data, context):
         "stdout": captured_stdout.getvalue(),
         "stderr": captured_stderr.getvalue(),
     }}
+{workbench_teardown}
     if error:
         output["error"] = error
         output["status"] = "failed"

--- a/backend/app/services/code_execution.py
+++ b/backend/app/services/code_execution.py
@@ -121,6 +121,7 @@ async def execute(
     # changes back afterwards (see _finalize_workbench below).
     workbench_input: dict[str, Any] = {}
     workbench_skipped_in: list[dict[str, Any]] = []
+    workbench_lazy: list[dict[str, Any]] = []
     workbench_chat_id: Optional[str] = None
     if chat_id:
         from sqlalchemy import select as _select
@@ -139,8 +140,12 @@ async def execute(
                     await _db.commit()  # get_or_create may have inserted the workbench row
                     workbench_chat_id = str(_chat.id)
                     workbench_skipped_in = manifest["skipped"]
+                    workbench_lazy = manifest["lazy"]
                     workbench_input = {
                         "workbench_files": manifest["files"],
+                        "workbench_lazy": [
+                            {"path": e["path"]} for e in manifest["lazy"]
+                        ],
                         "workbench_limits": {
                             "max_file_bytes": settings.workbench_sync_max_file_bytes,
                             "max_total_bytes": settings.workbench_sync_max_total_bytes,
@@ -148,6 +153,26 @@ async def execute(
                     }
         except Exception as e:
             logger.error(f"Workbench copy-in failed for chat {chat_id}: {e}")
+
+    async def _fetch_workbench_file(path: str) -> dict[str, Any]:
+        """Serve a lazy-fetch request from the sandbox (pause-channel handler)."""
+        if workbench_chat_id is None:
+            return {"path": path, "error": "no workbench bound to this execution"}
+        try:
+            async with _SessionLocal() as _db:
+                _chat = (
+                    await _db.execute(_select(_Chat).where(_Chat.id == workbench_chat_id))
+                ).scalar_one_or_none()
+                if not _chat:
+                    return {"path": path, "error": "chat not found"}
+                return await workbench_service.fetch_file_bytes(
+                    _db, _chat, path, settings.workbench_lazy_fetch_max_bytes
+                )
+        except Exception as e:
+            logger.error(f"Workbench lazy fetch failed for chat {workbench_chat_id}: {e}")
+            return {"path": path, "error": f"fetch failed: {e}"}
+
+    fetch_handler = _fetch_workbench_file if chat_id else None
 
     async def _finalize_workbench(res: dict[str, Any]) -> dict[str, Any]:
         """Copy-out: persist created/changed files, strip the blob payload."""
@@ -178,6 +203,10 @@ async def execute(
                 info["error"] = f"Failed to persist workbench changes: {e}"
         if workbench_skipped_in:
             info["not_materialized"] = workbench_skipped_in
+        if workbench_lazy:
+            info["lazy"] = [
+                {"path": e["path"], "size_bytes": e["size_bytes"]} for e in workbench_lazy
+            ]
         if return_skipped:
             info["not_synced_back"] = return_skipped
         if info:
@@ -238,7 +267,7 @@ async def execute(
                 )
             try:
                 wire = await run_payload_in_pod(
-                    name, namespace, payload, effective_timeout
+                    name, namespace, payload, effective_timeout, fetch_handler=fetch_handler
                 )
                 return await _finalize_workbench(
                     _shape_code_result(wire, int((time.time() - start_time) * 1000))
@@ -264,7 +293,8 @@ async def execute(
             try:
                 return await _finalize_workbench(
                     await _run_code_payload(
-                        container, payload, execution_id, effective_timeout, start_time
+                        container, payload, execution_id, effective_timeout, start_time,
+                        fetch_handler=fetch_handler,
                     )
                 )
             finally:
@@ -281,7 +311,8 @@ async def execute(
     try:
         container = await asyncio.to_thread(container_pool.client.containers.get, pc.name)
         result = await _run_code_payload(
-            container, payload, execution_id, effective_timeout, start_time
+            container, payload, execution_id, effective_timeout, start_time,
+            fetch_handler=fetch_handler,
         )
         # Discard the container if the run errored (avoid handing leaked state on).
         if result.get("error") is not None:
@@ -294,96 +325,112 @@ async def execute(
         await asyncio.to_thread(container_pool.release, pc.name, tainted=tainted)
 
 
-async def _run_code_payload(
-    container,
-    payload: dict[str, Any],
-    execution_id: str,
-    effective_timeout: int,
-    start_time: float,
-) -> dict[str, Any]:
-    """Run a code-execution payload in `container` and parse the result.
-
-    Shared by the pooled and ephemeral code-execution paths; only the container
-    lifecycle around this call differs. Raises on Docker/infra errors (callers
-    convert those to an error result).
-    """
+def _write_file_into_container(container, path: str, data: bytes) -> None:
+    """Write bytes to a path inside the container via a stdin pipe (atomic:
+    written to a temp path, then renamed)."""
     import socket as _sock_mod
 
-    eid = execution_id
-    request_path = f"/tmp/exec_request_{eid}.json"
-    trigger_file = f"/tmp/exec_trigger_{eid}"
-    result_file = f"/tmp/exec_result_{eid}.json"
-
-    # Write the request into the container via a stdin pipe.
-    payload_bytes = json.dumps(payload).encode("utf-8")
     api = container.client.api
     exec_id = api.exec_create(
         container.id,
         [
             "python3", "-c",
-            f'import sys; open("{request_path}","wb").write(sys.stdin.buffer.read())',
+            f'import sys, os; open("{path}.tmp","wb").write(sys.stdin.buffer.read()); '
+            f'os.replace("{path}.tmp", "{path}")',
         ],
         stdin=True,
         stdout=True,
         stderr=True,
     )["Id"]
     sock = api.exec_start(exec_id, socket=True)
-    sock._sock.sendall(payload_bytes)
+    sock._sock.sendall(data)
     sock._sock.shutdown(_sock_mod.SHUT_WR)
     sock.read()
     sock.close()
 
-    exec_result = await asyncio.to_thread(
-        container.exec_run,
-        cmd=[
-            "python3",
-            "-c",
-            f"""
-import sys, json, time, os
-with open("{trigger_file}", "w") as f:
-    f.write("1")
-max_wait = {effective_timeout}
-start = time.time()
-while time.time() - start < max_wait:
-    if os.path.exists("{result_file}"):
-        with open("{result_file}", "r") as f:
-            data = json.load(f)
-        os.remove("{result_file}")
-        print(json.dumps(data))
-        sys.exit(0)
-    time.sleep(0.1)
-print(json.dumps({{"status": "failed", "error": "Execution timed out"}}))
-sys.exit(1)
-""",
-        ],
-        stdout=True,
-        stderr=True,
+
+async def _run_code_payload(
+    container,
+    payload: dict[str, Any],
+    execution_id: str,
+    effective_timeout: int,
+    start_time: float,
+    fetch_handler=None,
+) -> dict[str, Any]:
+    """Run a code-execution payload in `container` and parse the result.
+
+    Shared by the pooled and ephemeral code-execution paths; only the
+    container lifecycle around this call differs. While the execution runs,
+    the wrapper may request workbench files over the pause channel; each
+    request is served through `fetch_handler` and the wait re-entered.
+    Raises on Docker/infra errors (callers convert those to an error result).
+    """
+    from app.services.executor._wire import (
+        build_wait_script,
+        fetch_response_path,
+        parse_wait_output,
     )
 
-    duration_ms = int((time.time() - start_time) * 1000)
+    eid = execution_id
+    request_path = f"/tmp/exec_request_{eid}.json"
 
-    if exec_result.exit_code != 0:
-        stderr_output = exec_result.output.decode("utf-8", errors="replace") if exec_result.output else ""
-        return {
-            "stdout": "",
-            "stderr": stderr_output,
-            "result": None,
-            "duration_ms": duration_ms,
-            "error": "Code execution failed",
-        }
+    await asyncio.to_thread(
+        _write_file_into_container, container, request_path, json.dumps(payload).encode("utf-8")
+    )
 
-    raw_output = exec_result.output.decode("utf-8", errors="replace") if exec_result.output else "{}"
-    try:
-        result_data = json.loads(raw_output.strip())
-    except json.JSONDecodeError:
-        return {
-            "stdout": raw_output,
-            "stderr": "",
-            "result": None,
-            "duration_ms": duration_ms,
-        }
+    deadline = time.time() + effective_timeout
+    first_wait = True
+    fetches_served = 0
+    while True:
+        remaining = max(1.0, deadline - time.time())
+        exec_result = await asyncio.to_thread(
+            container.exec_run,
+            cmd=["python3", "-c", build_wait_script(eid, remaining, write_trigger=first_wait)],
+            stdout=True,
+            stderr=True,
+        )
+        first_wait = False
+        duration_ms = int((time.time() - start_time) * 1000)
+        raw_output = (
+            exec_result.output.decode("utf-8", errors="replace") if exec_result.output else ""
+        )
+        envelope = parse_wait_output(raw_output)
 
-    return _shape_code_result(result_data, duration_ms)
+        if envelope is None:
+            if exec_result.exit_code != 0:
+                return {
+                    "stdout": "",
+                    "stderr": raw_output,
+                    "result": None,
+                    "duration_ms": duration_ms,
+                    "error": "Code execution failed",
+                }
+            return {
+                "stdout": raw_output,
+                "stderr": "",
+                "result": None,
+                "duration_ms": duration_ms,
+            }
+
+        if envelope["kind"] == "fetch":
+            req = envelope.get("req") or {}
+            path = req.get("path", "")
+            fetches_served += 1
+            if fetch_handler is None:
+                resp: dict[str, Any] = {"path": path, "error": "lazy fetch is not available"}
+            elif fetches_served > settings.workbench_lazy_fetch_max_calls:
+                resp = {"path": path, "error": "lazy fetch call limit reached for this execution"}
+            else:
+                resp = await fetch_handler(path)
+            await asyncio.to_thread(
+                _write_file_into_container,
+                container,
+                fetch_response_path(eid),
+                json.dumps(resp).encode("utf-8"),
+            )
+            continue
+
+        return _shape_code_result(envelope["data"], duration_ms)
 
 
 def _shape_code_result(
@@ -424,10 +471,15 @@ def _build_wrapper(user_code: str, workbench: bool = False) -> str:
     workbench_teardown = ""
     if workbench:
         workbench_setup = '''
-    import os as _os, base64 as _b64, hashlib as _hashlib, shutil as _shutil, tempfile as _tempfile
+    import builtins as _builtins
+    import io as _io
+    import os as _os, base64 as _b64, hashlib as _hashlib, shutil as _shutil, tempfile as _tempfile, time as _time
     _wb_files = (input_data or {}).get("workbench_files") or []
+    _wb_lazy = (input_data or {}).get("workbench_lazy") or []
     _wb_limits = (input_data or {}).get("workbench_limits") or {}
+    _wb_eid = (context or {}).get("execution_id", "")
     _wb_hashes = {}
+    _wb_lazy_unfetched = set()
     _wb_root = _tempfile.mkdtemp(prefix="workbench_")
     _wb_old_cwd = _os.getcwd()
     for _f in _wb_files:
@@ -436,9 +488,79 @@ def _build_wrapper(user_code: str, workbench: bool = False) -> str:
         with open(_p, "wb") as _fh:
             _fh.write(_b64.b64decode(_f["content_b64"]))
         _wb_hashes[_f["path"]] = _f["sha256"]
+    for _f in _wb_lazy:
+        _p = _os.path.join(_wb_root, _f["path"])
+        _os.makedirs(_os.path.dirname(_p), exist_ok=True)
+        with open(_p, "wb"):
+            pass  # stub — real bytes arrive on first read via workbench_fetch
+        _wb_lazy_unfetched.add(_f["path"])
     _os.chdir(_wb_root)
+
+    def workbench_fetch(path, _timeout=120):
+        """Fetch a lazy workbench file's real bytes from the backend.
+
+        Reads of lazy files through open() call this automatically; call it
+        explicitly before handing a lazy path to native code (numpy.memmap,
+        database engines) that bypasses Python's open().
+        """
+        _rel = _os.path.relpath(_os.path.abspath(path), _wb_root).replace(_os.sep, "/")
+        if _rel not in _wb_lazy_unfetched:
+            return path
+        _req = "/tmp/wb_fetch_req_" + _wb_eid + ".json"
+        _resp = "/tmp/wb_fetch_resp_" + _wb_eid + ".json"
+        with open(_req + ".tmp", "w") as _fh:
+            json.dump({"path": _rel}, _fh)
+        _os.replace(_req + ".tmp", _req)
+        _deadline = _time.time() + _timeout
+        while _time.time() < _deadline:
+            if _os.path.exists(_resp):
+                try:
+                    with open(_resp) as _fh:
+                        _data = json.load(_fh)
+                except (ValueError, OSError):
+                    _time.sleep(0.05)
+                    continue
+                _os.remove(_resp)
+                if _data.get("error"):
+                    raise IOError("workbench fetch of '" + _rel + "' failed: " + str(_data["error"]))
+                _bytes = _b64.b64decode(_data.get("content_b64", ""))
+                _full = _os.path.join(_wb_root, _rel)
+                with open(_full + ".tmp", "wb") as _fh:
+                    _fh.write(_bytes)
+                _os.replace(_full + ".tmp", _full)
+                _wb_lazy_unfetched.discard(_rel)
+                _wb_hashes[_rel] = _data.get("sha256") or _hashlib.sha256(_bytes).hexdigest()
+                return path
+            _time.sleep(0.1)
+        raise TimeoutError("workbench fetch of '" + _rel + "' timed out")
+
+    _wb_real_open = _builtins.open
+
+    def _wb_open(file, *args, **kwargs):
+        _rel = None
+        if isinstance(file, (str, bytes, _os.PathLike)) and _wb_lazy_unfetched:
+            try:
+                _fp = _os.fsdecode(file)
+                _rel = _os.path.relpath(_os.path.abspath(_fp), _wb_root).replace(_os.sep, "/")
+            except (OSError, ValueError, TypeError):
+                _rel = None
+        if _rel is not None and _rel in _wb_lazy_unfetched:
+            _mode = args[0] if args else kwargs.get("mode", "r")
+            # A plain overwrite ("w"/"x") doesn't need the old bytes; any
+            # other mode must fetch first — and a failed fetch must raise,
+            # never fall through to the empty stub.
+            if any(_c in str(_mode) for _c in ("r", "a", "+")):
+                workbench_fetch(_fp)
+            else:
+                _wb_lazy_unfetched.discard(_rel)
+        return _wb_real_open(file, *args, **kwargs)
+
+    _builtins.open = _wb_open
+    _io.open = _wb_open
 '''
         workbench_teardown = '''
+    _builtins.open = _wb_real_open
+    _io.open = _wb_real_open
     _wb_changes = []
     _wb_return_skipped = []
     try:
@@ -451,6 +573,9 @@ def _build_wrapper(user_code: str, workbench: bool = False) -> str:
                 _full = _os.path.join(_dirpath, _fn)
                 _rel = _os.path.relpath(_full, _wb_root).replace(_os.sep, "/")
                 if _os.path.islink(_full):
+                    continue
+                if _rel in _wb_lazy_unfetched:
+                    # Still a stub — the empty bytes are not the file's state.
                     continue
                 _size = _os.path.getsize(_full)
                 if _size > _max_file or _total + _size > _max_total:

--- a/backend/app/services/collection_tools.py
+++ b/backend/app/services/collection_tools.py
@@ -109,14 +109,16 @@ class CollectionToolConverter:
                 continue
 
             if coll_ref == "*/*":
-                result = await db.execute(select(Collection))
+                result = await db.execute(select(Collection).where(Collection.kind == "collection"))
                 for c in result.scalars().all():
                     if c.id not in seen_ids:
                         seen_ids.add(c.id)
                         expanded_entries.append((f"{c.namespace}/{c.name}", access, c))
             elif coll_ref.endswith("/*"):
                 ns = coll_ref[:-2]
-                result = await db.execute(select(Collection).where(Collection.namespace == ns))
+                result = await db.execute(
+                    select(Collection).where(Collection.namespace == ns, Collection.kind == "collection")
+                )
                 for c in result.scalars().all():
                     if c.id not in seen_ids:
                         seen_ids.add(c.id)
@@ -571,8 +573,13 @@ class CollectionToolConverter:
         namespace: str,
         user_id: str,
         arguments: dict[str, Any],
+        visibility: str = "shared",
     ) -> dict[str, Any]:
-        """Write content to a file, creating a new version if it exists."""
+        """Write content to a file, creating a new version if it exists.
+
+        visibility applies to newly created files only ("shared" keeps the
+        historical tool behavior; workbench writes pass "private").
+        """
         import uuid as uuid_lib
         filename = arguments.get("filename")
         content = arguments.get("content")
@@ -616,7 +623,7 @@ class CollectionToolConverter:
                 content_type=content_type,
                 current_version=1,
                 file_metadata={},
-                visibility="shared",
+                visibility=visibility,
             )
             db.add(file_record)
             created = True

--- a/backend/app/services/config_apply/resources.py
+++ b/backend/app/services/config_apply/resources.py
@@ -672,6 +672,7 @@ async def apply_collections(
             stmt = select(Collection).where(
                 Collection.namespace == coll_config.namespace,
                 Collection.name == coll_config.name,
+                Collection.kind == "collection",
             )
             result = await db.execute(stmt)
             existing = result.scalar_one_or_none()

--- a/backend/app/services/config_export.py
+++ b/backend/app/services/config_export.py
@@ -286,7 +286,7 @@ class ConfigExportService:
 
     async def _export_collections(self) -> list[dict]:
         """Export collections"""
-        stmt = select(Collection)
+        stmt = select(Collection).where(Collection.kind == "collection")
         if self.managed_only:
             stmt = stmt.where(Collection.managed_by == self.managed_by)
         result = await self.db.execute(stmt)

--- a/backend/app/services/container_pool.py
+++ b/backend/app/services/container_pool.py
@@ -30,6 +30,12 @@ class PooledContainer:
     container_id: str
     executions: int = 0
     created_at: float = field(default_factory=time.time)
+    # Workbench sync bookkeeping: the chat this container last served (for
+    # acquire affinity) and the content hashes of workbench blobs already
+    # shipped into its /tmp/wb_cache (for delta copy-in). Both are best-effort
+    # hints — a wiped container degrades to lazy fetch, never to wrong data.
+    last_chat_id: Optional[str] = None
+    known_hashes: set = field(default_factory=set)
 
 
 class ContainerPool:
@@ -265,12 +271,17 @@ class ContainerPool:
     # Acquire / Release
     # ------------------------------------------------------------------
 
-    async def acquire(self, timeout: Optional[int] = None) -> PooledContainer:
+    async def acquire(
+        self, timeout: Optional[int] = None, chat_id: Optional[str] = None
+    ) -> PooledContainer:
         """
         Acquire an idle container from the pool.
 
         Waits up to `timeout` seconds if none available. Signals
-        replenishment when the pool is low.
+        replenishment when the pool is low. When `chat_id` is given, an idle
+        container that last served the same chat is preferred — its
+        workbench blob cache is warm, so the delta copy-in ships nothing
+        the container has already seen.
         """
         if timeout is None:
             timeout = settings.sandbox_acquire_timeout
@@ -294,6 +305,16 @@ class ContainerPool:
                         f"No sandbox container available within {timeout}s "
                         f"(idle=0, in_use={len(self.in_use)})"
                     )
+
+            # Affinity: move the container that last served this chat to the
+            # front, so the pop below prefers it (falling through to the
+            # normal order if it turns out dead).
+            if chat_id:
+                for candidate in self.idle:
+                    if candidate.last_chat_id == chat_id:
+                        self.idle.remove(candidate)
+                        self.idle.appendleft(candidate)
+                        break
 
             # Pop idle containers, skipping any that no longer exist in Docker
             pc = None
@@ -329,6 +350,8 @@ class ContainerPool:
                 else:
                     raise TimeoutError("No sandbox container available after replenish")
 
+            if chat_id:
+                pc.last_chat_id = chat_id
             self.in_use[pc.name] = pc
 
             # Trigger replenish if idle is getting low
@@ -367,7 +390,13 @@ class ContainerPool:
                     )
                     await asyncio.to_thread(
                         container.exec_run,
-                        cmd=["sh", "-c", "rm -f /tmp/exec_request.json /tmp/exec_result.json /tmp/exec_trigger"],
+                        # Remove per-execution IPC files (legacy unsuffixed and
+                        # eid-suffixed, plus workbench fetch channel files) but
+                        # keep /tmp/wb_cache — the blob cache is the point of
+                        # reusing the container.
+                        cmd=["sh", "-c",
+                             "rm -f /tmp/exec_request*.json /tmp/exec_result*.json "
+                             "/tmp/exec_trigger* /tmp/wb_fetch_req_*.json /tmp/wb_fetch_resp_*.json"],
                     )
                 except Exception as e:
                     logger.warning(f"Failed to clean IPC files in {name}: {e}")

--- a/backend/app/services/executor/_k8s_runtime.py
+++ b/backend/app/services/executor/_k8s_runtime.py
@@ -367,59 +367,79 @@ async def run_payload_in_pod(
     namespace: str,
     payload: dict[str, Any],
     timeout: int,
+    fetch_handler=None,
 ) -> dict[str, Any]:
     """Run one execute_inline payload against the pod's executor daemon.
 
-    Same request/trigger/result-file protocol as the Docker runtimes. Returns
-    the parsed wire dict; raises on infra errors (exec failure, bad JSON).
+    Same request/trigger/result-file protocol as the Docker runtimes,
+    including the lazy-fetch extension: workbench file requests from the
+    wrapper are served through `fetch_handler` and the wait re-entered.
+    Returns the parsed wire dict; raises on infra errors (exec failure,
+    bad JSON).
     """
+    import time as _time
+
+    from app.core.config import settings
+    from app.services.executor._wire import (
+        build_wait_script,
+        fetch_response_path,
+        parse_wait_output,
+    )
+
     eid = payload["execution_id"]
     request_path = f"/tmp/exec_request_{eid}.json"
-    trigger_file = f"/tmp/exec_trigger_{eid}"
-    result_file = f"/tmp/exec_result_{eid}.json"
 
-    payload_json = json.dumps(payload)
-    writer = _STDIN_WRITER.format(path=request_path)
-    stdout, stderr, rc = await asyncio.to_thread(
-        _exec_blocking,
-        name,
-        namespace,
-        ["python3", "-c", writer],
-        stdin_payload=payload_json,
-        timeout=60,
-    )
-    expected = f"WROTE {len(payload_json.encode('utf-8'))}"
-    if expected not in stdout:
-        raise RuntimeError(
-            f"Failed to write request into sandbox pod {name}: "
-            f"rc={rc} stdout={stdout[-500:]!r} stderr={stderr[-500:]!r}"
+    async def _write_into_pod(path: str, data: str) -> None:
+        writer = _STDIN_WRITER.format(path=path)
+        stdout, stderr, rc = await asyncio.to_thread(
+            _exec_blocking,
+            name,
+            namespace,
+            ["python3", "-c", writer],
+            stdin_payload=data,
+            timeout=60,
         )
+        expected = f"WROTE {len(data.encode('utf-8'))}"
+        if expected not in stdout:
+            raise RuntimeError(
+                f"Failed to write {path} into sandbox pod {name}: "
+                f"rc={rc} stdout={stdout[-500:]!r} stderr={stderr[-500:]!r}"
+            )
 
-    poll_script = f"""
-import sys, json, time, os
-with open("{trigger_file}", "w") as f:
-    f.write("1")
-max_wait = {timeout}
-start = time.time()
-while time.time() - start < max_wait:
-    if os.path.exists("{result_file}"):
-        with open("{result_file}", "r") as f:
-            data = json.load(f)
-        print(json.dumps(data))
-        sys.exit(0)
-    time.sleep(0.1)
-print(json.dumps({{"status": "failed", "error": "Execution timeout after {timeout}s"}}))
-sys.exit(1)
-"""
-    stdout, stderr, rc = await asyncio.to_thread(
-        _exec_blocking,
-        name,
-        namespace,
-        ["python3", "-c", poll_script],
-        timeout=timeout + 30,
-    )
-    if not stdout.strip():
-        raise RuntimeError(
-            f"No result from sandbox pod {name}: rc={rc} stderr={stderr[-500:]!r}"
+    await _write_into_pod(request_path, json.dumps(payload))
+
+    deadline = _time.time() + timeout
+    first_wait = True
+    fetches_served = 0
+    while True:
+        remaining = max(1.0, deadline - _time.time())
+        stdout, stderr, rc = await asyncio.to_thread(
+            _exec_blocking,
+            name,
+            namespace,
+            ["python3", "-c", build_wait_script(eid, remaining, write_trigger=first_wait)],
+            timeout=remaining + 30,
         )
-    return json.loads(stdout.strip())
+        first_wait = False
+        if not stdout.strip():
+            raise RuntimeError(
+                f"No result from sandbox pod {name}: rc={rc} stderr={stderr[-500:]!r}"
+            )
+        envelope = parse_wait_output(stdout)
+        if envelope is None:
+            return json.loads(stdout.strip())
+
+        if envelope["kind"] == "fetch":
+            req = envelope.get("req") or {}
+            path = req.get("path", "")
+            fetches_served += 1
+            if fetch_handler is None:
+                resp: dict[str, Any] = {"path": path, "error": "lazy fetch is not available"}
+            elif fetches_served > settings.workbench_lazy_fetch_max_calls:
+                resp = {"path": path, "error": "lazy fetch call limit reached for this execution"}
+            else:
+                resp = await fetch_handler(path)
+            await _write_into_pod(fetch_response_path(eid), json.dumps(resp))
+            continue
+
+        return envelope["data"]

--- a/backend/app/services/executor/_wire.py
+++ b/backend/app/services/executor/_wire.py
@@ -1,0 +1,87 @@
+"""Shared pieces of the sandbox wire protocol.
+
+The request/trigger/result-file exchange is identical across the Docker and
+k8s sandbox runtimes. This module owns the in-container wait script so both
+runtimes speak the same dialect — including the lazy-fetch extension: while
+an execution runs, the sandbox wrapper may drop a fetch-request file
+(`/tmp/wb_fetch_req_{eid}.json`) asking the backend for a workbench file;
+the wait script exits early with that request, the backend services it by
+writing `/tmp/wb_fetch_resp_{eid}.json` into the container, and re-enters
+the wait. The wrapper's blocked read picks the response up and continues.
+"""
+import json
+from typing import Any, Optional
+
+
+def fetch_request_path(execution_id: str) -> str:
+    return f"/tmp/wb_fetch_req_{execution_id}.json"
+
+
+def fetch_response_path(execution_id: str) -> str:
+    return f"/tmp/wb_fetch_resp_{execution_id}.json"
+
+
+def build_wait_script(
+    execution_id: str,
+    timeout: float,
+    *,
+    write_trigger: bool,
+) -> str:
+    """The in-container poll loop, printing one JSON envelope and exiting.
+
+    Envelopes: {"kind": "result", "data": <wire result>} when the result
+    file appears, {"kind": "fetch", "req": {...}} when the wrapper requests
+    a workbench file. write_trigger must be True only for the FIRST wait of
+    an execution — re-writing the trigger would make the executor daemon
+    re-run the request.
+    """
+    trigger_file = f"/tmp/exec_trigger_{execution_id}"
+    result_file = f"/tmp/exec_result_{execution_id}.json"
+    req_file = fetch_request_path(execution_id)
+    return f"""
+import sys, json, time, os
+if {write_trigger!r}:
+    with open("{trigger_file}", "w") as f:
+        f.write("1")
+max_wait = {timeout}
+start = time.time()
+while time.time() - start < max_wait:
+    if os.path.exists("{result_file}"):
+        try:
+            with open("{result_file}", "r") as f:
+                data = json.load(f)
+        except Exception:
+            time.sleep(0.05)
+            continue
+        os.remove("{result_file}")
+        print(json.dumps({{"kind": "result", "data": data}}))
+        sys.exit(0)
+    if os.path.exists("{req_file}"):
+        try:
+            with open("{req_file}", "r") as f:
+                req = json.load(f)
+        except Exception:
+            time.sleep(0.05)
+            continue
+        os.remove("{req_file}")
+        print(json.dumps({{"kind": "fetch", "req": req}}))
+        sys.exit(0)
+    time.sleep(0.1)
+print(json.dumps({{"kind": "result", "data": {{"status": "failed", "error": "Execution timed out"}}}}))
+sys.exit(1)
+"""
+
+
+def parse_wait_output(raw_output: str) -> Optional[dict[str, Any]]:
+    """Parse the wait script's stdout into its envelope, or None if it isn't
+    one (older executors / stray prints fall back to legacy handling)."""
+    try:
+        data = json.loads(raw_output.strip())
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if isinstance(data, dict) and data.get("kind") in ("result", "fetch"):
+        return data
+    # A bare wire result (no envelope) still counts as a result.
+    if isinstance(data, dict) and "status" in data:
+        return {"kind": "result", "data": data}
+    return None

--- a/backend/app/services/icon_resolver.py
+++ b/backend/app/services/icon_resolver.py
@@ -46,6 +46,7 @@ async def resolve_icon_url(icon: Optional[str], db: AsyncSession) -> Optional[st
             select(Collection.is_public).where(
                 Collection.namespace == namespace,
                 Collection.name == collection,
+                Collection.kind == "collection",
             )
         )
         row = result.first()
@@ -66,6 +67,7 @@ async def resolve_icon_url(icon: Optional[str], db: AsyncSession) -> Optional[st
                 select(Collection.id).where(
                     Collection.namespace == namespace,
                     Collection.name == collection,
+                    Collection.kind == "collection",
                 )
             )
             coll_row = coll_result.first()

--- a/backend/app/services/openapi_generator.py
+++ b/backend/app/services/openapi_generator.py
@@ -172,7 +172,7 @@ async def generate_runtime_openapi(db: AsyncSession) -> dict[str, Any]:
         }
 
     # Add dynamic collection upload endpoints (database-driven)
-    collection_result = await db.execute(select(Collection))
+    collection_result = await db.execute(select(Collection).where(Collection.kind == "collection"))
     collections = collection_result.scalars().all()
 
     for coll in collections:

--- a/backend/app/services/tool_discovery.py
+++ b/backend/app/services/tool_discovery.py
@@ -336,7 +336,14 @@ async def get_available_tools(
     # Not advertised when disabled: offering a tool the platform will refuse
     # wastes context and invites retry loops when the model keeps trying it.
     if has_system_tool(system_tools, "codeExecution") and settings.code_execution_enabled:
-        tools.append(await get_code_exec_tool_definition(db))
+        code_exec_tool = await get_code_exec_tool_definition(db)
+        if has_system_tool(system_tools, "workbench"):
+            code_exec_tool["function"]["description"] += (
+                " The workbench files of this chat are materialized into the "
+                "working directory, and files you create or modify there are "
+                "persisted back to the workbench after the run."
+            )
+        tools.append(code_exec_tool)
     if has_system_tool(system_tools, "packageManagement"):
         from app.services.package_tools import get_package_tool_definitions
         tools.extend(get_package_tool_definitions())

--- a/backend/app/services/tool_discovery.py
+++ b/backend/app/services/tool_discovery.py
@@ -346,6 +346,9 @@ async def get_available_tools(
     if has_system_tool(system_tools, "databaseIntrospection"):
         from app.services.db_introspection_tools import get_db_introspection_tool_definitions
         tools.extend(get_db_introspection_tool_definitions())
+    if has_system_tool(system_tools, "workbench"):
+        from app.services.workbench import get_workbench_tool_definitions
+        tools.extend(get_workbench_tool_definitions())
 
     # Check for paused executions belonging to this chat
     result = await db.execute(

--- a/backend/app/services/tool_discovery.py
+++ b/backend/app/services/tool_discovery.py
@@ -341,7 +341,10 @@ async def get_available_tools(
             code_exec_tool["function"]["description"] += (
                 " The workbench files of this chat are materialized into the "
                 "working directory, and files you create or modify there are "
-                "persisted back to the workbench after the run."
+                "persisted back to the workbench after the run. Large files "
+                "appear as lazy stubs whose content loads automatically on "
+                "open(); call workbench_fetch(path) first when passing a lazy "
+                "file to native code that bypasses Python's open()."
             )
         tools.append(code_exec_tool)
     if has_system_tool(system_tools, "packageManagement"):

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -781,6 +781,18 @@ async def execute_single_tool(
                     arguments=arguments,
                     create_chat_with_agent_fn=create_chat_with_agent_fn,
                 )
+            elif tool_metadata.get("tool_type", "").startswith("workbench_"):
+                start_time = time.time()
+                from app.services.workbench import WorkbenchTools
+
+                result = await WorkbenchTools().execute_tool(
+                    db=db,
+                    chat=chat,
+                    user_id=user_id,
+                    tool_name=tool_name,
+                    arguments=arguments,
+                )
+                logger.debug(f"Workbench tool completed in {time.time() - start_time:.3f}s: {tool_name}")
             elif tool_metadata.get("tool_type", "").startswith("collection_"):
                 start_time = time.time()
                 result = await collection_converter.execute_tool(

--- a/backend/app/services/workbench.py
+++ b/backend/app/services/workbench.py
@@ -1,0 +1,625 @@
+"""Workbench: a chat's private working tree.
+
+A workbench is the mutable file tree an agent works in for the duration of
+a chat — scratchpad, artifact surface, and (once sandbox sync lands) the
+tree code execution runs against. It is backed by a Collection row with
+kind='workbench', which buys File/FileVersion versioning and storage for
+free, but it is not a collection in the API sense: workbench rows carry an
+internal namespace/name, are filtered out of every collections-API query
+and permission resolution (Collection.get_by_name and friends filter
+kind='collection'), and are reachable only through their chat.
+
+Authorization model: reaching the chat IS the authorization. The tools
+below are only ever bound for the chat's own conversation (tool discovery
+is chat-scoped and runtime chat access is owner-checked), so no collection
+permission is consulted for workbench-local operations. checkout/promote
+touch real collections and enforce those collections' download/upload
+permissions.
+
+Every file in a workbench is visibility='private' and owned by the chat's
+user. Design: backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+"""
+import logging
+import uuid as uuid_lib
+from fnmatch import fnmatch
+from typing import Any, Optional
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat
+from app.models.file import Collection, File, FileVersion
+from app.services.collection_tools import CollectionToolConverter
+from app.services.file_storage import FileStorage, get_storage
+
+logger = logging.getLogger(__name__)
+
+WORKBENCH_KIND = "workbench"
+# Internal identity only. Unreachable by name: every by-name resolver
+# filters kind='collection'. The name is the chat id, so the (namespace,
+# name) uniqueness constraint gives one workbench per chat.
+_INTERNAL_NAMESPACE = "_chat"
+
+# Bulk checkout bound — protects against "checkout */everything" surprises.
+MAX_CHECKOUT_FILES = 1000
+
+PROVENANCE_KEY = "workbench_source"  # file_metadata key carrying checkout provenance
+
+
+def _validate_path(filename: str) -> Optional[str]:
+    """Return an error string for unacceptable workbench paths, else None.
+
+    Workbench filenames are relative paths ('notes.md', 'src/app.py').
+    """
+    if not filename or not filename.strip():
+        return "filename is required"
+    if len(filename) > 255:
+        return "filename too long (max 255 characters)"
+    if filename.startswith("/") or filename.startswith("\\"):
+        return "filename must be a relative path"
+    parts = filename.replace("\\", "/").split("/")
+    if any(p in ("", ".", "..") for p in parts):
+        return "filename must not contain empty, '.' or '..' path segments"
+    return None
+
+
+async def get_or_create_workbench(db: AsyncSession, chat: Chat) -> Collection:
+    """Get the chat's workbench, creating it on first use (race-safe)."""
+    name = str(chat.id)
+    stmt = select(Collection).where(
+        Collection.kind == WORKBENCH_KIND,
+        Collection.namespace == _INTERNAL_NAMESPACE,
+        Collection.name == name,
+    )
+    existing = (await db.execute(stmt)).scalar_one_or_none()
+    if existing:
+        return existing
+
+    workbench = Collection(
+        namespace=_INTERNAL_NAMESPACE,
+        name=name,
+        kind=WORKBENCH_KIND,
+        user_id=chat.user_id,
+        metadata_schema={},
+        allow_shared_files=False,
+        allow_private_files=True,
+    )
+    db.add(workbench)
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Lost a creation race — the winner's row is what we want.
+        await db.rollback()
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing:
+            return existing
+        raise
+    return workbench
+
+
+def get_workbench_tool_definitions() -> list[dict[str, Any]]:
+    """Tool definitions for agents with system_tools: ["workbench"]."""
+
+    def tool(name: str, description: str, properties: dict, required: list[str]) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {"type": "object", "properties": properties, "required": required},
+                "_metadata": {"tool_type": name},
+            },
+        }
+
+    filename_prop = {
+        "type": "string",
+        "description": "Relative path within the workbench (e.g. 'notes.md', 'src/app.py')",
+    }
+
+    return [
+        tool(
+            "workbench_list",
+            "List/search files in this chat's workbench — your private, persistent "
+            "working tree. Files persist across turns of this conversation. "
+            "Optionally filter by a content query or metadata.",
+            {
+                "query": {"type": "string", "description": "Optional text/regex query against file contents"},
+                "metadata_filter": {"type": "object", "description": "Optional key-value metadata filter"},
+            },
+            [],
+        ),
+        tool(
+            "workbench_read",
+            "Read a file from the workbench. Text files return content inline with "
+            "line numbers; binary files return a temporary URL. Use offset/limit "
+            "for line ranges of large files.",
+            {
+                "filename": filename_prop,
+                "offset": {"type": "integer", "description": "Start line (1-indexed)"},
+                "limit": {"type": "integer", "description": "Max lines to return"},
+            },
+            ["filename"],
+        ),
+        tool(
+            "workbench_write",
+            "Write a file in the workbench (full contents; a new version is created "
+            "if it exists). For targeted changes to an existing file use "
+            "workbench_edit instead.",
+            {
+                "filename": filename_prop,
+                "content": {"type": "string", "description": "Full file contents"},
+            },
+            ["filename", "content"],
+        ),
+        tool(
+            "workbench_edit",
+            "Edit a workbench file by exact string replacement. old_string must "
+            "appear exactly once unless replace_all is true. Read the file first.",
+            {
+                "filename": filename_prop,
+                "old_string": {"type": "string", "description": "Exact text to replace"},
+                "new_string": {"type": "string", "description": "Replacement text"},
+                "replace_all": {"type": "boolean", "description": "Replace every occurrence (default false)"},
+            },
+            ["filename", "old_string", "new_string"],
+        ),
+        tool(
+            "workbench_delete",
+            "Delete a file from the workbench.",
+            {"filename": filename_prop},
+            ["filename"],
+        ),
+        tool(
+            "workbench_checkout",
+            "Copy files from a collection into the workbench to work on them. "
+            "Pass 'path' for one file or 'pattern' (glob) for several; neither "
+            "copies the whole collection. Checked-out files remember their "
+            "source, so workbench_promote can offer updating the original.",
+            {
+                "collection": {"type": "string", "description": "Source collection as 'namespace/name'"},
+                "path": {"type": "string", "description": "Exact filename to check out"},
+                "pattern": {"type": "string", "description": "Glob pattern of filenames to check out (e.g. 'data/*.csv')"},
+            },
+            ["collection"],
+        ),
+        tool(
+            "workbench_promote",
+            "Publish a workbench file to a collection so it outlives this chat. "
+            "A file that was checked out updates its source file (and reports a "
+            "conflict if the source changed since checkout); other files are "
+            "created in the target collection.",
+            {
+                "filename": filename_prop,
+                "collection": {"type": "string", "description": "Target collection as 'namespace/name'"},
+                "target_filename": {
+                    "type": "string",
+                    "description": "Filename in the target collection (defaults to the workbench filename)",
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": ["private", "shared"],
+                    "description": "Visibility of a newly created target file (default 'private')",
+                },
+            },
+            ["filename", "collection"],
+        ),
+    ]
+
+
+class WorkbenchTools:
+    """Executes workbench_* tool calls for a chat."""
+
+    def __init__(self) -> None:
+        self._conv = CollectionToolConverter()
+
+    async def execute_tool(
+        self,
+        db: AsyncSession,
+        chat: Chat,
+        user_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        if chat is None:
+            return {"error": "Workbench tools require a chat context"}
+        if str(chat.user_id) != str(user_id):
+            # Tool discovery is chat-scoped so this should be unreachable;
+            # belt and braces for the trust boundary.
+            return {"error": "Workbench belongs to a different user"}
+
+        workbench = await get_or_create_workbench(db, chat)
+
+        if tool_name == "workbench_list":
+            return await self._conv._search_collection(db, workbench, _INTERNAL_NAMESPACE, user_id, arguments)
+        if tool_name == "workbench_read":
+            return await self._conv._get_file(db, workbench, _INTERNAL_NAMESPACE, user_id, arguments)
+        if tool_name == "workbench_write":
+            err = _validate_path(arguments.get("filename", ""))
+            if err:
+                return {"error": err}
+            return await self._conv._write_file(
+                db, workbench, _INTERNAL_NAMESPACE, user_id, arguments, visibility="private"
+            )
+        if tool_name == "workbench_edit":
+            err = _validate_path(arguments.get("filename", ""))
+            if err:
+                return {"error": err}
+            return await self._conv._edit_file(db, workbench, _INTERNAL_NAMESPACE, user_id, arguments)
+        if tool_name == "workbench_delete":
+            return await self._conv._delete_file(db, workbench, _INTERNAL_NAMESPACE, user_id, arguments)
+        if tool_name == "workbench_checkout":
+            return await self._checkout(db, workbench, user_id, arguments)
+        if tool_name == "workbench_promote":
+            return await self._promote(db, workbench, user_id, arguments)
+        return {"error": f"Unknown workbench tool: {tool_name}"}
+
+    # ── checkout ────────────────────────────────────────────────────
+
+    async def _checkout(
+        self, db: AsyncSession, workbench: Collection, user_id: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        coll_ref = arguments.get("collection", "")
+        if "/" not in coll_ref:
+            return {"error": "collection must be 'namespace/name'"}
+        namespace, name = coll_ref.split("/", 1)
+
+        source = await Collection.get_by_name(db, namespace, name)
+        if not source:
+            return {"error": f"Collection '{coll_ref}' not found"}
+
+        perm_err = await self._check_collection_perm(db, user_id, namespace, name, write=False)
+        if perm_err:
+            return perm_err
+
+        path = arguments.get("path")
+        pattern = arguments.get("pattern")
+
+        # Candidate files: caller's own + shared — never other users' private
+        # files, mirroring collection search visibility.
+        stmt = select(File).where(
+            File.collection_id == source.id,
+            or_(File.user_id == uuid_lib.UUID(user_id), File.visibility == "shared"),
+        )
+        if path:
+            stmt = stmt.where(File.name == path)
+        files = (await db.execute(stmt)).scalars().all()
+        if pattern and not path:
+            files = [f for f in files if fnmatch(f.name, pattern)]
+
+        if not files:
+            target = path or pattern or "any files"
+            return {"error": f"No accessible files matching {target!r} in '{coll_ref}'"}
+        if len(files) > MAX_CHECKOUT_FILES:
+            return {
+                "error": (
+                    f"Checkout of {len(files)} files exceeds the limit of "
+                    f"{MAX_CHECKOUT_FILES}. Narrow with 'path' or 'pattern'."
+                )
+            }
+
+        storage = get_storage()
+        checked_out: list[dict[str, Any]] = []
+        errors: list[str] = []
+        for f in files:
+            version = await self._current_version(db, f)
+            if version is None:
+                errors.append(f"{f.name}: no stored version")
+                continue
+            try:
+                content = await storage.read(version.storage_path)
+            except Exception as e:
+                errors.append(f"{f.name}: read failed ({e})")
+                continue
+            provenance = {
+                PROVENANCE_KEY: {
+                    "collection": coll_ref,
+                    "file_id": str(f.id),
+                    "version": version.version_number,
+                }
+            }
+            result = await _write_bytes(
+                db,
+                storage,
+                workbench,
+                filename=f.name,
+                content=content,
+                content_type=f.content_type,
+                user_id=user_id,
+                visibility="private",
+                file_metadata=provenance,
+            )
+            if "error" in result:
+                errors.append(f"{f.name}: {result['error']}")
+            else:
+                checked_out.append({"filename": f.name, "source_version": version.version_number})
+
+        out: dict[str, Any] = {"collection": coll_ref, "checked_out": checked_out, "count": len(checked_out)}
+        if errors:
+            out["errors"] = errors
+        return out
+
+    # ── promote ─────────────────────────────────────────────────────
+
+    async def _promote(
+        self, db: AsyncSession, workbench: Collection, user_id: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        filename = arguments.get("filename", "")
+        err = _validate_path(filename)
+        if err:
+            return {"error": err}
+        coll_ref = arguments.get("collection", "")
+        if "/" not in coll_ref:
+            return {"error": "collection must be 'namespace/name'"}
+        namespace, name = coll_ref.split("/", 1)
+
+        target = await Collection.get_by_name(db, namespace, name)
+        if not target:
+            return {"error": f"Collection '{coll_ref}' not found"}
+
+        perm_err = await self._check_collection_perm(db, user_id, namespace, name, write=True)
+        if perm_err:
+            return perm_err
+
+        # Load the workbench file + current bytes
+        wb_file = (
+            await db.execute(
+                select(File).where(File.collection_id == workbench.id, File.name == filename)
+            )
+        ).scalar_one_or_none()
+        if not wb_file:
+            return {"error": f"'{filename}' not found in the workbench"}
+        wb_version = await self._current_version(db, wb_file)
+        if wb_version is None:
+            return {"error": f"'{filename}' has no stored version"}
+        storage = get_storage()
+        try:
+            content = await storage.read(wb_version.storage_path)
+        except Exception as e:
+            return {"error": f"Failed to read '{filename}': {e}"}
+
+        if target.content_filter_function:
+            filter_err = await self._run_content_filter(
+                db, target, namespace, name, filename, content, wb_file.content_type, user_id
+            )
+            if filter_err:
+                return filter_err
+
+        provenance = (wb_file.file_metadata or {}).get(PROVENANCE_KEY)
+        target_filename = arguments.get("target_filename") or filename
+
+        # Checked-out file going back to where it came from → update the source.
+        if provenance and provenance.get("collection") == coll_ref and not arguments.get("target_filename"):
+            source_file = (
+                await db.execute(select(File).where(File.id == uuid_lib.UUID(provenance["file_id"])))
+            ).scalar_one_or_none()
+            if source_file and source_file.collection_id == target.id:
+                if source_file.current_version != provenance.get("version"):
+                    return {
+                        "error": "conflict",
+                        "message": (
+                            f"'{target_filename}' in '{coll_ref}' is at version "
+                            f"{source_file.current_version}, but this file was checked out at "
+                            f"version {provenance.get('version')}. Re-run workbench_checkout to "
+                            "get the latest, re-apply your changes, then promote again."
+                        ),
+                    }
+                result = await _write_bytes(
+                    db,
+                    storage,
+                    target,
+                    filename=source_file.name,
+                    content=content,
+                    content_type=wb_file.content_type,
+                    user_id=user_id,
+                    visibility=source_file.visibility,
+                    existing=source_file,
+                )
+                if "error" in result:
+                    return result
+                # Re-stamp provenance at the new source version so a second
+                # promote doesn't see its own update as a conflict.
+                new_meta = dict(wb_file.file_metadata or {})
+                new_meta[PROVENANCE_KEY] = {**provenance, "version": result["version"]}
+                wb_file.file_metadata = new_meta
+                await db.flush()
+                return {**result, "collection": coll_ref, "updated_source": True}
+            # Source file vanished — fall through to create-new.
+
+        visibility = arguments.get("visibility", "private")
+        if visibility not in ("private", "shared"):
+            return {"error": "visibility must be 'private' or 'shared'"}
+        if visibility == "shared" and not target.allow_shared_files:
+            return {"error": f"Collection '{coll_ref}' does not allow shared files"}
+        if visibility == "private" and not target.allow_private_files:
+            return {"error": f"Collection '{coll_ref}' does not allow private files"}
+
+        result = await _write_bytes(
+            db,
+            storage,
+            target,
+            filename=target_filename,
+            content=content,
+            content_type=wb_file.content_type,
+            user_id=user_id,
+            visibility=visibility,
+        )
+        if "error" in result:
+            return result
+        return {**result, "collection": coll_ref, "updated_source": False}
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    async def _current_version(self, db: AsyncSession, f: File) -> Optional[FileVersion]:
+        return (
+            await db.execute(
+                select(FileVersion).where(
+                    FileVersion.file_id == f.id,
+                    FileVersion.version_number == f.current_version,
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def _check_collection_perm(
+        self, db: AsyncSession, user_id: str, namespace: str, name: str, write: bool
+    ) -> Optional[dict[str, Any]]:
+        from app.core.auth import get_user_permissions
+        from app.core.permissions import check_permission
+
+        action = "upload" if write else "download"
+        perm = f"sinas.collections/{namespace}/{name}.{action}:own"
+        user_permissions = await get_user_permissions(db, user_id)
+        if not check_permission(user_permissions, perm):
+            verb = "write to" if write else "read from"
+            return {
+                "error": "Permission denied",
+                "message": f"You don't have permission to {verb} collection '{namespace}/{name}'.",
+            }
+        return None
+
+    async def _run_content_filter(
+        self,
+        db: AsyncSession,
+        target: Collection,
+        namespace: str,
+        name: str,
+        filename: str,
+        content: bytes,
+        content_type: str,
+        user_id: str,
+    ) -> Optional[dict[str, Any]]:
+        """Run the target collection's content filter; None means approved.
+
+        Same contract as the upload endpoint: the filter function receives
+        the candidate file and must return {"approved": true} for the write
+        to proceed.
+        """
+        import base64
+
+        from app.models.function import Function
+        from app.models.execution import TriggerType
+        from app.services.queue_service import queue_service
+
+        filter_namespace, filter_name = target.content_filter_function.split("/")
+        func_record = await Function.get_by_name(db, filter_namespace, filter_name)
+        if not func_record:
+            return {
+                "error": (
+                    f"Content filter function '{target.content_filter_function}' "
+                    f"configured on '{namespace}/{name}' was not found"
+                )
+            }
+        try:
+            filter_result = await queue_service.enqueue_and_wait(
+                function_namespace=filter_namespace,
+                function_name=filter_name,
+                input_data={
+                    "content_base64": base64.b64encode(content).decode(),
+                    "namespace": namespace,
+                    "collection": name,
+                    "filename": filename,
+                    "content_type": content_type,
+                    "size_bytes": len(content),
+                    "user_metadata": {},
+                    "user_id": user_id,
+                },
+                execution_id=str(uuid_lib.uuid4()),
+                trigger_type=TriggerType.MANUAL.value,
+                trigger_id=f"content_filter:{namespace}/{name}",
+                user_id=user_id,
+            )
+        except Exception as e:
+            return {"error": f"Content filter failed to run: {e}"}
+        if not (isinstance(filter_result, dict) and filter_result.get("approved")):
+            reason = ""
+            if isinstance(filter_result, dict):
+                reason = filter_result.get("reason") or filter_result.get("message") or ""
+            return {
+                "error": "Rejected by content filter",
+                "message": reason or f"'{namespace}/{name}' declined this file.",
+            }
+        return None
+
+
+async def _write_bytes(
+    db: AsyncSession,
+    storage: FileStorage,
+    collection: Collection,
+    *,
+    filename: str,
+    content: bytes,
+    content_type: str,
+    user_id: str,
+    visibility: str,
+    file_metadata: Optional[dict[str, Any]] = None,
+    existing: Optional[File] = None,
+) -> dict[str, Any]:
+    """Byte-level write into a collection/workbench (checkout + promote path).
+
+    Mirrors CollectionToolConverter._write_file but takes bytes (binary-safe)
+    and lets the caller pin metadata, visibility, and the target File row.
+    Does NOT run content filters or permission checks — callers do.
+    """
+    size_mb = len(content) / (1024 * 1024)
+    if size_mb > collection.max_file_size_mb:
+        return {"error": f"File too large ({size_mb:.2f}MB > {collection.max_file_size_mb}MB limit)"}
+
+    file_hash = storage.calculate_hash(content)
+
+    if existing is None:
+        existing = (
+            await db.execute(
+                select(File)
+                .where(and_(File.collection_id == collection.id, File.name == filename))
+                .where(or_(File.user_id == uuid_lib.UUID(user_id), File.visibility == "shared"))
+                .order_by((File.user_id == uuid_lib.UUID(user_id)).desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    if existing:
+        existing.current_version += 1
+        existing.content_type = content_type
+        if file_metadata is not None:
+            existing.file_metadata = file_metadata
+        file_record = existing
+        created = False
+    else:
+        file_record = File(
+            collection_id=collection.id,
+            name=filename,
+            user_id=uuid_lib.UUID(user_id),
+            content_type=content_type,
+            current_version=1,
+            file_metadata=file_metadata or {},
+            visibility=visibility,
+        )
+        db.add(file_record)
+        created = True
+
+    await db.flush()
+
+    storage_path = f"{collection.namespace}/{collection.name}/{file_record.id}/v{file_record.current_version}"
+    try:
+        await storage.save(storage_path, content)
+    except Exception as e:
+        return {"error": f"Storage write failed: {e}"}
+
+    db.add(
+        FileVersion(
+            file_id=file_record.id,
+            version_number=file_record.current_version,
+            storage_path=storage_path,
+            size_bytes=len(content),
+            hash_sha256=file_hash,
+            uploaded_by=uuid_lib.UUID(user_id),
+        )
+    )
+    await db.flush()
+
+    return {
+        "filename": file_record.name,
+        "version": file_record.current_version,
+        "size_bytes": len(content),
+        "created": created,
+    }

--- a/backend/app/services/workbench.py
+++ b/backend/app/services/workbench.py
@@ -334,6 +334,12 @@ class WorkbenchTools:
             else:
                 checked_out.append({"filename": f.name, "source_version": version.version_number})
 
+        # Tool calls run in their own session that is discarded without a
+        # commit (the reused converter tools commit internally) — persist
+        # explicitly here.
+        if checked_out:
+            await db.commit()
+
         out: dict[str, Any] = {"collection": coll_ref, "checked_out": checked_out, "count": len(checked_out)}
         if errors:
             out["errors"] = errors
@@ -422,7 +428,7 @@ class WorkbenchTools:
                 new_meta = dict(wb_file.file_metadata or {})
                 new_meta[PROVENANCE_KEY] = {**provenance, "version": result["version"]}
                 wb_file.file_metadata = new_meta
-                await db.flush()
+                await db.commit()  # tool sessions are discarded uncommitted
                 return {**result, "collection": coll_ref, "updated_source": True}
             # Source file vanished — fall through to create-new.
 
@@ -446,6 +452,7 @@ class WorkbenchTools:
         )
         if "error" in result:
             return result
+        await db.commit()  # tool sessions are discarded uncommitted
         return {**result, "collection": coll_ref, "updated_source": False}
 
     # ── helpers ─────────────────────────────────────────────────────

--- a/backend/app/services/workbench.py
+++ b/backend/app/services/workbench.py
@@ -541,6 +541,121 @@ class WorkbenchTools:
         return None
 
 
+# ---------------------------------------------------------------------------
+# Sandbox sync (eager copy-in / copy-out)
+# ---------------------------------------------------------------------------
+
+
+async def chat_has_workbench_enabled(db: AsyncSession, chat: Chat) -> bool:
+    """True when the chat's agent opted in via system_tools: ["workbench"]."""
+    from app.models.agent import Agent
+    from app.services.system_tool_helpers import has_system_tool
+
+    if not chat or not chat.agent_id:
+        return False
+    agent = (await db.execute(select(Agent).where(Agent.id == chat.agent_id))).scalar_one_or_none()
+    return bool(agent) and has_system_tool(agent.system_tools or [], "workbench")
+
+
+async def build_sync_manifest(db: AsyncSession, chat: Chat) -> dict[str, Any]:
+    """Collect the workbench tree for copy-in to a sandbox execution.
+
+    Returns {"files": [{path, content_b64, sha256}], "skipped": [{path,
+    size_bytes, reason}]} bounded by the workbench_sync_* settings. Skipped
+    files stay tool-accessible; they just don't materialize in the sandbox.
+    """
+    import base64
+
+    from app.core.config import settings
+
+    workbench = await get_or_create_workbench(db, chat)
+    rows = (
+        await db.execute(select(File).where(File.collection_id == workbench.id))
+    ).scalars().all()
+
+    storage = get_storage()
+    files: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    total = 0
+    for f in rows:
+        version = (
+            await db.execute(
+                select(FileVersion).where(
+                    FileVersion.file_id == f.id,
+                    FileVersion.version_number == f.current_version,
+                )
+            )
+        ).scalar_one_or_none()
+        if version is None:
+            continue
+        if version.size_bytes > settings.workbench_sync_max_file_bytes:
+            skipped.append({"path": f.name, "size_bytes": version.size_bytes, "reason": "file too large"})
+            continue
+        if total + version.size_bytes > settings.workbench_sync_max_total_bytes:
+            skipped.append({"path": f.name, "size_bytes": version.size_bytes, "reason": "total sync cap reached"})
+            continue
+        try:
+            content = await storage.read(version.storage_path)
+        except Exception as e:
+            skipped.append({"path": f.name, "size_bytes": version.size_bytes, "reason": f"read failed: {e}"})
+            continue
+        total += len(content)
+        files.append(
+            {
+                "path": f.name,
+                "content_b64": base64.b64encode(content).decode(),
+                "sha256": version.hash_sha256,
+            }
+        )
+    return {"files": files, "skipped": skipped}
+
+
+async def apply_sync_changes(
+    db: AsyncSession, chat: Chat, user_id: str, changes: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Write files an execution created or modified back into the workbench.
+
+    Each change is {path, content_b64}. Deletions are deliberately NOT
+    synced: a crashed or chdir-ing execution must never wipe workbench
+    files it simply didn't touch. Returns {"synced": [...], "rejected":
+    [{path, reason}]}.
+    """
+    import base64
+
+    from app.services.collection_tools import _infer_content_type
+
+    workbench = await get_or_create_workbench(db, chat)
+    storage = get_storage()
+    synced: list[str] = []
+    rejected: list[dict[str, str]] = []
+    for change in changes or []:
+        path = change.get("path", "")
+        err = _validate_path(path)
+        if err:
+            rejected.append({"path": path, "reason": err})
+            continue
+        try:
+            content = base64.b64decode(change.get("content_b64", ""))
+        except Exception:
+            rejected.append({"path": path, "reason": "invalid base64 content"})
+            continue
+        result = await _write_bytes(
+            db,
+            storage,
+            workbench,
+            filename=path,
+            content=content,
+            content_type=_infer_content_type(path),
+            user_id=user_id,
+            visibility="private",
+        )
+        if "error" in result:
+            rejected.append({"path": path, "reason": result["error"]})
+        else:
+            synced.append(path)
+    return {"synced": synced, "rejected": rejected}
+
+
 async def _write_bytes(
     db: AsyncSession,
     storage: FileStorage,

--- a/backend/app/services/workbench.py
+++ b/backend/app/services/workbench.py
@@ -577,9 +577,11 @@ async def chat_has_workbench_enabled(db: AsyncSession, chat: Chat) -> bool:
 async def build_sync_manifest(db: AsyncSession, chat: Chat) -> dict[str, Any]:
     """Collect the workbench tree for copy-in to a sandbox execution.
 
-    Returns {"files": [{path, content_b64, sha256}], "skipped": [{path,
-    size_bytes, reason}]} bounded by the workbench_sync_* settings. Skipped
-    files stay tool-accessible; they just don't materialize in the sandbox.
+    Returns {"files": [{path, content_b64, sha256}], "lazy": [{path,
+    size_bytes, sha256}], "skipped": [{path, size_bytes, reason}]} bounded
+    by the workbench_sync_* settings. Lazy files materialize as stubs in the
+    sandbox and are fetched over the pause channel on first read; skipped
+    files (unreadable storage) don't materialize at all.
     """
     import base64
 
@@ -592,6 +594,7 @@ async def build_sync_manifest(db: AsyncSession, chat: Chat) -> dict[str, Any]:
 
     storage = get_storage()
     files: list[dict[str, Any]] = []
+    lazy: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     total = 0
     for f in rows:
@@ -605,11 +608,13 @@ async def build_sync_manifest(db: AsyncSession, chat: Chat) -> dict[str, Any]:
         ).scalar_one_or_none()
         if version is None:
             continue
-        if version.size_bytes > settings.workbench_sync_max_file_bytes:
-            skipped.append({"path": f.name, "size_bytes": version.size_bytes, "reason": "file too large"})
-            continue
-        if total + version.size_bytes > settings.workbench_sync_max_total_bytes:
-            skipped.append({"path": f.name, "size_bytes": version.size_bytes, "reason": "total sync cap reached"})
+        if (
+            version.size_bytes > settings.workbench_sync_max_file_bytes
+            or total + version.size_bytes > settings.workbench_sync_max_total_bytes
+        ):
+            lazy.append(
+                {"path": f.name, "size_bytes": version.size_bytes, "sha256": version.hash_sha256}
+            )
             continue
         try:
             content = await storage.read(version.storage_path)
@@ -624,7 +629,55 @@ async def build_sync_manifest(db: AsyncSession, chat: Chat) -> dict[str, Any]:
                 "sha256": version.hash_sha256,
             }
         )
-    return {"files": files, "skipped": skipped}
+    return {"files": files, "lazy": lazy, "skipped": skipped}
+
+
+async def fetch_file_bytes(
+    db: AsyncSession, chat: Chat, path: str, max_bytes: int
+) -> dict[str, Any]:
+    """Serve one workbench file for a sandbox lazy-fetch request.
+
+    Returns {"path", "content_b64", "sha256"} or {"path", "error"}. The
+    request path comes from inside the sandbox — treat it as untrusted.
+    """
+    import base64
+
+    err = _validate_path(path)
+    if err:
+        return {"path": path, "error": err}
+
+    workbench = await get_or_create_workbench(db, chat)
+    f = (
+        await db.execute(
+            select(File).where(File.collection_id == workbench.id, File.name == path)
+        )
+    ).scalar_one_or_none()
+    if not f:
+        return {"path": path, "error": f"'{path}' not found in the workbench"}
+    version = (
+        await db.execute(
+            select(FileVersion).where(
+                FileVersion.file_id == f.id,
+                FileVersion.version_number == f.current_version,
+            )
+        )
+    ).scalar_one_or_none()
+    if version is None:
+        return {"path": path, "error": f"'{path}' has no stored version"}
+    if version.size_bytes > max_bytes:
+        return {
+            "path": path,
+            "error": f"'{path}' is {version.size_bytes} bytes, above the lazy-fetch limit of {max_bytes}",
+        }
+    try:
+        content = await get_storage().read(version.storage_path)
+    except Exception as e:
+        return {"path": path, "error": f"read failed: {e}"}
+    return {
+        "path": path,
+        "content_b64": base64.b64encode(content).decode(),
+        "sha256": version.hash_sha256,
+    }
 
 
 async def apply_sync_changes(

--- a/backend/app/services/workbench.py
+++ b/backend/app/services/workbench.py
@@ -385,8 +385,15 @@ class WorkbenchTools:
             return {"error": f"Failed to read '{filename}': {e}"}
 
         if target.content_filter_function:
-            filter_err = await self._run_content_filter(
-                db, target, namespace, name, filename, content, wb_file.content_type, user_id
+            filter_err = await run_content_filter(
+                db,
+                target.content_filter_function,
+                namespace=namespace,
+                collection_name=name,
+                filename=filename,
+                content=content,
+                content_type=wb_file.content_type,
+                user_id=user_id,
             )
             if filter_err:
                 return filter_err
@@ -484,68 +491,71 @@ class WorkbenchTools:
             }
         return None
 
-    async def _run_content_filter(
-        self,
-        db: AsyncSession,
-        target: Collection,
-        namespace: str,
-        name: str,
-        filename: str,
-        content: bytes,
-        content_type: str,
-        user_id: str,
-    ) -> Optional[dict[str, Any]]:
-        """Run the target collection's content filter; None means approved.
 
-        Same contract as the upload endpoint: the filter function receives
-        the candidate file and must return {"approved": true} for the write
-        to proceed.
-        """
-        import base64
 
-        from app.models.function import Function
-        from app.models.execution import TriggerType
-        from app.services.queue_service import queue_service
+async def run_content_filter(
+    db: AsyncSession,
+    function_ref: str,
+    *,
+    namespace: str,
+    collection_name: str,
+    filename: str,
+    content: bytes,
+    content_type: str,
+    user_id: str,
+) -> Optional[dict[str, Any]]:
+    """Run a content filter function against candidate bytes; None = approved.
 
-        filter_namespace, filter_name = target.content_filter_function.split("/")
-        func_record = await Function.get_by_name(db, filter_namespace, filter_name)
-        if not func_record:
-            return {
-                "error": (
-                    f"Content filter function '{target.content_filter_function}' "
-                    f"configured on '{namespace}/{name}' was not found"
-                )
-            }
-        try:
-            filter_result = await queue_service.enqueue_and_wait(
-                function_namespace=filter_namespace,
-                function_name=filter_name,
-                input_data={
-                    "content_base64": base64.b64encode(content).decode(),
-                    "namespace": namespace,
-                    "collection": name,
-                    "filename": filename,
-                    "content_type": content_type,
-                    "size_bytes": len(content),
-                    "user_metadata": {},
-                    "user_id": user_id,
-                },
-                execution_id=str(uuid_lib.uuid4()),
-                trigger_type=TriggerType.MANUAL.value,
-                trigger_id=f"content_filter:{namespace}/{name}",
-                user_id=user_id,
+    Same contract as the collection upload endpoint: the filter receives the
+    candidate file and must return {"approved": true} for the write to
+    proceed. Used by workbench_promote (the target collection's filter) and
+    by workbench uploads (the deployment-wide workbench filter setting).
+    """
+    import base64
+
+    from app.models.execution import TriggerType
+    from app.models.function import Function
+    from app.services.queue_service import queue_service
+
+    filter_namespace, filter_name = function_ref.split("/")
+    func_record = await Function.get_by_name(db, filter_namespace, filter_name)
+    if not func_record:
+        return {
+            "error": (
+                f"Content filter function '{function_ref}' "
+                f"configured for '{namespace}/{collection_name}' was not found"
             )
-        except Exception as e:
-            return {"error": f"Content filter failed to run: {e}"}
-        if not (isinstance(filter_result, dict) and filter_result.get("approved")):
-            reason = ""
-            if isinstance(filter_result, dict):
-                reason = filter_result.get("reason") or filter_result.get("message") or ""
-            return {
-                "error": "Rejected by content filter",
-                "message": reason or f"'{namespace}/{name}' declined this file.",
-            }
-        return None
+        }
+    try:
+        filter_result = await queue_service.enqueue_and_wait(
+            function_namespace=filter_namespace,
+            function_name=filter_name,
+            input_data={
+                "content_base64": base64.b64encode(content).decode(),
+                "namespace": namespace,
+                "collection": collection_name,
+                "filename": filename,
+                "content_type": content_type,
+                "size_bytes": len(content),
+                "user_metadata": {},
+                "user_id": user_id,
+            },
+            execution_id=str(uuid_lib.uuid4()),
+            trigger_type=TriggerType.MANUAL.value,
+            trigger_id=f"content_filter:{namespace}/{collection_name}",
+            user_id=user_id,
+        )
+    except Exception as e:
+        return {"error": f"Content filter failed to run: {e}"}
+    if not (isinstance(filter_result, dict) and filter_result.get("approved")):
+        reason = ""
+        if isinstance(filter_result, dict):
+            reason = filter_result.get("reason") or filter_result.get("message") or ""
+        return {
+            "error": "Rejected by content filter",
+            "message": reason or f"'{namespace}/{collection_name}' declined this file.",
+        }
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+++ b/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
@@ -79,6 +79,45 @@ we validate against traversal.
 Scope is **per-chat** in v1. A per-task/per-delegation scope can layer on
 later by keying the backing collection differently; don't design for it now.
 
+### Metadata and visibility
+
+Collections today gate access in two layers: a namespaced collection
+permission (`collection_tools.py:339-348`), then per-file `visibility`
+(`private` = owner-only for reads, hidden from others' search;
+`shared` = readable by anyone holding the collection permission —
+`collection_tools.py:378,490`). A workbench collapses this: the tree
+belongs to the chat, and the chat belongs to one user, so there is nothing
+for `shared` to mean inside it.
+
+- **Every workbench file is `visibility="private"`, `user_id` = the chat's
+  owner.** The workbench-bound tool path sets this unconditionally — note
+  the plain tool path defaults writes to `"shared"` today
+  (`collection_tools.py:619`), so this is an explicit override, not an
+  inherited default. With everything private, the existing per-file checks
+  already deny reads and hide search results for any other user who
+  reaches the backing collection through generic code paths.
+- **Authorization derives from chat access, not collection grants.** The
+  reserved `_workbench` namespace is excluded from wildcard collection
+  permission matching (`collections:*` must not sweep in other people's
+  workbenches) and from collection listings; the rule is: you can reach a
+  workbench iff you can reach its chat. Operator/support access to
+  workbench contents, if wanted, is its own explicit permission — never a
+  side effect of a broad collection grant. This is belt-and-braces on top
+  of the private-visibility guarantee, and it's the part to test
+  adversarially.
+- **`metadata_schema` / `file_metadata`:** backing collections carry no
+  metadata schema (free-form); `file_metadata` stays available and is where
+  workbench bookkeeping lives (e.g. `origin: upload | tool | execution`,
+  originating execution id).
+- **Nothing is inherited implicitly at promotion.** Promotion re-decides
+  visibility (default: private to the promoting user), validates
+  `file_metadata` against the target collection's `metadata_schema` — a
+  promotion can legitimately fail validation — and runs the target's hooks.
+- **Sync safety follows from single ownership:** the sandbox receives the
+  whole tree, which is fine only because every file in it is the chat
+  owner's. If multi-participant chats ever arrive, workbench visibility
+  semantics must be redesigned *before* those chats get workbench sync.
+
 ### Execution: sync first, mount later
 
 The design decision with teeth is mount vs sync. **Decide: copy-in/copy-out

--- a/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+++ b/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
@@ -1,0 +1,181 @@
+# ADR: Workbench — one mutable file tree under both file tools and code execution
+
+- **Status:** Proposed
+- **Date:** 2026-09-01
+- **Authors:** Kjeld Oostra (with Claude)
+- **Related code:**
+  - `backend/app/services/collection_tools.py` — the file tools (search / get_file / write_file / edit_file with exact-match + `replace_all` semantics) the workbench reuses
+  - `backend/app/models/file.py` — `Collection` / `File` / `FileVersion`, the storage + versioning substrate
+  - `backend/app/services/file_storage.py` — `LocalFileStorage` at `/var/sinas/files` (mounted into backend and workers, **not** into sandboxes)
+  - `backend/app/services/code_execution.py` — sandbox entry point; today has zero awareness of collections or file storage
+  - `backend/app/services/executor/` — the three sandbox runtimes (`docker_pool`, `docker_ephemeral`, `k8s_pod`) and the `execute_inline` wire payload the sync rides on
+  - `backend/app/services/execution_engine.py` — `AWAITING_INPUT` pause/resume; changed on `release/0.4.0`, rebase before implementing
+  - `backend/app/services/config_apply/agents.py` — where the one per-agent enablement field lands
+
+## Context
+
+Reducing Claude Code / Cowork to primitives, Sinas already has most of them:
+skills (first-class, preloadable), subagents (delegation with depth bound and
+suspend mode), hooks, versioned file tools whose `edit_file` is genuine
+Read/Write/Edit semantics (`collection_tools.py:246`), and two working
+pause/resume mechanisms (`PendingToolApproval`, and execution-level
+`AWAITING_INPUT` where function code can call `input()` and resume with a
+human value — `execution_engine.py:411,521`).
+
+The concentrated architectural gap is that Sinas has **two disjoint file
+universes**:
+
+- The agent's file tools operate on **Collections** — Postgres metadata
+  (`File`/`FileVersion`) plus bytes under `/var/sinas/files`, a volume
+  mounted into the backend and workers only.
+- **Code execution** runs in sandboxes (`docker_pool` / `docker_ephemeral` /
+  `k8s_pod`) that deliberately see none of it: `code_execution.py` builds an
+  `execute_inline` payload with the code string and nothing else.
+
+So an agent can write a file it can never execute, and execute code whose
+outputs evaporate at the end of the call. Claude Code's core loop — Edit and
+`pytest` touching the same tree, results persisting to the next turn — is
+impossible today. This is the single missing primitive; the rest of the gap
+(steering, permission modes, MCP, compaction) is behavioral and orthogonal.
+
+## Decision
+
+Introduce the **Workbench**: a per-chat mutable file tree that
+
+1. the existing file tools operate on,
+2. is synchronized into that chat's sandbox executions (both directions), and
+3. persists across turns with the versioning Collections already have.
+
+### Naming
+
+"Workspace" is out: it already informally means the whole tenant in this
+codebase (`agent.py:29` — "NULL = workspace-wide") and collides with
+claude.ai/Slack workspace vocabulary. Candidates considered:
+
+| Name | For | Against |
+|---|---|---|
+| **Workbench** | The place an agent works with tools on materials; pairs naturally with Collections-as-shelf; reads well in UI ("Open workbench") and API (`/chats/{id}/workbench`) | none found |
+| Worktree | Precise ("mutable tree"), git flavor | invites confusion with git worktrees; developer-only vocabulary in a product growing a BA surface (Studio) |
+| Desk | Cowork-friendly, short | cute over clear; weak as an API noun |
+| Scratchpad | familiar | implies disposable — this is persistent and versioned, the opposite |
+| Drive / Vault / Locker | storage nouns | describe only half the feature (miss the execution unification); Drive collides with the Google Drive connector, Vault with secrets |
+
+**Recommendation: Workbench** (working name throughout this ADR; s/Workbench/X/
+is cheap until code lands).
+
+### Storage: a backing collection, not new tables
+
+A workbench **is** a collection with a reserved flavor — auto-created on first
+use, e.g. namespace `_workbench`, name = the chat's `session_key`, owned by
+the chat's user. This buys, for free: `File`/`FileVersion` versioning, the
+existing four file tools, storage backends, and the existing uniqueness/
+visibility machinery. What's new is a `kind` (or reserved-namespace
+convention) so workbenches are excluded from normal collection listings and
+lifecycle (deleted/archived with the chat), and relative-path filenames
+(`src/app.py`) — `File.name` is a 255-char string today, so nested paths fit;
+we validate against traversal.
+
+Scope is **per-chat** in v1. A per-task/per-delegation scope can layer on
+later by keying the backing collection differently; don't design for it now.
+
+### Execution: sync first, mount later
+
+The design decision with teeth is mount vs sync. **Decide: copy-in/copy-out
+sync in v1**, because it is the only option that works across all three
+sandbox runtimes and changes nothing about the sandbox trust boundary:
+
+- **Copy-in:** `code_execution.execute()` (which already receives `chat_id`)
+  loads the workbench manifest, and ships current-version file contents into
+  the sandbox inside the existing `execute_inline` payload; the wrapper
+  materializes them under a fixed root (e.g. `/workbench`, the process cwd).
+- **Copy-out:** the wrapper walks the tree after execution, returns
+  `{path → content}` for files whose hash changed (plus created/deleted
+  lists) in the result envelope; the backend writes them back through the
+  same code path as `write_file`, so every execution's effects are versioned
+  `FileVersion` rows — turn-level diffability free of charge.
+- **Deltas, not full trees:** `FileVersion` already stores a content hash;
+  send only what the sandbox hasn't seen (matters for `docker_pool`, where a
+  warm container can keep its tree and receive deltas keyed on chat_id).
+  Cap tree size and per-file size from settings; oversized files stay
+  tool-accessible but are listed, not materialized, in the sandbox.
+
+A k8s RWX subpath mount is a **later optimization behind the same
+interface**, not the v1: it requires RWX in prod, punches the file-storage
+volume into untrusted pods (subPath scoping becomes security-critical), and
+does nothing for the two docker runtimes. If sync transfer costs ever hurt,
+that's the moment to build it.
+
+Same call on warm session-scoped sandboxes ("the agent's machine"): stay
+ephemeral-with-sync in v1. `docker_pool` already gives warm-container
+mechanics; binding a pooled container to a chat for its lifetime is a cost/
+lifecycle problem to take on only after sync proves the experience. Sync
+makes warmth an optimization instead of a correctness requirement — pool
+affinity by `chat_id` gets most of the feel with none of the lifecycle risk.
+
+### Enablement
+
+Per-agent flag (alongside the existing tool enablement fields): workbench
+off by default, on = the agent's file tools bind to the chat's workbench
+(collection tools on explicit collections unchanged) and code execution
+gains the sync behavior. This flag is the **only** config-apply touchpoint.
+
+## Sequencing
+
+- **Vs. config-apply unification** (folding every management endpoint into
+  config-apply): **parallel is correct**. A workbench is runtime state —
+  chat-scoped, user-owned, like messages and files — and never appears in
+  declarative config. The single shared edge is the per-agent flag, one
+  field in a resource `config_apply/agents.py` already serializes.
+- **Vs. the steering triad** (per-chat lock, cooperative interrupt
+  [#142](https://github.com/sinas-platform/sinas/issues/142), mid-turn
+  message injection): independent code paths, but the triad is what makes
+  long workbench-powered turns safe to ship to users. Build in parallel;
+  gate any "long autonomous turn" positioning on both landing.
+- **Branches:** `dev` is currently a strict ancestor of `release/0.4.0`
+  (39 commits behind, including changes to `execution_engine.py` and
+  `config_apply/agents.py`). This ADR branches off `dev` and merges forward
+  cleanly; the implementation should start from whichever line is the
+  integration target when it begins, and expect a rebase over 0.4.0.
+
+## Impact
+
+| Component | Change |
+|---|---|
+| `models/file.py` + migration | collection `kind` (or reserved namespace) for workbench backing collections; chat-lifecycle cascade |
+| `collection_tools.py` | resolve the implicit target collection to the chat's workbench when the agent flag is on; accept nested paths |
+| `code_execution.py` | build sync manifest from `chat_id`; write back changed files post-execution |
+| `executor/` wrapper + `container_executor.py` | materialize tree pre-run, hash-walk and return changes post-run |
+| `models/agent.py`, `config_apply/agents.py`, schemas | one enablement field |
+| Console / Studio | workbench file browser on the chat view (reuses collection file UI); out of v1's backend scope |
+
+## Open questions
+
+1. Final name — Workbench is the recommendation; decide before code lands.
+2. Concurrency: what happens when two executions in one chat overlap? The
+   per-chat lock from the steering triad is the clean answer; until it
+   lands, last-write-wins per file (each write is a version, so nothing is
+   lost, merely shadowed).
+3. Binary/large files: v1 caps materialization size — is "listed but not
+   materialized" acceptable, or do we need lazy fetch from inside the
+   sandbox (implies a sandbox→backend channel we currently don't have and
+   may not want)?
+4. Does the workbench also become the default target for user file uploads
+   in chat? (Probably yes; out of scope here.)
+
+## What we'd NOT do
+
+- No new storage system, no new file tables — Collections are the substrate.
+- No RWX mounts into sandboxes in v1.
+- No session-pinned warm sandboxes in v1 (pool affinity at most).
+- No per-task workbench scope in v1.
+- No config-apply resource for workbenches — runtime state only.
+
+## Next steps
+
+1. Settle the name.
+2. Backing-collection mechanics + migration (small, self-contained PR).
+3. Sync in `docker_ephemeral` (simplest runtime) end-to-end; then
+   `docker_pool` deltas and `k8s_pod`.
+4. Agent flag + tool binding.
+5. E2e: agent writes file → executes it → edits → re-executes across two
+   turns, asserting `FileVersion` history matches.

--- a/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+++ b/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
@@ -1,6 +1,6 @@
 # ADR: Workbench — one mutable file tree under both file tools and code execution
 
-- **Status:** Proposed
+- **Status:** Accepted (2026-09-01; `kind` discriminator confirmed, one workbench per chat — cross-chat sharing goes through collections via checkout/promote)
 - **Date:** 2026-09-01
 - **Authors:** Kjeld Oostra (with Claude)
 - **Related code:**

--- a/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+++ b/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
@@ -48,7 +48,8 @@ Introduce the **Workbench**: a per-chat mutable file tree that
 
 ### Naming
 
-"Workspace" is out: it already informally means the whole tenant in this
+**Decided: Workbench** (2026-09-01). The shortlist below is kept for the
+record. "Workspace" is out: it already informally means the whole tenant in this
 codebase (`agent.py:29` — "NULL = workspace-wide") and collides with
 claude.ai/Slack workspace vocabulary. Candidates considered:
 
@@ -96,8 +97,30 @@ sandbox runtimes and changes nothing about the sandbox trust boundary:
 - **Deltas, not full trees:** `FileVersion` already stores a content hash;
   send only what the sandbox hasn't seen (matters for `docker_pool`, where a
   warm container can keep its tree and receive deltas keyed on chat_id).
-  Cap tree size and per-file size from settings; oversized files stay
-  tool-accessible but are listed, not materialized, in the sandbox.
+  Cap eager materialization by per-file and total-tree size from settings.
+
+**Oversized files: lazy fetch over the pause channel.** Files above the
+eager cap (and, by the same mechanism, any file when the tree as a whole is
+too big) are materialized as **stubs** — the path exists, a manifest marks
+it lazy. "The file is needed" is signaled by the sandbox trying to read it:
+
+- The wrapper patches Python-level reads (`builtins.open` / `Path.open` /
+  `os.open`) for paths under the workbench root; a read of a lazy path
+  triggers a fetch instead of returning stub bytes.
+- The fetch transport is the **pause/resume channel that already exists**:
+  the executor protocol's `AWAITING_INPUT` generalizes to typed pause
+  requests (`kind: "fetch_file"`) that the backend auto-completes with the
+  version's content instead of waiting on a human — the exact "pluggable
+  completers" generalization the deferred-tools design already calls for,
+  so this is convergent work, not a side quest. On resume the wrapper
+  writes the real bytes over the stub and the read proceeds; `docker_pool`
+  containers keep fetched blobs by content hash, so each is paid for once.
+- The Python-level hook can't see raw reads from C extensions (memmap,
+  DB engines opening files directly). For those the sandbox context gets an
+  explicit `workbench.fetch(path)` helper, and the lazy manifest is visible
+  to the agent, so the model knows which paths to fetch before handing them
+  to native code. Good enough for v1; a FUSE layer that makes laziness
+  fully transparent is a later option behind the same interface.
 
 A k8s RWX subpath mount is a **later optimization behind the same
 interface**, not the v1: it requires RWX in prod, punches the file-storage
@@ -111,6 +134,31 @@ mechanics; binding a pooled container to a chat for its lifetime is a cost/
 lifecycle problem to take on only after sync proves the experience. Sync
 makes warmth an optimization instead of a correctness requirement — pool
 affinity by `chat_id` gets most of the feel with none of the lifecycle risk.
+
+### Chat uploads land in the workbench
+
+Chat uploads currently target a collection directly, which conflates "hand
+the agent a file to work on" with "commit a document to the curated
+library". With workbenches, uploads default to the chat's workbench, and
+**promotion** to a real collection is an explicit action (agent tool +
+UI affordance) that copies the current version out.
+
+The safety property collections provide today — pre/post upload hooks, used
+e.g. to filter sensitive images so they are never stored — carries over for
+free, because a workbench **is** a collection: workbench backing collections
+carry a deployment-level (overridable per-agent) default hook chain, so an
+upload to the workbench passes the same pre-upload filter before any bytes
+persist. Promotion then runs the *target* collection's own hooks at
+promotion time, since its policy may be stricter.
+
+Explicitly rejected: two-way sync between a workbench and a collection.
+It turns every sandbox write into a potential mutation of a curated,
+shared collection, needs conflict resolution in both directions, and
+double-writes version history. One-way promotion keeps the mental model
+(bench = working copy, shelf = published) and the audit trail clean.
+Front-ends that want today's behavior can still upload straight to a
+collection — the runtime upload endpoint keeps accepting an explicit
+collection target.
 
 ### Enablement
 
@@ -150,17 +198,16 @@ gains the sync behavior. This flag is the **only** config-apply touchpoint.
 
 ## Open questions
 
-1. Final name — Workbench is the recommendation; decide before code lands.
-2. Concurrency: what happens when two executions in one chat overlap? The
+1. Concurrency: what happens when two executions in one chat overlap? The
    per-chat lock from the steering triad is the clean answer; until it
    lands, last-write-wins per file (each write is a version, so nothing is
    lost, merely shadowed).
-3. Binary/large files: v1 caps materialization size — is "listed but not
-   materialized" acceptable, or do we need lazy fetch from inside the
-   sandbox (implies a sandbox→backend channel we currently don't have and
-   may not want)?
-4. Does the workbench also become the default target for user file uploads
-   in chat? (Probably yes; out of scope here.)
+2. The eager/lazy size thresholds and the shape of the default workbench
+   hook chain (deployment-level only, or per-agent overridable from day
+   one?).
+3. Whether promotion preserves version history in the target collection
+   (copy current version only, or replay the workbench's versions?). v1
+   leans current-version-only.
 
 ## What we'd NOT do
 
@@ -168,6 +215,8 @@ gains the sync behavior. This flag is the **only** config-apply touchpoint.
 - No RWX mounts into sandboxes in v1.
 - No session-pinned warm sandboxes in v1 (pool affinity at most).
 - No per-task workbench scope in v1.
+- No two-way workbench↔collection sync — promotion is an explicit one-way
+  copy.
 - No config-apply resource for workbenches — runtime state only.
 
 ## Next steps

--- a/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+++ b/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
@@ -46,6 +46,13 @@ Introduce the **Workbench**: a per-chat mutable file tree that
 2. is synchronized into that chat's sandbox executions (both directions), and
 3. persists across turns with the versioning Collections already have.
 
+The workbench is deliberately multi-purpose: it is the agent's scratchpad
+(intermediate results, working notes — cheap to write, versioned anyway)
+**and** the artifact surface — a deliverable (report, chart, generated
+document) is just a workbench file the chat UI renders or offers for
+download, and promotes to a collection when it should outlive the chat.
+No separate artifact concept is needed.
+
 ### Naming
 
 **Decided: Workbench** (2026-09-01). The shortlist below is kept for the
@@ -81,6 +88,31 @@ via `/chats/{id}/workbench`, authorized by chat access. Lifecycle follows
 the chat (archived/deleted with it). New alongside `kind`: relative-path
 filenames (`src/app.py`) — `File.name` is a 255-char string today, so
 nested paths fit; we validate against traversal.
+
+**Backward compatibility:** `kind` gets a `server_default='collection'`
+in the migration; existing rows, API request/response shapes, and config
+round-trips are untouched — the field is additive and clients never need
+to send it.
+
+**Alternative considered (open for review): no `kind`, plain collections
+plus careful permissioning.** Workbenches could be ordinary collections
+gated purely by grants. What tips it toward `kind` is not reachability
+but **grant compatibility**: existing deployments hold `collections:*`
+wildcard grants today, and without a discriminator those grants would
+silently widen to cover every chat's working files the day workbenches
+ship — the permission-level analogue of an API break. Secondary: without
+`kind`, each workbench needs a synthetic namespace/name (the reserved-
+namespace convention returns through the back door), and listings/config
+export need to filter them — that filter *is* a kind column. The audit
+argument does not require plain collections either: auditing follows the
+chat, which runtime access control already treats as the unit (strict
+owner check at `chats.py`), so a management/audit-level chat-read
+permission naturally covers `/chats/{id}/workbench` — the conversation
+and its files audit together, which is better audit semantics than
+reading working files detached from their transcript. What plain
+collections *would* buy is ACL-based workbench sharing for free; if
+sharing a workbench with a colleague ever becomes a requirement, revisit
+then.
 
 Scope is **per-chat** in v1. A per-task/per-delegation scope can layer on
 later by keying the backing collection differently; don't design for it now.
@@ -197,12 +229,29 @@ collections are remotes:
 - **Read via existing tools, unchanged:** the collection file tools keep
   working in workbench-enabled chats, with their existing permission and
   visibility checks. Browsing a collection doesn't require pulling it in.
-- **Checkout (v1):** an explicit `workbench_checkout(collection, path)`
-  tool copies a file (or prefix) into the workbench. The copy records
-  provenance in `file_metadata` (source collection, file id, version), so
-  promotion back to the source can be offered as an *update* — and can
-  detect that the source moved on since checkout and surface a conflict
-  instead of silently clobbering.
+- **Checkout (v1), single file or bulk:** an explicit
+  `workbench_checkout(collection, path_or_glob)` tool copies a file, a
+  prefix, a glob, or the whole collection into the workbench. Bulk is
+  permission-aware by construction: the collection permission gates the
+  call, and the file query applies the same visibility filter as search —
+  the caller's own private files plus `shared` ones; other users' private
+  files are never candidates. Bulk should also be **cheap**: `FileVersion`
+  stores a content hash, so checkout creates new `File`/`FileVersion` rows
+  that reference the existing stored blob instead of copying bytes —
+  copy-on-write, since any edit writes a new version anyway. (This needs
+  the `storage_path` unique constraint relaxed into a shared-blob
+  arrangement — a deliberate part of the checkout PR, with delete-time
+  refcounting to match.) Eager-sync caps still apply: a huge checked-out
+  dataset lands as lazy stubs in the sandbox and fetches on read.
+  Every checkout records provenance in `file_metadata` (source collection,
+  file id, version).
+- **Promote is the reverse of checkout** — the same round trip, outbound:
+  copy a workbench file into a target collection, running the target's
+  hooks and metadata validation. Where checkout provenance exists,
+  promote offers *update the source file* (and detects that the source
+  moved on since checkout, surfacing a conflict instead of clobbering);
+  without provenance — a file born in the workbench — promote creates a
+  new file in the target.
 - **Read-only lazy mount (v1.5):** selected collections can appear in the
   sandbox under a read-only root (e.g. `/collections/<name>/`) using the
   same stub + `fetch_file` pause channel as oversized workbench files —
@@ -286,6 +335,10 @@ gains the sync behavior. This flag is the **only** config-apply touchpoint.
 3. Whether promotion preserves version history in the target collection
    (copy current version only, or replay the workbench's versions?). v1
    leans current-version-only.
+4. `kind` column vs. plain collections with permission discipline — see
+   the alternative in Storage. Current lean: keep `kind` (grant
+   compatibility, no synthetic naming); revisit if workbench *sharing*
+   becomes a requirement.
 
 ## What we'd NOT do
 

--- a/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
+++ b/backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md
@@ -66,15 +66,21 @@ is cheap until code lands).
 
 ### Storage: a backing collection, not new tables
 
-A workbench **is** a collection with a reserved flavor — auto-created on first
-use, e.g. namespace `_workbench`, name = the chat's `session_key`, owned by
-the chat's user. This buys, for free: `File`/`FileVersion` versioning, the
-existing four file tools, storage backends, and the existing uniqueness/
-visibility machinery. What's new is a `kind` (or reserved-namespace
-convention) so workbenches are excluded from normal collection listings and
-lifecycle (deleted/archived with the chat), and relative-path filenames
-(`src/app.py`) — `File.name` is a 255-char string today, so nested paths fit;
-we validate against traversal.
+A workbench **is** a collection row — auto-created on first use, owned by
+the chat's user — but discriminated by a **`kind` column**
+(`'collection' | 'workbench'`), not by a reserved-namespace convention.
+Reusing the table buys `File`/`FileVersion` versioning, the four file
+tools' internals, storage backends, and uniqueness machinery for free.
+The `kind` discriminator is what keeps the reuse from leaking: workbench
+rows have no user-facing namespace/name identity (internal key only, e.g.
+the chat id), are **not addressable through the collections API at all**
+— every collections-API query and the collection permission resolver
+filter on `kind='collection'` at the query level, so there is no
+string-matched namespace exclusion anywhere — and are reached exclusively
+via `/chats/{id}/workbench`, authorized by chat access. Lifecycle follows
+the chat (archived/deleted with it). New alongside `kind`: relative-path
+filenames (`src/app.py`) — `File.name` is a 255-char string today, so
+nested paths fit; we validate against traversal.
 
 Scope is **per-chat** in v1. A per-task/per-delegation scope can layer on
 later by keying the backing collection differently; don't design for it now.
@@ -96,15 +102,14 @@ for `shared` to mean inside it.
   inherited default. With everything private, the existing per-file checks
   already deny reads and hide search results for any other user who
   reaches the backing collection through generic code paths.
-- **Authorization derives from chat access, not collection grants.** The
-  reserved `_workbench` namespace is excluded from wildcard collection
-  permission matching (`collections:*` must not sweep in other people's
-  workbenches) and from collection listings; the rule is: you can reach a
-  workbench iff you can reach its chat. Operator/support access to
+- **Authorization derives from chat access, not collection grants.**
+  Because workbench rows are typed `kind='workbench'` and filtered out of
+  the collections API and permission resolver at the query level (see
+  Storage above), a wildcard `collections:*` grant structurally cannot
+  reach them — no namespace string-matching involved. The rule is: you can
+  reach a workbench iff you can reach its chat. Operator/support access to
   workbench contents, if wanted, is its own explicit permission — never a
-  side effect of a broad collection grant. This is belt-and-braces on top
-  of the private-visibility guarantee, and it's the part to test
-  adversarially.
+  side effect of a broad collection grant. Test this adversarially anyway.
 - **`metadata_schema` / `file_metadata`:** backing collections carry no
   metadata schema (free-form); `file_metadata` stays available and is where
   workbench bookkeeping lives (e.g. `origin: upload | tool | execution`,
@@ -174,6 +179,39 @@ lifecycle problem to take on only after sync proves the experience. Sync
 makes warmth an optimization instead of a correctness requirement — pool
 affinity by `chat_id` gets most of the feel with none of the lifecycle risk.
 
+### Collections and the workbench: checkout, not mount
+
+A chat's user typically holds permissions on several collections. Those
+collections are **not** mounted into the workbench or the sandbox. Three
+reasons: the sandbox tree is all-or-nothing (a mounted collection would
+expose `shared` files wholesale and bypass per-file `private` visibility
+the moment code, not the tool layer, does the reading); auto-mounting
+makes every sandbox write a potential mutation of curated shared data
+(the two-way-sync problem in a different coat); and eagerly syncing
+everything a user can read is exactly the transfer-cost explosion the
+lazy design avoids.
+
+Instead, the git mental model — the workbench is the working copy,
+collections are remotes:
+
+- **Read via existing tools, unchanged:** the collection file tools keep
+  working in workbench-enabled chats, with their existing permission and
+  visibility checks. Browsing a collection doesn't require pulling it in.
+- **Checkout (v1):** an explicit `workbench_checkout(collection, path)`
+  tool copies a file (or prefix) into the workbench. The copy records
+  provenance in `file_metadata` (source collection, file id, version), so
+  promotion back to the source can be offered as an *update* — and can
+  detect that the source moved on since checkout and surface a conflict
+  instead of silently clobbering.
+- **Read-only lazy mount (v1.5):** selected collections can appear in the
+  sandbox under a read-only root (e.g. `/collections/<name>/`) using the
+  same stub + `fetch_file` pause channel as oversized workbench files —
+  the manifest is built per-user (private files of others never listed),
+  and the backend re-checks permission on every fetch. Read-only means no
+  write-back semantics to design; modifying still goes through checkout.
+  This lands after the fetch channel exists and only if checkout proves
+  too much friction.
+
 ### Chat uploads land in the workbench
 
 Chat uploads currently target a collection directly, which conflates "hand
@@ -228,7 +266,8 @@ gains the sync behavior. This flag is the **only** config-apply touchpoint.
 
 | Component | Change |
 |---|---|
-| `models/file.py` + migration | collection `kind` (or reserved namespace) for workbench backing collections; chat-lifecycle cascade |
+| `models/file.py` + migration | `kind` discriminator on collections; workbench rows carry no public namespace/name; chat-lifecycle cascade; collections-API queries and permission resolver filter `kind='collection'` |
+| `collection_tools.py` (new tool) | `workbench_checkout` — copy collection files into the workbench with provenance metadata |
 | `collection_tools.py` | resolve the implicit target collection to the chat's workbench when the agent flag is on; accept nested paths |
 | `code_execution.py` | build sync manifest from `chat_id`; write back changed files post-execution |
 | `executor/` wrapper + `container_executor.py` | materialize tree pre-run, hash-walk and return changes post-run |

--- a/backend/tests/unit/test_workbench.py
+++ b/backend/tests/unit/test_workbench.py
@@ -454,3 +454,82 @@ class TestSandboxSync:
         ns["handler"]({"workbench_files": [], "workbench_limits": {}}, {})
         after = set(glob.glob(os.path.join(tempfile.gettempdir(), "workbench_*")))
         assert after == before
+
+
+# ---------------------------------------------------------------------------
+# Runtime workbench API (chat uploads + browsing)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkbenchAPI:
+    @pytest.mark.asyncio
+    async def test_upload_list_read_delete_roundtrip(self, db, chat, client, test_user):
+        import base64
+
+        headers = auth_headers(test_user)
+        upload = {
+            "name": "data/report.csv",
+            "content_base64": base64.b64encode(b"a,b\n1,2\n").decode(),
+        }
+        resp = await client.post(f"/chats/{chat.id}/workbench/files", json=upload, headers=headers)
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["name"] == "data/report.csv"
+        assert body["content_type"] == "text/csv"
+        assert body["file_metadata"]["origin"] == "upload"
+
+        # The stored file is private and owned by the chat user
+        wb = await get_or_create_workbench(db, chat)
+        from sqlalchemy import select
+        f = (await db.execute(select(File).where(File.collection_id == wb.id))).scalar_one()
+        assert f.visibility == "private"
+
+        resp = await client.get(f"/chats/{chat.id}/workbench/files", headers=headers)
+        assert resp.status_code == 200
+        assert [e["name"] for e in resp.json()] == ["data/report.csv"]
+
+        resp = await client.get(
+            f"/chats/{chat.id}/workbench/files/data/report.csv", headers=headers
+        )
+        assert resp.status_code == 200
+        assert base64.b64decode(resp.json()["content_base64"]) == b"a,b\n1,2\n"
+
+        resp = await client.delete(
+            f"/chats/{chat.id}/workbench/files/data/report.csv", headers=headers
+        )
+        assert resp.status_code == 204
+        resp = await client.get(
+            f"/chats/{chat.id}/workbench/files/data/report.csv", headers=headers
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_other_users_chat_is_404(self, chat, client, admin_user):
+        resp = await client.get(f"/chats/{chat.id}/workbench/files", headers=auth_headers(admin_user))
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_traversal_upload_rejected(self, chat, client, test_user):
+        import base64
+
+        resp = await client.post(
+            f"/chats/{chat.id}/workbench/files",
+            json={"name": "../../etc/passwd", "content_base64": base64.b64encode(b"x").decode()},
+            headers=auth_headers(test_user),
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_agent_tools_see_uploaded_file(self, db, chat, client, test_user):
+        import base64
+
+        resp = await client.post(
+            f"/chats/{chat.id}/workbench/files",
+            json={"name": "notes.md", "content_base64": base64.b64encode(b"# hi").decode()},
+            headers=auth_headers(test_user),
+        )
+        assert resp.status_code == 201
+        result = await WorkbenchTools().execute_tool(
+            db, chat, str(test_user.id), "workbench_read", {"filename": "notes.md"}
+        )
+        assert "# hi" in str(result)

--- a/backend/tests/unit/test_workbench.py
+++ b/backend/tests/unit/test_workbench.py
@@ -668,3 +668,124 @@ class TestLazyFetchWrapper:
         import base64
         changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in output["workbench_changes"]}
         assert changes["size.txt"] == b"123"
+
+
+# ---------------------------------------------------------------------------
+# docker_pool delta sync + affinity
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaAndAffinity:
+    def test_wrapper_writes_and_reuses_blob_cache(self):
+        """First run ships bytes and populates /tmp/wb_cache; second run
+        ships a cached reference and the wrapper restores it from the cache."""
+        import base64
+        import hashlib
+        import os as _os
+        import uuid as _uuid
+
+        from app.services.code_execution import _build_wrapper
+
+        content = f"unique-{_uuid.uuid4().hex}".encode()
+        sha = hashlib.sha256(content).hexdigest()
+
+        wrapper = _build_wrapper("data = open('input.txt').read()\n", workbench=True)
+        ns: dict = {}
+        exec(wrapper, ns)
+        out = ns["handler"](
+            {
+                "workbench_files": [
+                    {"path": "input.txt", "content_b64": base64.b64encode(content).decode(), "sha256": sha}
+                ],
+                "workbench_limits": {},
+            },
+            {"execution_id": _uuid.uuid4().hex},
+        )
+        assert out["status"] == "completed", out
+        assert _os.path.exists(f"/tmp/wb_cache/{sha}")
+
+        # Second execution: cached reference only, no bytes.
+        wrapper2 = _build_wrapper(
+            "content = open('input.txt').read()\n"
+            "with open('echo.txt', 'w') as f:\n"
+            "    f.write(content)\n",
+            workbench=True,
+        )
+        ns2: dict = {}
+        exec(wrapper2, ns2)
+        out = ns2["handler"](
+            {
+                "workbench_files": [{"path": "input.txt", "sha256": sha, "cached": True}],
+                "workbench_limits": {},
+            },
+            {"execution_id": _uuid.uuid4().hex},
+        )
+        assert out["status"] == "completed", out
+        changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in out["workbench_changes"]}
+        assert changes == {"echo.txt": content}
+
+    def test_cached_reference_with_cold_cache_degrades_to_lazy_fetch(self):
+        import base64
+        import hashlib
+        import threading
+        import uuid as _uuid
+
+        from app.services.code_execution import _build_wrapper
+
+        content = b"cold-cache-content"
+        sha = hashlib.sha256(b"never-cached-" + _uuid.uuid4().hex.encode()).hexdigest()
+        eid = _uuid.uuid4().hex
+
+        wrapper = _build_wrapper(
+            "data = open('cold.txt').read()\n"
+            "with open('copy.txt', 'w') as f:\n"
+            "    f.write(data)\n",
+            workbench=True,
+        )
+        ns: dict = {}
+        exec(wrapper, ns)
+        server = threading.Thread(
+            target=_serve_one_fetch, args=(eid, {"cold.txt": content}), daemon=True
+        )
+        server.start()
+        out = ns["handler"](
+            {
+                "workbench_files": [{"path": "cold.txt", "sha256": sha, "cached": True}],
+                "workbench_limits": {},
+            },
+            {"execution_id": eid},
+        )
+        server.join(timeout=5)
+        assert out["status"] == "completed", out
+        changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in out["workbench_changes"]}
+        assert changes == {"copy.txt": content}
+
+    @pytest.mark.asyncio
+    async def test_pool_acquire_prefers_chat_affine_container(self):
+        from app.services.container_pool import ContainerPool, PooledContainer
+
+        pool = ContainerPool()
+
+        class _FakeContainers:
+            def get(self, name):
+                return object()
+
+        class _FakeClient:
+            containers = _FakeContainers()
+
+        pool._client = _FakeClient()
+        a = PooledContainer(name="sinas-sandbox-1", container_id="a")
+        b = PooledContainer(name="sinas-sandbox-2", container_id="b", last_chat_id="chat-42")
+        c = PooledContainer(name="sinas-sandbox-3", container_id="c")
+        pool.idle.extend([a, b, c])
+
+        got = await pool.acquire(timeout=1, chat_id="chat-42")
+        assert got is b
+
+        # Without affinity, FIFO order holds.
+        got = await pool.acquire(timeout=1)
+        assert got is a
+
+        # Affinity stamps the chat on whatever container was handed out.
+        got = await pool.acquire(timeout=1, chat_id="chat-7")
+        assert got is c and c.last_chat_id == "chat-7"

--- a/backend/tests/unit/test_workbench.py
+++ b/backend/tests/unit/test_workbench.py
@@ -1,0 +1,326 @@
+"""Workbench: per-chat working tree — fence, tools, checkout/promote.
+
+Covers the two contracts from the workbench ADR:
+- the kind='workbench' fence: workbench rows are invisible to every
+  collections-facing surface (by-name resolution, wildcard tool expansion,
+  the collections API), even for wildcard/admin grants;
+- workbench semantics: private-only files, chat-scoped access, checkout
+  with provenance and visibility filtering, promote as checkout's reverse
+  (source update with conflict detection, else create-in-target).
+"""
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat
+from app.models.file import Collection, File
+from app.models.user import RolePermission, User
+from app.services.collection_tools import CollectionToolConverter
+from app.services.workbench import (
+    PROVENANCE_KEY,
+    WorkbenchTools,
+    get_or_create_workbench,
+    get_workbench_tool_definitions,
+)
+
+from tests.conftest import auth_headers
+
+
+@pytest.fixture(autouse=True)
+def _tmp_file_storage(tmp_path, monkeypatch):
+    """Point file storage at a per-test temp dir (and drop the cached backend)."""
+    import app.services.file_storage as fs
+
+    monkeypatch.setenv("FILE_STORAGE_PATH", str(tmp_path / "files"))
+    fs._storage = None
+    yield
+    fs._storage = None
+
+
+@pytest_asyncio.fixture
+async def chat(db: AsyncSession, test_user: User) -> Chat:
+    c = Chat(user_id=test_user.id, title="workbench test chat")
+    db.add(c)
+    await db.flush()
+    await db.refresh(c)
+    return c
+
+
+async def _grant(db: AsyncSession, user: User, *perm_keys: str) -> None:
+    """Attach permission keys to the user's first active role."""
+    from sqlalchemy import select
+    from app.models.user import UserRole
+
+    role_id = (
+        await db.execute(select(UserRole.role_id).where(UserRole.user_id == user.id).limit(1))
+    ).scalar_one()
+    for key in perm_keys:
+        db.add(RolePermission(role_id=role_id, permission_key=key, permission_value=True))
+    await db.flush()
+
+
+async def _make_collection(db: AsyncSession, owner: User, name: str, **kwargs) -> Collection:
+    coll = Collection(namespace="test", name=name, user_id=owner.id, **kwargs)
+    db.add(coll)
+    await db.flush()
+    await db.refresh(coll)
+    return coll
+
+
+# ---------------------------------------------------------------------------
+# The fence
+# ---------------------------------------------------------------------------
+
+
+class TestWorkbenchFence:
+    @pytest.mark.asyncio
+    async def test_get_by_name_never_resolves_workbenches(self, db, chat):
+        wb = await get_or_create_workbench(db, chat)
+        assert wb.kind == "workbench"
+        found = await Collection.get_by_name(db, wb.namespace, wb.name)
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_wildcard_tool_expansion_skips_workbenches(self, db, chat, test_user):
+        await get_or_create_workbench(db, chat)
+        await _make_collection(db, test_user, f"real-{uuid.uuid4().hex[:6]}")
+
+        tools = await CollectionToolConverter().get_available_collections(
+            db=db, user_id=str(test_user.id), enabled_collections=["*/*"]
+        )
+        refs = {t["function"]["_metadata"]["collection_ref"] for t in tools}
+        assert refs  # the real collection produced tools
+        assert not any(ref.startswith("_chat/") for ref in refs)
+
+    @pytest.mark.asyncio
+    async def test_collections_api_hides_workbenches_even_from_admin(
+        self, db, chat, client, admin_user
+    ):
+        wb = await get_or_create_workbench(db, chat)
+
+        resp = await client.get("/api/v1/collections", headers=auth_headers(admin_user))
+        assert resp.status_code == 200
+        names = {(c["namespace"], c["name"]) for c in resp.json()}
+        assert (wb.namespace, wb.name) not in names
+
+        resp = await client.get(
+            f"/api/v1/collections/{wb.namespace}/{wb.name}", headers=auth_headers(admin_user)
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Core tool semantics
+# ---------------------------------------------------------------------------
+
+
+class TestWorkbenchTools:
+    @pytest.mark.asyncio
+    async def test_get_or_create_is_idempotent(self, db, chat):
+        first = await get_or_create_workbench(db, chat)
+        second = await get_or_create_workbench(db, chat)
+        assert first.id == second.id
+
+    @pytest.mark.asyncio
+    async def test_write_read_edit_roundtrip_forces_private(self, db, chat, test_user):
+        tools = WorkbenchTools()
+        uid = str(test_user.id)
+
+        result = await tools.execute_tool(
+            db, chat, uid, "workbench_write",
+            {"filename": "src/app.py", "content": "print('hello')\n"},
+        )
+        assert result.get("created") is True and result["version"] == 1
+
+        wb = await get_or_create_workbench(db, chat)
+        from sqlalchemy import select
+        f = (
+            await db.execute(select(File).where(File.collection_id == wb.id))
+        ).scalar_one()
+        assert f.visibility == "private"
+        assert f.user_id == chat.user_id
+
+        result = await tools.execute_tool(
+            db, chat, uid, "workbench_edit",
+            {"filename": "src/app.py", "old_string": "hello", "new_string": "workbench"},
+        )
+        assert "error" not in result and result["version"] == 2
+
+        result = await tools.execute_tool(db, chat, uid, "workbench_read", {"filename": "src/app.py"})
+        assert "workbench" in str(result)
+
+        result = await tools.execute_tool(db, chat, uid, "workbench_list", {})
+        assert result.get("count", len(result.get("files", []))) >= 1
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self, db, chat, test_user):
+        tools = WorkbenchTools()
+        for bad in ("../escape.txt", "/abs.txt", "a//b.txt", "a/../b.txt"):
+            result = await tools.execute_tool(
+                db, chat, str(test_user.id), "workbench_write", {"filename": bad, "content": "x"}
+            )
+            assert "error" in result, bad
+
+    @pytest.mark.asyncio
+    async def test_other_user_cannot_use_someone_elses_chat_workbench(
+        self, db, chat, admin_user
+    ):
+        result = await WorkbenchTools().execute_tool(
+            db, chat, str(admin_user.id), "workbench_write", {"filename": "x.txt", "content": "x"}
+        )
+        assert "error" in result
+
+    def test_tool_definitions_shape(self):
+        defs = get_workbench_tool_definitions()
+        names = {d["function"]["name"] for d in defs}
+        assert names == {
+            "workbench_list", "workbench_read", "workbench_write", "workbench_edit",
+            "workbench_delete", "workbench_checkout", "workbench_promote",
+        }
+        for d in defs:
+            assert d["function"]["_metadata"]["tool_type"].startswith("workbench_")
+
+
+# ---------------------------------------------------------------------------
+# Checkout / promote
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def source_collection(db, test_user, admin_user):
+    """A collection with a shared file, an own-private file, and another
+    user's private file (which checkout must never copy)."""
+    coll = await _make_collection(db, test_user, f"src-{uuid.uuid4().hex[:6]}")
+    from app.services.workbench import _write_bytes
+    from app.services.file_storage import get_storage
+
+    storage = get_storage()
+    await _write_bytes(
+        db, storage, coll, filename="shared.txt", content=b"shared data",
+        content_type="text/plain", user_id=str(test_user.id), visibility="shared",
+    )
+    await _write_bytes(
+        db, storage, coll, filename="mine.txt", content=b"my private data",
+        content_type="text/plain", user_id=str(test_user.id), visibility="private",
+    )
+    await _write_bytes(
+        db, storage, coll, filename="theirs.txt", content=b"someone else's secret",
+        content_type="text/plain", user_id=str(admin_user.id), visibility="private",
+    )
+    return coll
+
+
+class TestCheckoutPromote:
+    @pytest.mark.asyncio
+    async def test_checkout_requires_download_permission(self, db, chat, test_user, source_collection):
+        result = await WorkbenchTools().execute_tool(
+            db, chat, str(test_user.id), "workbench_checkout",
+            {"collection": f"test/{source_collection.name}"},
+        )
+        assert result.get("error") == "Permission denied"
+
+    @pytest.mark.asyncio
+    async def test_bulk_checkout_respects_visibility_and_records_provenance(
+        self, db, chat, test_user, source_collection
+    ):
+        await _grant(db, test_user, "sinas.collections/*/*.download:own")
+
+        result = await WorkbenchTools().execute_tool(
+            db, chat, str(test_user.id), "workbench_checkout",
+            {"collection": f"test/{source_collection.name}"},
+        )
+        names = {e["filename"] for e in result["checked_out"]}
+        assert names == {"shared.txt", "mine.txt"}  # never theirs.txt
+
+        wb = await get_or_create_workbench(db, chat)
+        from sqlalchemy import select
+        rows = (await db.execute(select(File).where(File.collection_id == wb.id))).scalars().all()
+        assert {f.name for f in rows} == names
+        for f in rows:
+            assert f.visibility == "private"
+            prov = f.file_metadata[PROVENANCE_KEY]
+            assert prov["collection"] == f"test/{source_collection.name}"
+            assert prov["version"] == 1
+
+    @pytest.mark.asyncio
+    async def test_checkout_glob_pattern(self, db, chat, test_user, source_collection):
+        await _grant(db, test_user, "sinas.collections/*/*.download:own")
+        result = await WorkbenchTools().execute_tool(
+            db, chat, str(test_user.id), "workbench_checkout",
+            {"collection": f"test/{source_collection.name}", "pattern": "shared.*"},
+        )
+        assert [e["filename"] for e in result["checked_out"]] == ["shared.txt"]
+
+    @pytest.mark.asyncio
+    async def test_promote_new_file_into_target(self, db, chat, test_user):
+        await _grant(db, test_user, "sinas.collections/*/*.upload:own")
+        target = await _make_collection(db, test_user, f"tgt-{uuid.uuid4().hex[:6]}")
+        tools = WorkbenchTools()
+        uid = str(test_user.id)
+
+        await tools.execute_tool(
+            db, chat, uid, "workbench_write", {"filename": "report.md", "content": "# Findings\n"}
+        )
+        result = await tools.execute_tool(
+            db, chat, uid, "workbench_promote",
+            {"filename": "report.md", "collection": f"test/{target.name}"},
+        )
+        assert result.get("updated_source") is False and result["version"] == 1
+
+        from sqlalchemy import select
+        promoted = (
+            await db.execute(select(File).where(File.collection_id == target.id))
+        ).scalar_one()
+        assert promoted.name == "report.md"
+        assert promoted.visibility == "private"
+
+    @pytest.mark.asyncio
+    async def test_promote_updates_source_and_detects_conflict(
+        self, db, chat, test_user, source_collection
+    ):
+        await _grant(
+            db, test_user,
+            "sinas.collections/*/*.download:own",
+            "sinas.collections/*/*.upload:own",
+        )
+        tools = WorkbenchTools()
+        uid = str(test_user.id)
+        ref = f"test/{source_collection.name}"
+
+        await tools.execute_tool(
+            db, chat, uid, "workbench_checkout", {"collection": ref, "path": "shared.txt"}
+        )
+        await tools.execute_tool(
+            db, chat, uid, "workbench_edit",
+            {"filename": "shared.txt", "old_string": "shared data", "new_string": "edited data"},
+        )
+
+        result = await tools.execute_tool(
+            db, chat, uid, "workbench_promote", {"filename": "shared.txt", "collection": ref}
+        )
+        assert result.get("updated_source") is True and result["version"] == 2
+
+        # A second promote must not conflict with its own update…
+        result = await tools.execute_tool(
+            db, chat, uid, "workbench_promote", {"filename": "shared.txt", "collection": ref}
+        )
+        assert result.get("updated_source") is True and result["version"] == 3
+
+        # …but someone else moving the source on must surface a conflict.
+        from sqlalchemy import select
+        source_file = (
+            await db.execute(
+                select(File).where(
+                    File.collection_id == source_collection.id, File.name == "shared.txt"
+                )
+            )
+        ).scalar_one()
+        source_file.current_version += 1
+        await db.flush()
+
+        result = await tools.execute_tool(
+            db, chat, uid, "workbench_promote", {"filename": "shared.txt", "collection": ref}
+        )
+        assert result.get("error") == "conflict"

--- a/backend/tests/unit/test_workbench.py
+++ b/backend/tests/unit/test_workbench.py
@@ -362,9 +362,9 @@ class TestSandboxSync:
         assert {f["path"] for f in manifest["files"]} == {"data/input.txt", "data/output.txt"}
 
     @pytest.mark.asyncio
-    async def test_manifest_skips_oversized_files(self, db, chat, test_user, monkeypatch):
+    async def test_manifest_marks_oversized_files_lazy(self, db, chat, test_user, monkeypatch):
         from app.core.config import settings as app_settings
-        from app.services.workbench import build_sync_manifest
+        from app.services.workbench import build_sync_manifest, fetch_file_bytes
 
         monkeypatch.setattr(app_settings, "workbench_sync_max_file_bytes", 10)
         tools = WorkbenchTools()
@@ -378,7 +378,18 @@ class TestSandboxSync:
 
         manifest = await build_sync_manifest(db, chat)
         assert [f["path"] for f in manifest["files"]] == ["small.txt"]
-        assert manifest["skipped"][0]["path"] == "big.txt"
+        assert [e["path"] for e in manifest["lazy"]] == ["big.txt"]
+        assert manifest["skipped"] == []
+
+        # The lazy file is servable over the fetch channel…
+        import base64
+        result = await fetch_file_bytes(db, chat, "big.txt", max_bytes=1024)
+        assert base64.b64decode(result["content_b64"]) == b"x" * 100
+        # …within the fetch cap, and traversal paths are rejected.
+        result = await fetch_file_bytes(db, chat, "big.txt", max_bytes=10)
+        assert "error" in result
+        result = await fetch_file_bytes(db, chat, "../escape", max_bytes=1024)
+        assert "error" in result
 
     def test_wrapper_materializes_and_reports_changes(self):
         """Run the real sandbox wrapper in-process: files land in cwd, and
@@ -533,3 +544,127 @@ class TestWorkbenchAPI:
             db, chat, str(test_user.id), "workbench_read", {"filename": "notes.md"}
         )
         assert "# hi" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# Lazy fetch (stub materialization, open() hook, pause-channel roundtrip)
+# ---------------------------------------------------------------------------
+
+
+def _serve_one_fetch(eid: str, responses: dict):
+    """Background thread playing the backend: waits for the wrapper's fetch
+    request file and answers it, like the executor wait-loop does."""
+    import base64
+    import hashlib
+    import json as _json
+    import os as _os
+    import time as _time
+
+    req = f"/tmp/wb_fetch_req_{eid}.json"
+    resp = f"/tmp/wb_fetch_resp_{eid}.json"
+    deadline = _time.time() + 10
+    while _time.time() < deadline:
+        if _os.path.exists(req):
+            with open(req) as fh:
+                request = _json.load(fh)
+            _os.remove(req)
+            path = request["path"]
+            if path in responses:
+                content = responses[path]
+                payload = {
+                    "path": path,
+                    "content_b64": base64.b64encode(content).decode(),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                }
+            else:
+                payload = {"path": path, "error": "not found"}
+            with open(resp + ".tmp", "w") as fh:
+                _json.dump(payload, fh)
+            _os.replace(resp + ".tmp", resp)
+            return
+        _time.sleep(0.02)
+
+
+class TestLazyFetchWrapper:
+    def _run(self, user_code: str, lazy: list, responses: dict, files: list = ()):
+        import threading
+        import uuid as _uuid
+
+        from app.services.code_execution import _build_wrapper
+
+        eid = _uuid.uuid4().hex
+        wrapper = _build_wrapper(user_code, workbench=True)
+        ns: dict = {}
+        exec(wrapper, ns)
+        server = threading.Thread(target=_serve_one_fetch, args=(eid, responses), daemon=True)
+        server.start()
+        output = ns["handler"](
+            {
+                "workbench_files": list(files),
+                "workbench_lazy": [{"path": p} for p in lazy],
+                "workbench_limits": {"max_file_bytes": 4096, "max_total_bytes": 8192},
+            },
+            {"execution_id": eid},
+        )
+        server.join(timeout=5)
+        return output
+
+    def test_open_of_lazy_file_fetches_real_bytes(self):
+        output = self._run(
+            "data = open('big.csv').read()\n"
+            "with open('summary.txt', 'w') as f:\n"
+            "    f.write(str(len(data)))\n",
+            lazy=["big.csv"],
+            responses={"big.csv": b"a,b\n" * 50},
+        )
+        assert output["status"] == "completed", output
+        import base64
+        changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in output["workbench_changes"]}
+        # The fetched-but-unmodified lazy file is NOT a change; only summary.txt is.
+        assert changes == {"summary.txt": b"200"}
+
+    def test_unfetched_stub_never_reported_as_change(self):
+        output = self._run(
+            "x = 1\n",
+            lazy=["huge.bin"],
+            responses={},
+        )
+        assert output["status"] == "completed"
+        assert output["workbench_changes"] == []
+
+    def test_modified_lazy_file_is_a_change(self):
+        output = self._run(
+            "content = open('doc.txt').read()\n"
+            "with open('doc.txt', 'w') as f:\n"
+            "    f.write(content + ' edited')\n",
+            lazy=["doc.txt"],
+            responses={"doc.txt": b"original"},
+        )
+        assert output["status"] == "completed", output
+        import base64
+        changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in output["workbench_changes"]}
+        assert changes == {"doc.txt": b"original edited"}
+
+    def test_fetch_error_surfaces_to_user_code(self):
+        output = self._run(
+            "open('missing.bin').read()\n",
+            lazy=["missing.bin"],
+            responses={},
+        )
+        assert output["status"] == "failed"
+        assert "missing.bin" in output.get("error", "")
+
+    def test_explicit_workbench_fetch_helper(self):
+        output = self._run(
+            "workbench_fetch('blob.bin')\n"
+            "import os\n"
+            "size = os.path.getsize('blob.bin')\n"
+            "with open('size.txt', 'w') as f:\n"
+            "    f.write(str(size))\n",
+            lazy=["blob.bin"],
+            responses={"blob.bin": b"\x00" * 123},
+        )
+        assert output["status"] == "completed", output
+        import base64
+        changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in output["workbench_changes"]}
+        assert changes["size.txt"] == b"123"

--- a/backend/tests/unit/test_workbench.py
+++ b/backend/tests/unit/test_workbench.py
@@ -8,6 +8,7 @@ Covers the two contracts from the workbench ADR:
   with provenance and visibility filtering, promote as checkout's reverse
   (source update with conflict detection, else create-in-target).
 """
+import os
 import uuid
 
 import pytest
@@ -324,3 +325,132 @@ class TestCheckoutPromote:
             db, chat, uid, "workbench_promote", {"filename": "shared.txt", "collection": ref}
         )
         assert result.get("error") == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox sync (copy-in manifest, wrapper diff, copy-out write-back)
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxSync:
+    @pytest.mark.asyncio
+    async def test_manifest_and_write_back_roundtrip(self, db, chat, test_user):
+        from app.services.workbench import apply_sync_changes, build_sync_manifest
+
+        tools = WorkbenchTools()
+        uid = str(test_user.id)
+        await tools.execute_tool(
+            db, chat, uid, "workbench_write", {"filename": "data/input.txt", "content": "42\n"}
+        )
+
+        manifest = await build_sync_manifest(db, chat)
+        assert [f["path"] for f in manifest["files"]] == ["data/input.txt"]
+        assert manifest["skipped"] == []
+
+        import base64
+        result = await apply_sync_changes(
+            db, chat, uid,
+            [
+                {"path": "data/output.txt", "content_b64": base64.b64encode(b"84\n").decode()},
+                {"path": "../evil.txt", "content_b64": base64.b64encode(b"x").decode()},
+            ],
+        )
+        assert result["synced"] == ["data/output.txt"]
+        assert result["rejected"][0]["path"] == "../evil.txt"
+
+        manifest = await build_sync_manifest(db, chat)
+        assert {f["path"] for f in manifest["files"]} == {"data/input.txt", "data/output.txt"}
+
+    @pytest.mark.asyncio
+    async def test_manifest_skips_oversized_files(self, db, chat, test_user, monkeypatch):
+        from app.core.config import settings as app_settings
+        from app.services.workbench import build_sync_manifest
+
+        monkeypatch.setattr(app_settings, "workbench_sync_max_file_bytes", 10)
+        tools = WorkbenchTools()
+        uid = str(test_user.id)
+        await tools.execute_tool(
+            db, chat, uid, "workbench_write", {"filename": "big.txt", "content": "x" * 100}
+        )
+        await tools.execute_tool(
+            db, chat, uid, "workbench_write", {"filename": "small.txt", "content": "ok"}
+        )
+
+        manifest = await build_sync_manifest(db, chat)
+        assert [f["path"] for f in manifest["files"]] == ["small.txt"]
+        assert manifest["skipped"][0]["path"] == "big.txt"
+
+    def test_wrapper_materializes_and_reports_changes(self):
+        """Run the real sandbox wrapper in-process: files land in cwd, and
+        created/changed files come back as workbench_changes by hash diff."""
+        import base64
+        import hashlib
+
+        from app.services.code_execution import _build_wrapper
+
+        user_code = (
+            "content = open('data/input.txt').read()\n"
+            "with open('result.txt', 'w') as f:\n"
+            "    f.write(content.upper())\n"
+            "with open('untouched.txt', 'w') as f:\n"
+            "    f.write('same')\n"
+        )
+        wrapper = _build_wrapper(user_code, workbench=True)
+        ns: dict = {}
+        exec(wrapper, ns)
+
+        untouched = b"same"
+        input_data = {
+            "workbench_files": [
+                {
+                    "path": "data/input.txt",
+                    "content_b64": base64.b64encode(b"hello").decode(),
+                    "sha256": hashlib.sha256(b"hello").hexdigest(),
+                },
+                {
+                    "path": "untouched.txt",
+                    "content_b64": base64.b64encode(untouched).decode(),
+                    "sha256": hashlib.sha256(untouched).hexdigest(),
+                },
+            ],
+            "workbench_limits": {"max_file_bytes": 1024, "max_total_bytes": 4096},
+        }
+        output = ns["handler"](input_data, {})
+        assert output["status"] == "completed", output
+
+        changes = {c["path"]: base64.b64decode(c["content_b64"]) for c in output["workbench_changes"]}
+        # result.txt is new; untouched.txt was rewritten with identical bytes
+        # (hash-identical → not a change); input.txt was only read.
+        assert changes == {"result.txt": b"HELLO"}
+
+    def test_wrapper_reports_changes_even_when_user_code_fails(self):
+        import base64
+
+        from app.services.code_execution import _build_wrapper
+
+        user_code = (
+            "with open('partial.txt', 'w') as f:\n"
+            "    f.write('progress')\n"
+            "raise RuntimeError('boom')\n"
+        )
+        wrapper = _build_wrapper(user_code, workbench=True)
+        ns: dict = {}
+        exec(wrapper, ns)
+        output = ns["handler"]({"workbench_files": [], "workbench_limits": {}}, {})
+        assert output["status"] == "failed"
+        changes = {c["path"] for c in output["workbench_changes"]}
+        assert changes == {"partial.txt"}
+
+    def test_wrapper_cleans_up_temp_tree(self, tmp_path):
+        import glob
+        import tempfile
+
+        from app.services.code_execution import _build_wrapper
+
+        before = set(glob.glob(os.path.join(tempfile.gettempdir(), "workbench_*")))
+        wrapper = _build_wrapper("x = 1\n", workbench=True)
+        ns: dict = {}
+        exec(wrapper, ns)
+        ns["handler"]({"workbench_files": [], "workbench_limits": {}}, {})
+        after = set(glob.glob(os.path.join(tempfile.gettempdir(), "workbench_*")))
+        assert after == before

--- a/console/src/components/workbench/WorkbenchPanel.tsx
+++ b/console/src/components/workbench/WorkbenchPanel.tsx
@@ -1,0 +1,249 @@
+import { useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../../lib/api';
+import type { WorkbenchFile } from '../../types';
+import {
+  Download,
+  FileText,
+  FolderOpen,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  Upload,
+  X,
+} from 'lucide-react';
+
+function formatSize(bytes: number | null): string {
+  if (bytes === null || bytes === undefined) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function isTextual(contentType: string): boolean {
+  return (
+    contentType.startsWith('text/') ||
+    [
+      'application/json',
+      'application/x-yaml',
+      'application/sql',
+      'application/javascript',
+      'application/typescript',
+      'application/xml',
+    ].includes(contentType)
+  );
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+/** The chat's workbench: the working tree the agent reads, writes, and
+ * executes against. Files uploaded here are visible to the agent's
+ * workbench tools and materialize into its code executions. */
+export function WorkbenchPanel({ chatId, onClose }: { chatId: string; onClose?: () => void }) {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<{ name: string; text: string } | null>(null);
+  const [busyFile, setBusyFile] = useState<string | null>(null);
+
+  const filesKey = ['workbench-files', chatId];
+  const { data: files, isLoading, refetch, isFetching } = useQuery({
+    queryKey: filesKey,
+    queryFn: () => apiClient.listWorkbenchFiles(chatId),
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: globalThis.File) => {
+      const buffer = await file.arrayBuffer();
+      let binary = '';
+      const bytes = new Uint8Array(buffer);
+      const chunk = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+      }
+      return apiClient.uploadWorkbenchFile(chatId, {
+        name: file.name,
+        content_base64: btoa(binary),
+        content_type: file.type || undefined,
+      });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: filesKey }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (path: string) => apiClient.deleteWorkbenchFile(chatId, path),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: filesKey }),
+  });
+
+  const openFile = async (file: WorkbenchFile) => {
+    setBusyFile(file.name);
+    try {
+      const content = await apiClient.readWorkbenchFile(chatId, file.name);
+      const bytes = base64ToBytes(content.content_base64);
+      if (isTextual(content.content_type)) {
+        setPreview({ name: file.name, text: new TextDecoder().decode(bytes) });
+      } else {
+        downloadBytes(file.name, bytes, content.content_type);
+      }
+    } finally {
+      setBusyFile(null);
+    }
+  };
+
+  const downloadFile = async (file: WorkbenchFile) => {
+    setBusyFile(file.name);
+    try {
+      const content = await apiClient.readWorkbenchFile(chatId, file.name);
+      downloadBytes(file.name, base64ToBytes(content.content_base64), content.content_type);
+    } finally {
+      setBusyFile(null);
+    }
+  };
+
+  const downloadBytes = (name: string, bytes: Uint8Array, contentType: string) => {
+    const blob = new Blob([bytes.buffer as ArrayBuffer], { type: contentType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name.split('/').pop() || name;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-80 border-l border-line-soft bg-transparent">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-line-soft">
+        <div className="flex items-center text-gray-100">
+          <FolderOpen className="w-4 h-4 mr-2 text-primary-600" />
+          <span className="text-sm font-semibold">Workbench</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            title="Upload file"
+            className="p-1.5 text-gray-400 hover:text-gray-100"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploadMutation.isPending}
+          >
+            {uploadMutation.isPending ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Upload className="w-4 h-4" />
+            )}
+          </button>
+          <button
+            title="Refresh"
+            className="p-1.5 text-gray-400 hover:text-gray-100"
+            onClick={() => refetch()}
+          >
+            <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+          </button>
+          {onClose && (
+            <button title="Close" className="p-1.5 text-gray-400 hover:text-gray-100" onClick={onClose}>
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) uploadMutation.mutate(f);
+            e.target.value = '';
+          }}
+        />
+      </div>
+
+      {uploadMutation.isError && (
+        <div className="px-3 py-2 text-xs text-red-400 border-b border-line-soft">
+          Upload failed: {(uploadMutation.error as Error)?.message}
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="w-5 h-5 animate-spin text-primary-600" />
+          </div>
+        ) : !files || files.length === 0 ? (
+          <p className="px-3 py-8 text-center text-xs text-gray-500">
+            No files yet. The agent's working files and your uploads appear here.
+          </p>
+        ) : (
+          <ul>
+            {files.map((file) => (
+              <li
+                key={file.name}
+                className="group flex items-center px-3 py-2 border-b border-line-soft hover:bg-white/5 cursor-pointer"
+                onClick={() => openFile(file)}
+              >
+                <FileText className="w-4 h-4 mr-2 shrink-0 text-gray-500" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-gray-100 truncate" title={file.name}>
+                    {file.name}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {formatSize(file.size_bytes)} · v{file.current_version} ·{' '}
+                    {new Date(file.updated_at).toLocaleString()}
+                  </p>
+                </div>
+                {busyFile === file.name ? (
+                  <Loader2 className="w-4 h-4 animate-spin text-gray-400" />
+                ) : (
+                  <span className="hidden group-hover:flex items-center gap-1">
+                    <button
+                      title="Download"
+                      className="p-1 text-gray-400 hover:text-gray-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        downloadFile(file);
+                      }}
+                    >
+                      <Download className="w-4 h-4" />
+                    </button>
+                    <button
+                      title="Delete"
+                      className="p-1 text-gray-400 hover:text-red-400"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (confirm(`Delete '${file.name}' from the workbench?`)) {
+                          deleteMutation.mutate(file.name);
+                        }
+                      }}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {preview && (
+        <div className="h-1/2 flex flex-col border-t border-line-soft">
+          <div className="flex items-center justify-between px-3 py-1.5 border-b border-line-soft">
+            <span className="text-xs font-mono text-gray-400 truncate" title={preview.name}>
+              {preview.name}
+            </span>
+            <button
+              className="p-1 text-gray-400 hover:text-gray-100"
+              onClick={() => setPreview(null)}
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+          <pre className="flex-1 min-h-0 overflow-auto px-3 py-2 text-xs text-gray-300 whitespace-pre-wrap break-words">
+            {preview.text}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -82,6 +82,8 @@ import type {
   PipelineUpdate,
   PipelineRun,
   PipelineRunOutcome,
+  WorkbenchFile,
+  WorkbenchFileContent,
 } from '../types';
 
 // Auto-detect API base URL based on environment
@@ -344,6 +346,29 @@ class APIClient {
   async listMessages(chatId: string): Promise<Message[]> {
     const response = await this.runtimeClient.get(`/chats/${chatId}/messages`);
     return response.data;
+  }
+
+  // Workbench (Runtime API) — a chat's private working tree
+  async listWorkbenchFiles(chatId: string): Promise<WorkbenchFile[]> {
+    const response = await this.runtimeClient.get(`/chats/${chatId}/workbench/files`);
+    return response.data;
+  }
+
+  async readWorkbenchFile(chatId: string, path: string): Promise<WorkbenchFileContent> {
+    const response = await this.runtimeClient.get(`/chats/${chatId}/workbench/files/${path}`);
+    return response.data;
+  }
+
+  async uploadWorkbenchFile(
+    chatId: string,
+    data: { name: string; content_base64: string; content_type?: string }
+  ): Promise<WorkbenchFile> {
+    const response = await this.runtimeClient.post(`/chats/${chatId}/workbench/files`, data);
+    return response.data;
+  }
+
+  async deleteWorkbenchFile(chatId: string, path: string): Promise<void> {
+    await this.runtimeClient.delete(`/chats/${chatId}/workbench/files/${path}`);
   }
 
   // Agents

--- a/console/src/pages/ChatDetail.tsx
+++ b/console/src/pages/ChatDetail.tsx
@@ -1,12 +1,15 @@
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient, API_BASE_URL } from '../lib/api';
-import { ArrowLeft, Loader2, Bot } from 'lucide-react';
+import { ArrowLeft, Loader2, Bot, FolderOpen } from 'lucide-react';
 import { Chat } from '../components/chat/Chat';
+import { WorkbenchPanel } from '../components/workbench/WorkbenchPanel';
 
 export function ChatDetail() {
   const { chatId } = useParams<{ chatId: string }>();
   const queryClient = useQueryClient();
+  const [showWorkbench, setShowWorkbench] = useState(false);
 
   const { data: chat, isLoading } = useQuery({
     queryKey: ['chat-meta', chatId],
@@ -61,22 +64,37 @@ export function ChatDetail() {
             </p>
           </div>
         </div>
+        <button
+          title={showWorkbench ? 'Hide workbench' : 'Show workbench'}
+          onClick={() => setShowWorkbench((v) => !v)}
+          className={`p-2 rounded-lg ${
+            showWorkbench ? 'text-primary-600' : 'text-gray-400 hover:text-gray-100'
+          }`}
+        >
+          <FolderOpen className="w-5 h-5" />
+        </button>
       </div>
 
-      {/* Chat component from @sinas/ui */}
-      <div className="flex-1 min-h-0 pt-4">
-        <Chat
-          agent={agentRef}
-          chatId={chatId}
-          height="100%"
-          placeholder="Type your message... (Shift+Enter for new line)"
-          agentIconUrl={agent?.icon_url || undefined}
-          apiBaseUrl={API_BASE_URL}
-          onMessagesRefreshed={() => {
-            queryClient.invalidateQueries({ queryKey: ['chat-meta', chatId] });
-          }}
-          style={{ border: 'none', borderRadius: 0, backgroundColor: 'transparent' }}
-        />
+      {/* Chat component from @sinas/ui, with the workbench tree alongside */}
+      <div className="flex flex-1 min-h-0 pt-4">
+        <div className="flex-1 min-w-0">
+          <Chat
+            agent={agentRef}
+            chatId={chatId}
+            height="100%"
+            placeholder="Type your message... (Shift+Enter for new line)"
+            agentIconUrl={agent?.icon_url || undefined}
+            apiBaseUrl={API_BASE_URL}
+            onMessagesRefreshed={() => {
+              queryClient.invalidateQueries({ queryKey: ['chat-meta', chatId] });
+              queryClient.invalidateQueries({ queryKey: ['workbench-files', chatId] });
+            }}
+            style={{ border: 'none', borderRadius: 0, backgroundColor: 'transparent' }}
+          />
+        </div>
+        {showWorkbench && chatId && (
+          <WorkbenchPanel chatId={chatId} onClose={() => setShowWorkbench(false)} />
+        )}
       </div>
     </div>
   );

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -115,6 +115,24 @@ export interface Chat {
   last_message_at: string | null;
 }
 
+export interface WorkbenchFile {
+  name: string;
+  content_type: string;
+  current_version: number;
+  size_bytes: number | null;
+  file_metadata: Record<string, any>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkbenchFileContent {
+  name: string;
+  content_base64: string;
+  content_type: string;
+  version: number;
+  file_metadata: Record<string, any>;
+}
+
 export interface ChatCreate {
   title?: string;
   input?: Record<string, any>;

--- a/docs-mint/build-resources/system-tools.mdx
+++ b/docs-mint/build-resources/system-tools.mdx
@@ -27,6 +27,7 @@ agents:
 | `configIntrospection` | string | Read-only inspection of the current Sinas configuration: list resource types, browse resources by name/description, read full resource detail |
 | `packageManagement` | string | Validate, preview, install, and uninstall Sinas packages. Install and uninstall require user approval. |
 | `databaseIntrospection` | object | Read-only schema inspection of database connections. Requires `connections` list specifying which connections the agent can access. |
+| `workbench` | string | A per-chat persistent working tree. Adds `workbench_list/read/write/edit/delete` file tools, `workbench_checkout` (copy collection files in, single or bulk) and `workbench_promote` (publish back to a collection, updating a checked-out source with conflict detection). Every workbench file is private to the chat's user. Combined with `codeExecution`, workbench files are materialized into the sandbox working directory and files the code creates or modifies persist back to the workbench after the run. |
 
 **Config introspection tools:**
 


### PR DESCRIPTION
## What this adds

The missing Claude Code-style primitive from the gap analysis: a **Workbench** — a per-chat mutable file tree that the agent's file tools operate on, that materializes into sandbox code executions (all three runtimes), and that persists across turns with versioning. Design and decision record: `backend/docs/adrs/2026-09-01-workbench-unified-file-tree-and-execution.md` (Accepted).

### Core (`kind` discriminator + tools)
- `collections.kind` (`'collection' | 'workbench'`, `server_default='collection'` — existing rows, API shapes, and grants untouched). Workbench rows carry no public namespace/name and are fenced out of every collections-facing surface at the query level: by-name resolution, `*/*` wildcard tool expansion, the collections API (list + 404 guards), config export/apply, OpenAPI generator, icon resolver. A wildcard `collections:*` grant structurally cannot reach a workbench; access derives from chat ownership only.
- Enablement via `system_tools: ["workbench"]` (no agent schema change). Tools: `workbench_list/read/write/edit/delete` (reusing the collection tool internals, visibility forced private), `workbench_checkout` (single/glob/bulk, download-permission gated, visibility-filtered, provenance recorded), `workbench_promote` (upload-permission gated, runs the target's content filter, updates a checked-out source with conflict detection, else creates in target).

### Sandbox sync
- Copy-in/copy-out over the existing `execute_inline` wire — no runtime-specific code. The wrapper materializes the tree into a fresh temp dir, chdirs there, hash-diffs afterward; created/modified files persist back through the validated workbench write path even when the user code raised. The temp tree is always removed so pooled containers can't leak between chats.
- **Lazy fetch**: files above the sync caps materialize as stubs; an `open()`/`io.open` hook fetches real bytes over a typed extension of the pause channel (shared wait script in `executor/_wire.py`, used by Docker and k8s runtimes; also fixes a stale-awaiting read race in k8s resume). `workbench_fetch(path)` covers native code; failed fetches raise; unfetched stubs are excluded from the copy-out diff.
- **docker_pool delta + affinity**: per-container blob cache keyed by content hash; already-seen files ride as references; `acquire(chat_id=…)` prefers the container that last served the chat; a cold cache degrades to lazy fetch.

### Chat uploads + console
- `/chats/{id}/workbench/files` runtime API (list/read/upload/delete), authorized by chat ownership + agent chat permission. Uploads are private, take nested paths, and run the deployment-wide `workbench_content_filter_function` before any bytes persist.
- Console: toggleable workbench panel on the chat view (list, inline text preview, download, upload, delete), refreshing with messages.

## Testing
- 30 workbench unit tests: the fence (admin wildcard cannot see workbenches), private-only writes, path traversal rejection, cross-user denial, checkout/promote round trip incl. conflict detection, sync manifest/write-back, and in-process executions of the real sandbox wrapper (materialization, hash diff, lazy fetch served by a thread playing the backend, blob cache, cleanup).
- Full backend suite green against local Postgres 16 + Redis (474 at this branch point). Console build verified with the CI recipe (tsc + vite, pinned @sinas/sdk).

Stacked follow-up: #179 builds on this branch.