### PR TITLE
Agent loop controls: steering triad, permission modes, compaction

### DIFF
--- a/backend/alembic/versions/t1a2p3r4v5l6_agent_tool_approvals.py
+++ b/backend/alembic/versions/t1a2p3r4v5l6_agent_tool_approvals.py
@@ -1,0 +1,22 @@
+"""agents.tool_approvals: per-agent tool approval rules (permission modes)
+
+Revision ID: t1a2p3r4v5l6
+Revises: w1o2r3k4b5n6
+Create Date: 2026-09-01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "t1a2p3r4v5l6"
+down_revision = "w1o2r3k4b5n6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Nullable: NULL keeps today's behavior (function requires_approval only).
+    op.add_column("agents", sa.Column("tool_approvals", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "tool_approvals")

--- a/backend/app/api/runtime/endpoints/chats.py
+++ b/backend/app/api/runtime/endpoints/chats.py
@@ -997,6 +997,44 @@ async def update_chat(
     )
 
 
+@router.post("/chats/{chat_id}/interrupt")
+async def interrupt_chat(
+    chat_id: str,
+    http_request: Request,
+    current_user_data: tuple = Depends(get_current_user_with_permissions),
+    db: AsyncSession = Depends(get_db),
+):
+    """Stop the chat's running agent loop without touching the transcript
+    (issue #142).
+
+    Arms a cooperative interrupt: the loop stops at its next tool-round
+    boundary and appends an 'interrupted by operator' system marker; queued
+    continuation jobs that start within the flag's TTL stop immediately.
+    The chat and its messages stay intact, and the next user message clears
+    the flag and starts a fresh turn.
+    """
+    user_id, permissions = current_user_data
+
+    result = await db.execute(select(Chat).where(Chat.id == chat_id, Chat.user_id == user_id))
+    chat = result.scalar_one_or_none()
+    if not chat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found")
+
+    agent_chat_perm = f"sinas.agents/{chat.agent_namespace}/{chat.agent_name}.chat:all"
+    if not check_permission(permissions, agent_chat_perm):
+        set_permission_used(http_request, agent_chat_perm, has_perm=False)
+        raise HTTPException(
+            403, f"Not authorized to chat with agent '{chat.agent_namespace}/{chat.agent_name}'"
+        )
+    set_permission_used(http_request, agent_chat_perm)
+
+    from app.services import chat_steering
+
+    was_running = await chat_steering.is_chat_locked(chat_id)
+    await chat_steering.request_interrupt(chat_id, requested_by=user_id)
+    return {"interrupted": True, "was_running": was_running}
+
+
 @router.delete("/chats/{chat_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_chat(
     chat_id: str,

--- a/backend/app/api/runtime/endpoints/chats.py
+++ b/backend/app/api/runtime/endpoints/chats.py
@@ -761,6 +761,22 @@ async def approve_tool_call(
     pending_approval.approved = request.approved
     await db.commit()
 
+    # "Always allow": remember the user's decision for this chat so the
+    # same tool skips the ask next time (session-scoped grant).
+    if request.approved and request.always_allow:
+        from app.services import approval_rules
+
+        # Session grants key on the tool name the model calls. For function
+        # tools the pending row stores namespace/name; the tool name is the
+        # call's function name — recover it from the stored call.
+        tool_name = None
+        for tc in pending_approval.all_tool_calls or []:
+            if tc.get("id") == tool_call_id:
+                tool_name = tc.get("function", {}).get("name")
+                break
+        if tool_name:
+            await approval_rules.add_session_grant(chat_id, tool_name)
+
     # Extract token and enqueue resume job
     user_token = http_request.headers.get("authorization", "").replace("Bearer ", "")
     channel_id = str(uuid.uuid4())

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -103,6 +103,7 @@ async def create_agent(
         default_job_timeout=agent_data.default_job_timeout,
         default_keep_alive=agent_data.default_keep_alive or False,
         system_tools=[t.model_dump() if hasattr(t, 'model_dump') else t for t in (agent_data.system_tools or [])],
+        tool_approvals=agent_data.tool_approvals,
     )
 
     db.add(agent)
@@ -276,6 +277,8 @@ async def update_agent(
             t.model_dump() if hasattr(t, 'model_dump') else t
             for t in agent_data.system_tools
         ]
+    if agent_data.tool_approvals is not None:
+        agent.tool_approvals = agent_data.tool_approvals
     await db.flush()
     await db.refresh(agent)
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -251,6 +251,12 @@ class Settings(BaseSettings):
 
     # Message history
     max_history_messages: int = 100  # Max messages to load for conversation history
+    # Compaction: when a conversation outgrows max_history_messages, the
+    # dropped prefix is summarized (asynchronously, incrementally) and the
+    # summary rides along as context instead of the history just falling off
+    # a cliff. Disable to restore pure windowing.
+    compaction_enabled: bool = True
+    compaction_summary_max_tokens: int = 800
     max_tool_iterations: int = 25  # Max consecutive tool-call rounds before stopping
 
     # Tool result store

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -127,6 +127,13 @@ class Agent(Base, PermissionMixin):
         JSON, nullable=False, default=list, server_default="[]"
     )
 
+    # Tool approval rules (permission modes): first-match glob rules over
+    # tool names, e.g. {"default": "auto", "rules": [{"match": "write_*",
+    # "action": "ask"}]}. An explicit "auto" rule overrides a function's
+    # requires_approval; unmatched tools fall back to requires_approval,
+    # then to "default". NULL = today's behavior (requires_approval only).
+    tool_approvals: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_default: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[created_at]

--- a/backend/app/queue/agent_jobs.py
+++ b/backend/app/queue/agent_jobs.py
@@ -397,22 +397,35 @@ async def execute_agent_resume_job(ctx: dict, **kwargs: Any) -> None:
                     status_templates = agent_obj.status_templates or {}
 
             if approved:
-                # Execute the approved tool calls and stream the LLM response
-                async for chunk in message_service._handle_tool_calls(
-                    chat_id=chat_id,
-                    user_id=user_id,
-                    user_token=user_token,
-                    messages=pending_approval.conversation_context["messages"],
-                    tool_calls=pending_approval.all_tool_calls,
-                    provider=pending_approval.conversation_context.get("provider"),
-                    model=pending_approval.conversation_context.get("model"),
-                    temperature=pending_approval.conversation_context.get("temperature", 0.7),
-                    max_tokens=pending_approval.conversation_context.get("max_tokens"),
-                    tools=pending_approval.conversation_context.get("tools", []),
-                    status_templates=status_templates,
-                ):
-                    if isinstance(chunk, dict):
-                        await stream_relay.publish(channel_id, chunk, ttl=stream_ttl)
+                # Continuations re-enter the loop, so they hold the chat lock
+                # like any other loop (waiting briefly for a running one).
+                from app.services import chat_steering
+
+                lock_token = await chat_steering.acquire_chat_lock_wait(chat_id)
+                if lock_token is None:
+                    await stream_relay.publish_error(
+                        channel_id, "Chat is busy with another running turn — try again"
+                    )
+                    return
+                try:
+                    # Execute the approved tool calls and stream the LLM response
+                    async for chunk in message_service._handle_tool_calls(
+                        chat_id=chat_id,
+                        user_id=user_id,
+                        user_token=user_token,
+                        messages=pending_approval.conversation_context["messages"],
+                        tool_calls=pending_approval.all_tool_calls,
+                        provider=pending_approval.conversation_context.get("provider"),
+                        model=pending_approval.conversation_context.get("model"),
+                        temperature=pending_approval.conversation_context.get("temperature", 0.7),
+                        max_tokens=pending_approval.conversation_context.get("max_tokens"),
+                        tools=pending_approval.conversation_context.get("tools", []),
+                        status_templates=status_templates,
+                    ):
+                        if isinstance(chunk, dict):
+                            await stream_relay.publish(channel_id, chunk, ttl=stream_ttl)
+                finally:
+                    await chat_steering.release_chat_lock(chat_id, lock_token)
             else:
                 # Handle rejection - publish rejection info
                 await stream_relay.publish(channel_id, {
@@ -525,7 +538,16 @@ async def execute_agent_delegate_resume_job(ctx: dict, **kwargs: Any) -> None:
     completed = False
     _suspended = False
     _output_parts: list[str] = []
+    lock_token = None
+    from app.services import chat_steering
+
     try:
+        lock_token = await chat_steering.acquire_chat_lock_wait(chat_id)
+        if lock_token is None:
+            await stream_relay.publish_error(
+                channel_id, "Chat is busy with another running turn — try again"
+            )
+            return
         async with AsyncSessionLocal() as db:
             message_service = MessageService(db)
             async for chunk in message_service._stream_followup_after_tools(
@@ -625,6 +647,8 @@ async def execute_agent_delegate_resume_job(ctx: dict, **kwargs: Any) -> None:
         raise
 
     finally:
+        if lock_token is not None:
+            await chat_steering.release_chat_lock(chat_id, lock_token)
         ping_task.cancel()
         if not completed:
             logger.warning(f"Delegate-resume job {job_id} cancelled/timed out")

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -132,6 +132,16 @@ class AgentCreate(BaseModel):
             "(per-chat persistent working tree)."
         ),
     )
+    tool_approvals: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Tool approval rules: {'default': 'auto'|'ask', 'rules': "
+            "[{'match': '<glob>', 'action': 'auto'|'ask'}]}. First matching "
+            "rule wins; an explicit 'auto' overrides a function's "
+            "requires_approval; unmatched tools fall back to "
+            "requires_approval, then to 'default'."
+        ),
+    )
 
 
 class AgentUpdate(BaseModel):
@@ -194,6 +204,7 @@ class AgentUpdate(BaseModel):
     default_job_timeout: Optional[int] = Field(None, gt=0)
     default_keep_alive: Optional[bool] = None
     system_tools: Optional[list[Union[str, SystemToolConfig]]] = None
+    tool_approvals: Optional[dict[str, Any]] = None
 
 
 class AgentResponse(BaseModel):
@@ -231,6 +242,7 @@ class AgentResponse(BaseModel):
     default_job_timeout: Optional[int] = None
     default_keep_alive: bool = False
     system_tools: list[Union[str, SystemToolConfig]] = []
+    tool_approvals: Optional[dict[str, Any]] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -186,6 +186,9 @@ class ToolApprovalRequest(BaseModel):
     """Approve or reject a tool call that requires user approval."""
 
     approved: bool
+    # "Always allow" for the rest of this chat: approving with this flag
+    # records a session grant so the same tool won't ask again.
+    always_allow: bool = False
 
 
 class ToolApprovalResponse(BaseModel):

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -228,6 +228,14 @@ class AgentConfig(BaseModel):
             "(per-chat persistent working tree)."
         ),
     )
+    toolApprovals: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Tool approval rules: {'default': 'auto'|'ask', 'rules': "
+            "[{'match': '<glob>', 'action': 'auto'|'ask'}]}. First matching "
+            "rule wins; 'auto' overrides a function's requiresApproval."
+        ),
+    )
 
 
 class WebhookDedupConfig(BaseModel):

--- a/backend/app/services/approval_rules.py
+++ b/backend/app/services/approval_rules.py
@@ -1,0 +1,83 @@
+"""Tool approval rules — permission modes for agent tool calls.
+
+Layered on the existing requires_approval machinery, not new machinery:
+per-agent first-match glob rules over tool names decide auto vs ask,
+"always allow" session grants remember a user's approval for the rest of
+the chat, and anything unmatched falls back to the intrinsic
+requires_approval flag, then to the agent's default.
+
+Resolution order for one tool call:
+1. per-chat session grant (the user clicked "always allow" earlier) → auto
+2. first matching agent rule → its action ("auto" may deliberately
+   override a function's requires_approval — that is the "auto-allow
+   reads" use case, and both knobs belong to the same agent author)
+3. intrinsic requires_approval (function flag / system-tool metadata) → ask
+4. the agent's default ("auto" when unset — today's behavior)
+
+Config shape (agents.tool_approvals):
+    {"default": "auto" | "ask",
+     "rules": [{"match": "<glob over tool name>", "action": "auto" | "ask"}]}
+"""
+import logging
+from fnmatch import fnmatch
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_GRANT_PREFIX = "chat:tool-grant:"
+# Session grants outlive the loop but not the account: a week covers any
+# realistic conversation without becoming a permanent standing grant.
+_GRANT_TTL = 7 * 24 * 3600
+
+AUTO = "auto"
+ASK = "ask"
+
+
+def resolve_action(
+    tool_approvals: Optional[dict[str, Any]],
+    tool_name: str,
+    intrinsic_ask: bool,
+    session_grants: set[str],
+) -> str:
+    """Decide "auto" or "ask" for one tool call. Pure function — see the
+    module docstring for the order."""
+    if tool_name in session_grants:
+        return AUTO
+
+    if tool_approvals:
+        for rule in tool_approvals.get("rules") or []:
+            pattern = rule.get("match")
+            action = rule.get("action")
+            if not pattern or action not in (AUTO, ASK):
+                continue
+            if fnmatch(tool_name, pattern):
+                return action
+
+    if intrinsic_ask:
+        return ASK
+
+    default = (tool_approvals or {}).get("default", AUTO)
+    return default if default in (AUTO, ASK) else AUTO
+
+
+async def get_session_grants(chat_id: str) -> set[str]:
+    """Tool names the user has 'always allowed' for this chat."""
+    from app.core.redis import get_redis
+
+    try:
+        redis = await get_redis()
+        members = await redis.smembers(f"{_GRANT_PREFIX}{chat_id}")
+        return {m if isinstance(m, str) else m.decode() for m in members or set()}
+    except Exception as e:
+        # Fail closed: no grants — worst case the user is asked again.
+        logger.warning(f"Failed to load session tool grants for chat {chat_id}: {e}")
+        return set()
+
+
+async def add_session_grant(chat_id: str, tool_name: str) -> None:
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    key = f"{_GRANT_PREFIX}{chat_id}"
+    await redis.sadd(key, tool_name)
+    await redis.expire(key, _GRANT_TTL)

--- a/backend/app/services/chat_steering.py
+++ b/backend/app/services/chat_steering.py
@@ -1,0 +1,121 @@
+"""Chat steering: per-chat execution lock, cooperative interrupt, injection.
+
+Long autonomous turns are only safe if exactly one agent loop runs per chat
+(the lock), a human can stop a runaway loop without deleting the chat (the
+interrupt — issue #142), and a message sent mid-turn steers the running
+loop instead of racing it (injection).
+
+Mechanics:
+
+- Lock: a Redis SET NX token per chat, held for the duration of one agent
+  loop (send, stream, or a resume/continuation job). The TTL is generous —
+  the agent job timeout plus slack — so a crashed worker can never wedge a
+  chat forever.
+- Interrupt: a Redis flag checked at tool-round boundaries. The loop
+  consumes it, writes an "interrupted by operator" system marker into the
+  transcript, and stops. The flag has its own TTL so an interrupt aimed at
+  a loop that already ended also catches the queued continuation jobs the
+  issue asks about — and a fresh user message clears it, so a stale flag
+  never kills a new turn.
+- Injection needs no machinery here: the loop rebuilds its conversation
+  from the DB at every round boundary, so a user message row persisted
+  while the lock is held is picked up naturally. MessageService uses the
+  lock to decide send-vs-inject.
+"""
+import logging
+import uuid
+from typing import Optional
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_LOCK_PREFIX = "chat:loop-lock:"
+_INTERRUPT_PREFIX = "chat:interrupt:"
+
+# How long an interrupt request stays armed. Long enough to catch queued
+# continuation jobs that haven't started yet, short enough that a forgotten
+# interrupt doesn't ambush next week's conversation.
+INTERRUPT_TTL = 600
+
+
+def _lock_ttl() -> int:
+    return settings.agent_job_timeout + 120
+
+
+async def acquire_chat_lock(chat_id: str) -> Optional[str]:
+    """Try to become the chat's one running loop. Returns a release token,
+    or None when another loop already holds the chat."""
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    token = uuid.uuid4().hex
+    ok = await redis.set(f"{_LOCK_PREFIX}{chat_id}", token, nx=True, ex=_lock_ttl())
+    return token if ok else None
+
+
+async def release_chat_lock(chat_id: str, token: str) -> None:
+    """Release the lock if we still hold it (token-checked, atomic)."""
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    # Compare-and-delete so an expired-and-reacquired lock is never released
+    # by the previous holder.
+    script = (
+        "if redis.call('get', KEYS[1]) == ARGV[1] then "
+        "return redis.call('del', KEYS[1]) else return 0 end"
+    )
+    try:
+        await redis.eval(script, 1, f"{_LOCK_PREFIX}{chat_id}", token)
+    except Exception as e:
+        logger.warning(f"Failed to release chat lock for {chat_id}: {e}")
+
+
+async def is_chat_locked(chat_id: str) -> bool:
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    return bool(await redis.exists(f"{_LOCK_PREFIX}{chat_id}"))
+
+
+async def acquire_chat_lock_wait(chat_id: str, wait_seconds: float = 60) -> Optional[str]:
+    """Acquire the lock, waiting up to `wait_seconds` for the current holder
+    to finish. For continuation jobs (approval resume, delegate resume) that
+    must run but should not race a still-active loop."""
+    import asyncio
+    import time
+
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        token = await acquire_chat_lock(chat_id)
+        if token or time.monotonic() >= deadline:
+            return token
+        await asyncio.sleep(0.5)
+
+
+async def request_interrupt(chat_id: str, requested_by: str = "") -> None:
+    """Arm the interrupt flag; the running loop stops at its next boundary,
+    and continuation jobs that start within the TTL stop immediately."""
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    await redis.set(f"{_INTERRUPT_PREFIX}{chat_id}", requested_by or "1", ex=INTERRUPT_TTL)
+
+
+async def consume_interrupt(chat_id: str) -> bool:
+    """Check-and-clear the interrupt flag (the boundary check)."""
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    return bool(await redis.getdel(f"{_INTERRUPT_PREFIX}{chat_id}"))
+
+
+async def clear_interrupt(chat_id: str) -> None:
+    """Disarm a pending interrupt (a fresh user turn starts clean)."""
+    from app.core.redis import get_redis
+
+    redis = await get_redis()
+    await redis.delete(f"{_INTERRUPT_PREFIX}{chat_id}")
+
+
+INTERRUPT_MARKER = "Interrupted by operator."

--- a/backend/app/services/compaction.py
+++ b/backend/app/services/compaction.py
@@ -1,0 +1,232 @@
+"""Conversation compaction: summarize-and-continue instead of the cliff.
+
+Without this, a chat that outgrows max_history_messages silently loses its
+oldest messages. With it, the dropped prefix is summarized once
+(asynchronously — never on the user's critical path) and the summary is
+injected as context whenever windowing applies, so long-running chats keep
+their thread.
+
+The summary lives in chat.chat_metadata["compaction"]:
+    {"summary": str, "covered_count": int, "updated_at": iso8601}
+covered_count is how many of the chat's earliest messages the summary
+covers. Refreshes are incremental: prior summary + the messages between
+covered_count and the current window start produce the next summary, so
+each message is summarized at most once. A Redis NX guard keeps one
+refresh per chat at a time; every failure path leaves the previous
+behavior (plain windowing) intact.
+"""
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from sqlalchemy import select
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_COMPACT_GUARD_PREFIX = "chat:compacting:"
+_GUARD_TTL = 300
+
+_SUMMARY_SYSTEM_PROMPT = (
+    "You maintain a running summary of a conversation between a user and an "
+    "AI assistant so the assistant can continue seamlessly after older "
+    "messages are dropped. Merge the prior summary (if any) with the new "
+    "messages into ONE updated summary. Preserve: stated user preferences "
+    "and facts, decisions made, unresolved questions or tasks, names of "
+    "files/artifacts created or modified, and any commitments the assistant "
+    "made. Be concise; use short bullet points; do not invent details."
+)
+
+
+def get_compaction(chat) -> Optional[dict[str, Any]]:
+    meta = chat.chat_metadata or {}
+    compaction = meta.get("compaction")
+    if isinstance(compaction, dict) and compaction.get("summary"):
+        return compaction
+    return None
+
+
+def summary_message(compaction: dict[str, Any]) -> dict[str, Any]:
+    """The system message injected in place of the summarized prefix."""
+    return {
+        "role": "system",
+        "content": (
+            "## Earlier conversation (summarized)\n"
+            "Older messages were removed to fit the context window. "
+            "Summary of what happened:\n\n" + compaction["summary"]
+        ),
+    }
+
+
+def _render_messages(messages) -> str:
+    """Render Message rows into plain text for the summarizer."""
+    lines: list[str] = []
+    for msg in messages:
+        if msg.role == "assistant" and msg.tool_calls:
+            calls = ", ".join(
+                f"{tc.get('function', {}).get('name', '?')}("
+                f"{str(tc.get('function', {}).get('arguments', ''))[:200]})"
+                for tc in msg.tool_calls
+            )
+            prefix = f"assistant called tools: {calls}"
+            if msg.content:
+                lines.append(f"assistant: {msg.content[:1000]}")
+            lines.append(prefix)
+        elif msg.role == "tool":
+            content = (msg.content or "")[:500]
+            lines.append(f"tool result ({msg.name or '?'}): {content}")
+        else:
+            lines.append(f"{msg.role}: {(msg.content or '')[:2000]}")
+    return "\n".join(lines)
+
+
+def maybe_schedule_compaction(chat_id: str) -> None:
+    """Fire-and-forget a compaction refresh for this chat. Never raises."""
+    if not settings.compaction_enabled:
+        return
+    try:
+        asyncio.get_running_loop().create_task(_guarded_run(chat_id))
+    except RuntimeError:
+        # No running loop (sync/offline caller) — skip; the next turn retries.
+        pass
+
+
+async def _guarded_run(chat_id: str) -> None:
+    from app.core.redis import get_redis
+
+    try:
+        redis = await get_redis()
+        if not await redis.set(f"{_COMPACT_GUARD_PREFIX}{chat_id}", "1", nx=True, ex=_GUARD_TTL):
+            return
+    except Exception as e:
+        logger.warning(f"Compaction guard unavailable for chat {chat_id}: {e}")
+        return
+    try:
+        await run_compaction(chat_id)
+    except Exception:
+        logger.exception(f"Compaction failed for chat {chat_id}")
+    finally:
+        try:
+            await redis.delete(f"{_COMPACT_GUARD_PREFIX}{chat_id}")
+        except Exception:
+            pass
+
+
+async def run_compaction(chat_id: str, db=None) -> Optional[dict[str, Any]]:
+    """Bring the chat's summary up to the current window start.
+
+    Returns the stored compaction dict, or None when nothing to do.
+    `db` is injectable for tests; production callers let it open its own
+    session.
+    """
+    if db is not None:
+        return await _run_compaction_with_session(chat_id, db)
+
+    from app.core.database import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as session:
+        return await _run_compaction_with_session(chat_id, session)
+
+
+async def _run_compaction_with_session(chat_id: str, db) -> Optional[dict[str, Any]]:
+    from app.models.chat import Chat, Message
+
+    chat = (
+        await db.execute(select(Chat).where(Chat.id == chat_id))
+    ).scalar_one_or_none()
+    if not chat:
+        return None
+
+    all_messages = (
+        await db.execute(
+            select(Message).where(Message.chat_id == chat.id).order_by(Message.created_at)
+        )
+    ).scalars().all()
+
+    target = len(all_messages) - settings.max_history_messages
+    if target <= 0:
+        return get_compaction(chat)
+
+    existing = get_compaction(chat)
+    covered = existing["covered_count"] if existing else 0
+    if covered >= target:
+        return existing
+
+    delta = all_messages[covered:target]
+    prior_summary = existing["summary"] if existing else ""
+
+    summary = await _summarize(db, chat, prior_summary, delta)
+    if not summary:
+        return existing
+
+    meta = dict(chat.chat_metadata or {})
+    compaction = {
+        "summary": summary,
+        "covered_count": target,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    meta["compaction"] = compaction
+    chat.chat_metadata = meta
+    await db.commit()
+    logger.info(
+        f"Compacted chat {chat_id}: summary now covers the first {target} messages"
+    )
+    return compaction
+
+
+async def _summarize(db, chat, prior_summary: str, delta_messages) -> Optional[str]:
+    """One summarization call via the platform's LLM provider."""
+    from app.providers import create_provider
+
+    parts = []
+    if prior_summary:
+        parts.append(f"## Prior summary\n{prior_summary}")
+    parts.append(f"## New messages to fold in\n{_render_messages(delta_messages)}")
+    user_content = "\n\n".join(parts)
+
+    # Providers don't fall back on model=None — resolve the default
+    # provider's default model explicitly.
+    from app.models.llm_provider import LLMProvider
+
+    provider_row = (
+        await db.execute(
+            select(LLMProvider).where(
+                LLMProvider.is_default == True, LLMProvider.is_active == True  # noqa: E712
+            )
+        )
+    ).scalar_one_or_none()
+    model = provider_row.default_model if provider_row else None
+    if not model:
+        logger.warning("Compaction skipped: no default LLM provider/model configured")
+        return None
+
+    agent_label = (
+        f"{chat.agent_namespace}/{chat.agent_name}"
+        if chat.agent_namespace and chat.agent_name
+        else None
+    )
+    llm = await create_provider(
+        None,
+        None,
+        db,
+        usage_context={
+            "user_id": str(chat.user_id),
+            "chat_id": str(chat.id),
+            "agent": agent_label,
+            "source": "compaction",
+        },
+    )
+    response = await llm.complete(
+        messages=[
+            {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+            {"role": "user", "content": user_content},
+        ],
+        model=model,
+        tools=None,
+        temperature=0.2,
+        max_tokens=settings.compaction_summary_max_tokens,
+    )
+    content = (response or {}).get("content")
+    return content.strip() if isinstance(content, str) and content.strip() else None

--- a/backend/app/services/config_apply/agents.py
+++ b/backend/app/services/config_apply/agents.py
@@ -179,6 +179,7 @@ async def apply_agents(
                     "default_job_timeout": agent_config.defaultJobTimeout,
                     "default_keep_alive": agent_config.defaultKeepAlive,
                     "system_tools": agent_config.systemTools,
+                    "tool_approvals": agent_config.toolApprovals,
                 }
             )
 
@@ -232,6 +233,7 @@ async def apply_agents(
                     existing.default_job_timeout = agent_config.defaultJobTimeout
                     existing.default_keep_alive = agent_config.defaultKeepAlive
                     existing.system_tools = agent_config.systemTools
+                    existing.tool_approvals = agent_config.toolApprovals
                     if agent_config.isDefault:
                         await db.execute(
                             Agent.__table__.update()
@@ -293,6 +295,7 @@ async def apply_agents(
                         default_job_timeout=agent_config.defaultJobTimeout,
                         default_keep_alive=agent_config.defaultKeepAlive,
                         system_tools=agent_config.systemTools,
+                        tool_approvals=agent_config.toolApprovals,
                         user_id=owner_user_id,
                         is_active=True,
                         managed_by=managed_by,

--- a/backend/app/services/conversation_history.py
+++ b/backend/app/services/conversation_history.py
@@ -144,8 +144,22 @@ async def build_conversation_history(
     )
     all_messages = result.scalars().all()
 
-    # Apply windowing if conversation exceeds max_history_messages
+    # Apply windowing if conversation exceeds max_history_messages.
+    # Compaction (summarize-and-continue) rides on top: a stored summary of
+    # the dropped prefix is injected as context, and a background refresh is
+    # scheduled whenever the summary lags the window start — so the history
+    # never just falls off a cliff.
     if len(all_messages) > settings.max_history_messages:
+        from app.services import compaction
+
+        if settings.compaction_enabled:
+            stored = compaction.get_compaction(chat)
+            dropped = len(all_messages) - settings.max_history_messages
+            if stored:
+                messages.append(compaction.summary_message(stored))
+            if not stored or stored.get("covered_count", 0) < dropped:
+                compaction.maybe_schedule_compaction(str(chat.id))
+
         chat_messages = all_messages[-settings.max_history_messages:]
 
         # Ensure tool call/result pairs aren't split by the window boundary.

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -368,10 +368,77 @@ class MessageService:
             "agent_label": f"{agent.namespace}/{agent.name}" if agent else None,
         }
 
+    async def inject_user_message(
+        self, chat_id: str, user_id: str, content: str
+    ) -> Optional[Message]:
+        """Steer a running agent loop: persist the user message so the loop's
+        next round boundary picks it up (the conversation is rebuilt from the
+        DB every round). Runs on_user_message hooks first — a blocked message
+        is not persisted and None is returned."""
+        result = await self.db.execute(
+            select(Chat).where(Chat.id == chat_id, Chat.user_id == user_id)
+        )
+        chat = result.scalar_one_or_none()
+        if not chat:
+            raise ValueError("Chat not found")
+
+        agent = None
+        if chat.agent_id:
+            agent = (
+                await self.db.execute(select(Agent).where(Agent.id == chat.agent_id))
+            ).scalar_one_or_none()
+
+        final_content = content
+        if agent and agent.hooks and agent.hooks.get("on_user_message"):
+            hook_result = await run_hooks(
+                hooks=agent.hooks["on_user_message"],
+                message_content=content,
+                message_role="user",
+                chat_id=chat_id,
+                agent_namespace=agent.namespace,
+                agent_name=agent.name,
+                user_id=user_id,
+                session_key=getattr(chat, "session_key", None),
+            )
+            if hook_result.blocked:
+                return None
+            if hook_result.mutated_content:
+                final_content = hook_result.mutated_content
+
+        message = Message(
+            chat_id=chat_id, role="user", content=strip_base64_data(final_content)
+        )
+        self.db.add(message)
+        await self.db.commit()
+        await self.db.refresh(message)
+        return message
+
     async def send_message(
         self, chat_id: str, user_id: str, user_token: str, content: str
     ) -> Message:
-        """Send a message and get LLM response (non-streaming)."""
+        """Send a message and get LLM response (non-streaming).
+
+        One loop per chat: if another loop is already running this chat, the
+        message is injected into it (picked up at the next tool-round
+        boundary) instead of starting a concurrent loop.
+        """
+        from app.services import chat_steering
+
+        lock_token = await chat_steering.acquire_chat_lock(chat_id)
+        if lock_token is None:
+            injected = await self.inject_user_message(chat_id, user_id, content)
+            if injected is None:
+                raise ValueError("Message blocked by hook")
+            return injected
+        try:
+            await chat_steering.clear_interrupt(chat_id)
+            return await self._send_message_locked(chat_id, user_id, user_token, content)
+        finally:
+            await chat_steering.release_chat_lock(chat_id, lock_token)
+
+    async def _send_message_locked(
+        self, chat_id: str, user_id: str, user_token: str, content: str
+    ) -> Message:
         prep = await self._prepare_message_context(
             chat_id=chat_id,
             user_id=user_id,
@@ -532,7 +599,47 @@ class MessageService:
         user_token: str,
         content: str,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Send a message and stream LLM response."""
+        """Send a message and stream LLM response.
+
+        One loop per chat: if a loop is already running this chat, the
+        message is injected into it (the running loop drains it at its next
+        tool-round boundary) and a single "injected" event is emitted
+        instead of starting a concurrent loop.
+        """
+        from app.services import chat_steering
+
+        lock_token = await chat_steering.acquire_chat_lock(chat_id)
+        if lock_token is None:
+            injected = await self.inject_user_message(chat_id, user_id, content)
+            if injected is None:
+                yield {"type": "error", "error": "Message blocked by hook"}
+            else:
+                yield {
+                    "type": "injected",
+                    "message_id": str(injected.id),
+                    "content": (
+                        "Message delivered into the running turn — the agent "
+                        "will see it at its next step."
+                    ),
+                }
+            yield {"type": "done", "status": "injected"}
+            return
+        try:
+            await chat_steering.clear_interrupt(chat_id)
+            async for chunk in self._send_message_stream_locked(
+                chat_id=chat_id, user_id=user_id, user_token=user_token, content=content
+            ):
+                yield chunk
+        finally:
+            await chat_steering.release_chat_lock(chat_id, lock_token)
+
+    async def _send_message_stream_locked(
+        self,
+        chat_id: str,
+        user_id: str,
+        user_token: str,
+        content: str,
+    ) -> AsyncIterator[dict[str, Any]]:
         prep = await self._prepare_message_context(
             chat_id=chat_id,
             user_id=user_id,
@@ -889,6 +996,31 @@ class MessageService:
         # Separate tool calls into parallel and sequential groups
         valid_tool_calls = [tc for tc in tool_calls if tc.get("id")]
 
+        # Cooperative interrupt (issue #142): boundary check before executing
+        # this round's tools. Synthetic tool results keep the transcript
+        # provider-valid — an assistant message with tool_calls must never be
+        # left without matching tool results.
+        from app.services import chat_steering
+
+        if await chat_steering.consume_interrupt(chat_id):
+            interrupted_result = json.dumps({"error": "Interrupted by operator before execution"})
+            for tc in valid_tool_calls:
+                self.db.add(
+                    Message(
+                        chat_id=chat_id,
+                        role="tool",
+                        content=interrupted_result,
+                        tool_call_id=tc["id"],
+                        name=tc["function"]["name"],
+                    )
+                )
+            self.db.add(
+                Message(chat_id=chat_id, role="system", content=chat_steering.INTERRUPT_MARKER)
+            )
+            await self.db.commit()
+            yield {"type": "interrupted", "content": chat_steering.INTERRUPT_MARKER}
+            return
+
         # Suspend-on-delegate (issue #90): in "suspend" mode, agent-delegation
         # tools are split off — they don't execute (and block) here. After the
         # regular tools finish, the children are enqueued and this generator
@@ -1160,7 +1292,22 @@ class MessageService:
         are persisted as Message rows. Called inline by _handle_tool_calls,
         and re-entered by execute_agent_delegate_resume_job once suspended
         sub-agents have reported back (issue #90).
+
+        This is the tool-round boundary: the conversation is rebuilt from
+        the DB here, which is also what makes mid-turn injection work — a
+        user message persisted while the round ran is picked up now. The
+        cooperative interrupt is checked at the same point.
         """
+        from app.services import chat_steering
+
+        if await chat_steering.consume_interrupt(chat_id):
+            self.db.add(
+                Message(chat_id=chat_id, role="system", content=chat_steering.INTERRUPT_MARKER)
+            )
+            await self.db.commit()
+            yield {"type": "interrupted", "content": chat_steering.INTERRUPT_MARKER}
+            return
+
         result_chat = await self.db.execute(select(Chat).where(Chat.id == chat_id))
         chat = result_chat.scalar_one_or_none()
 

--- a/backend/app/services/message_service.py
+++ b/backend/app/services/message_service.py
@@ -880,45 +880,10 @@ class MessageService:
             )
 
             if approval_needed:
-                _tool_meta = {t["function"]["name"]: t["function"].get("_metadata", {}) for t in tools} if tools else {}
-                for tool_call in tool_calls:
-                    tool_name = tool_call["function"]["name"]
-                    arguments_str = tool_call["function"]["arguments"]
-
-                    meta = _tool_meta.get(tool_name, {})
-
-                    # System tool with approval (e.g. sinas_package_install)
-                    if meta.get("system_tool") and meta.get("requires_approval"):
-                        parsed_args = arguments_str
-                        if isinstance(arguments_str, str):
-                            parsed_args = json.loads(arguments_str) if arguments_str.strip() else {}
-                        yield {
-                            "type": "approval_required",
-                            "tool_call_id": tool_call["id"],
-                            "function_namespace": "sinas",
-                            "function_name": tool_name,
-                            "arguments": parsed_args,
-                        }
-                        continue
-
-                    namespace, name = meta.get("namespace"), meta.get("name")
-                    if not namespace or not name:
-                        continue
-
-                    function = await Function.get_by_name(self.db, namespace, name)
-                    if function and function.requires_approval:
-                        parsed_args = arguments_str
-                        if isinstance(arguments_str, str):
-                            parsed_args = json.loads(arguments_str) if arguments_str.strip() else {}
-
-                        yield {
-                            "type": "approval_required",
-                            "tool_call_id": tool_call["id"],
-                            "function_namespace": namespace,
-                            "function_name": name,
-                            "arguments": parsed_args,
-                        }
-
+                # check_approval_requirements already resolved rules and
+                # created the PendingToolApproval rows — announce each.
+                for entry in approval_needed:
+                    yield {"type": "approval_required", **entry}
                 return
 
             async for chunk in self._handle_tool_calls(
@@ -1501,39 +1466,10 @@ class MessageService:
             )
 
             if approval_needed:
-                _tool_meta = {t["function"]["name"]: t["function"].get("_metadata", {}) for t in tools} if tools else {}
-                for tool_call in final_tool_calls:
-                    tc_name = tool_call["function"]["name"]
-                    tc_args = tool_call["function"]["arguments"]
-                    meta = _tool_meta.get(tc_name, {})
-
-                    if meta.get("system_tool") and meta.get("requires_approval"):
-                        parsed_args = tc_args
-                        if isinstance(tc_args, str):
-                            parsed_args = json.loads(tc_args) if tc_args.strip() else {}
-                        yield {
-                            "type": "approval_required",
-                            "tool_call_id": tool_call["id"],
-                            "function_namespace": "sinas",
-                            "function_name": tc_name,
-                            "arguments": parsed_args,
-                        }
-                        continue
-
-                    ns, nm = meta.get("namespace"), meta.get("name")
-                    if ns and nm:
-                        function = await Function.get_by_name(self.db, ns, nm)
-                        if function and function.requires_approval:
-                            parsed_args = tc_args
-                            if isinstance(tc_args, str):
-                                parsed_args = json.loads(tc_args) if tc_args.strip() else {}
-                            yield {
-                                "type": "approval_required",
-                                "tool_call_id": tool_call["id"],
-                                "function_namespace": ns,
-                                "function_name": nm,
-                                "arguments": parsed_args,
-                            }
+                # check_approval_requirements already resolved rules and
+                # created the PendingToolApproval rows — announce each.
+                for entry in approval_needed:
+                    yield {"type": "approval_required", **entry}
                 return
 
             async for result_chunk in self._handle_tool_calls(

--- a/backend/app/services/resource_serializers.py
+++ b/backend/app/services/resource_serializers.py
@@ -274,6 +274,7 @@ def serialize_agent(agent, provider_name: Optional[str] = None) -> dict:
         "defaultJobTimeout": agent.default_job_timeout,
         "defaultKeepAlive": agent.default_keep_alive if agent.default_keep_alive else None,
         "systemTools": agent.system_tools if agent.system_tools else None,
+        "toolApprovals": agent.tool_approvals if agent.tool_approvals else None,
     })
 
 

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -324,15 +324,30 @@ async def check_approval_requirements(
     temperature: float,
     max_tokens: Optional[int],
     tools: Optional[list[dict[str, Any]]] = None,
-) -> bool:
-    """Check if any tool calls require user approval before execution.
+) -> list[dict[str, Any]]:
+    """Check which tool calls require user approval before execution.
 
-    If approval is needed, creates PendingToolApproval records.
+    Applies the agent's tool-approval rules and the chat's session grants on
+    top of the intrinsic requires_approval flags; creates a
+    PendingToolApproval record per asked call.
 
     Returns:
-        True if any tool calls require approval, False otherwise
+        One {tool_call_id, function_namespace, function_name, arguments}
+        entry per call that needs approval (empty list: run everything).
     """
-    requires_approval = False
+    from app.services import approval_rules
+
+    asked: list[dict[str, Any]] = []
+
+    # Agent tool-approval rules (permission modes) + the user's per-chat
+    # "always allow" grants — both consulted per call below, layered over
+    # the intrinsic requires_approval flags.
+    tool_approvals = None
+    chat = await db.get(Chat, chat_id)
+    if chat and chat.agent_id:
+        agent = await db.get(Agent, chat.agent_id)
+        tool_approvals = agent.tool_approvals if agent else None
+    session_grants = await approval_rules.get_session_grants(chat_id)
 
     # Build tool name → metadata lookup from tools list
     tool_meta_map = {}
@@ -349,35 +364,47 @@ async def check_approval_requirements(
         meta = tool_meta_map.get(tool_name, {})
         namespace: Optional[str] = None
         name: Optional[str] = None
+        intrinsic_ask = False
 
         if meta.get("system_tool"):
             # Sinas built-in system tool (e.g. package management).
             # Approval requirement comes directly from the tool definition's
             # _metadata.requires_approval flag.
-            if not meta.get("requires_approval"):
-                continue
+            intrinsic_ask = bool(meta.get("requires_approval"))
             namespace = "sinas"
             name = tool_name
-        else:
+        elif meta.get("namespace") and meta.get("name"):
             # Regular user-defined function tool
-            namespace = meta.get("namespace")
-            name = meta.get("name")
-            if not namespace or not name:
-                # Not a function tool (agents, collections, etc.), skip
-                continue
-
-            # Load function to check requires_approval flag
+            namespace = meta["namespace"]
+            name = meta["name"]
             function = await Function.get_by_name(db, namespace, name)
-            if not function or not function.requires_approval:
-                continue
+            intrinsic_ask = bool(function and function.requires_approval)
+        else:
+            # Any other tool kind (collections, workbench, connectors,
+            # pipelines, delegation…): no intrinsic flag, but agent rules
+            # can still gate it.
+            namespace = "tool"
+            name = tool_name
+
+        if (
+            approval_rules.resolve_action(
+                tool_approvals, tool_name, intrinsic_ask, session_grants
+            )
+            != approval_rules.ASK
+        ):
+            continue
 
         # This tool requires approval
-        requires_approval = True
-
         # Parse arguments safely - handle empty strings
         parsed_args = arguments_str
         if isinstance(arguments_str, str):
             parsed_args = json.loads(arguments_str) if arguments_str.strip() else {}
+        asked.append({
+            "tool_call_id": tool_call["id"],
+            "function_namespace": namespace,
+            "function_name": name,
+            "arguments": parsed_args,
+        })
 
         # Create PendingToolApproval record
         pending_approval = PendingToolApproval(
@@ -400,10 +427,10 @@ async def check_approval_requirements(
         )
         db.add(pending_approval)
 
-    if requires_approval:
+    if asked:
         await db.commit()
 
-    return requires_approval
+    return asked
 
 
 async def prepare_agent_delegation(

--- a/backend/tests/unit/test_approval_rules.py
+++ b/backend/tests/unit/test_approval_rules.py
@@ -1,0 +1,272 @@
+"""Permission modes: tool approval rules + per-chat session grants.
+
+Layered over requires_approval: first-match glob rules per agent decide
+auto vs ask for ANY tool kind, an explicit 'auto' rule can deliberately
+override a function's requires_approval, and an approval given with
+always_allow=true is remembered for the rest of the chat.
+"""
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Agent, Chat
+from app.models.function import Function
+from app.models.pending_approval import PendingToolApproval
+from app.models.user import User
+from app.services import approval_rules
+from app.services.approval_rules import resolve_action
+from app.services.tool_execution import check_approval_requirements
+
+
+class TestResolveAction:
+    def test_defaults_to_auto_with_no_config(self):
+        assert resolve_action(None, "any_tool", intrinsic_ask=False, session_grants=set()) == "auto"
+
+    def test_intrinsic_ask_without_rules(self):
+        assert resolve_action(None, "risky_fn", intrinsic_ask=True, session_grants=set()) == "ask"
+
+    def test_first_matching_rule_wins(self):
+        cfg = {
+            "rules": [
+                {"match": "write_*", "action": "ask"},
+                {"match": "write_file_docs", "action": "auto"},  # never reached
+            ]
+        }
+        assert resolve_action(cfg, "write_file_docs", False, set()) == "ask"
+
+    def test_glob_matching(self):
+        cfg = {"rules": [{"match": "workbench_*", "action": "ask"}]}
+        assert resolve_action(cfg, "workbench_promote", False, set()) == "ask"
+        assert resolve_action(cfg, "search_collection_docs", False, set()) == "auto"
+
+    def test_auto_rule_overrides_intrinsic_requires_approval(self):
+        cfg = {"rules": [{"match": "get_*", "action": "auto"}]}
+        assert resolve_action(cfg, "get_report", intrinsic_ask=True, session_grants=set()) == "auto"
+
+    def test_default_ask_catches_unmatched(self):
+        cfg = {"default": "ask", "rules": [{"match": "read_*", "action": "auto"}]}
+        assert resolve_action(cfg, "read_thing", False, set()) == "auto"
+        assert resolve_action(cfg, "delete_thing", False, set()) == "ask"
+
+    def test_session_grant_beats_everything(self):
+        cfg = {"default": "ask", "rules": [{"match": "*", "action": "ask"}]}
+        assert resolve_action(cfg, "granted_tool", True, {"granted_tool"}) == "auto"
+
+    def test_malformed_rules_are_skipped(self):
+        cfg = {"rules": [{"match": None}, {"action": "ask"}, {"match": "x", "action": "maybe"}]}
+        assert resolve_action(cfg, "x", False, set()) == "auto"
+
+    def test_invalid_default_falls_back_to_auto(self):
+        assert resolve_action({"default": "yolo"}, "x", False, set()) == "auto"
+
+
+class TestSessionGrants:
+    @pytest.mark.asyncio
+    async def test_grant_roundtrip(self):
+        chat_id = f"grants-{uuid.uuid4().hex}"
+        assert await approval_rules.get_session_grants(chat_id) == set()
+        await approval_rules.add_session_grant(chat_id, "workbench_promote")
+        await approval_rules.add_session_grant(chat_id, "send_email")
+        assert await approval_rules.get_session_grants(chat_id) == {
+            "workbench_promote",
+            "send_email",
+        }
+
+
+@pytest_asyncio.fixture
+async def agent_with_rules(db: AsyncSession, test_user: User) -> Agent:
+    agent = Agent(
+        namespace="test",
+        name=f"gated-{uuid.uuid4().hex[:6]}",
+        user_id=test_user.id,
+        tool_approvals={"rules": [{"match": "workbench_promote", "action": "ask"}]},
+    )
+    db.add(agent)
+    await db.flush()
+    await db.refresh(agent)
+    return agent
+
+
+@pytest_asyncio.fixture
+async def gated_chat(db: AsyncSession, test_user: User, agent_with_rules: Agent) -> Chat:
+    c = Chat(
+        user_id=test_user.id,
+        agent_id=agent_with_rules.id,
+        agent_namespace=agent_with_rules.namespace,
+        agent_name=agent_with_rules.name,
+        title="gated chat",
+    )
+    db.add(c)
+    await db.flush()
+    await db.refresh(c)
+    return c
+
+
+def _call(tool_name: str, call_id: str | None = None) -> dict:
+    return {
+        "id": call_id or f"call_{uuid.uuid4().hex[:8]}",
+        "type": "function",
+        "function": {"name": tool_name, "arguments": "{}"},
+    }
+
+
+class TestCheckApprovalRequirements:
+    @pytest.mark.asyncio
+    async def test_rule_gates_generic_tool(self, db, gated_chat, test_user):
+        """A rule can put ANY tool behind approval — not just functions."""
+        import uuid as _uuid
+        from app.models.chat import Message
+
+        msg = Message(chat_id=gated_chat.id, role="assistant", content=None)
+        db.add(msg)
+        await db.flush()
+
+        asked = await check_approval_requirements(
+            db=db,
+            tool_calls=[_call("workbench_promote", "call_gate1"), _call("workbench_read")],
+            chat_id=str(gated_chat.id),
+            user_id=str(test_user.id),
+            message_id=str(msg.id),
+            messages=[],
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=[],
+        )
+        assert [e["tool_call_id"] for e in asked] == ["call_gate1"]
+        assert asked[0]["function_namespace"] == "tool"
+        assert asked[0]["function_name"] == "workbench_promote"
+
+        pending = (
+            await db.execute(
+                select(PendingToolApproval).where(PendingToolApproval.chat_id == gated_chat.id)
+            )
+        ).scalars().all()
+        assert len(pending) == 1 and pending[0].tool_call_id == "call_gate1"
+
+    @pytest.mark.asyncio
+    async def test_session_grant_suppresses_ask(self, db, gated_chat, test_user):
+        from app.models.chat import Message
+
+        await approval_rules.add_session_grant(str(gated_chat.id), "workbench_promote")
+        msg = Message(chat_id=gated_chat.id, role="assistant", content=None)
+        db.add(msg)
+        await db.flush()
+
+        asked = await check_approval_requirements(
+            db=db,
+            tool_calls=[_call("workbench_promote")],
+            chat_id=str(gated_chat.id),
+            user_id=str(test_user.id),
+            message_id=str(msg.id),
+            messages=[],
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=[],
+        )
+        assert asked == []
+
+    @pytest.mark.asyncio
+    async def test_no_rules_keeps_generic_tools_auto(self, db, test_user):
+        """Back-compat: without rules, only requires_approval functions ask."""
+        from app.models.chat import Message
+
+        chat = Chat(user_id=test_user.id, title="plain chat")
+        db.add(chat)
+        await db.flush()
+        msg = Message(chat_id=chat.id, role="assistant", content=None)
+        db.add(msg)
+        await db.flush()
+
+        asked = await check_approval_requirements(
+            db=db,
+            tool_calls=[_call("workbench_promote"), _call("anything_else")],
+            chat_id=str(chat.id),
+            user_id=str(test_user.id),
+            message_id=str(msg.id),
+            messages=[],
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=[],
+        )
+        assert asked == []
+
+    @pytest.mark.asyncio
+    async def test_auto_rule_unlocks_requires_approval_function(self, db, test_user):
+        from app.models.chat import Message
+
+        fn = Function(
+            namespace="test",
+            name=f"guarded-{uuid.uuid4().hex[:6]}",
+            user_id=test_user.id,
+            code="def handler(i, c): return {}",
+            input_schema={},
+            output_schema={},
+            requires_approval=True,
+        )
+        agent = Agent(
+            namespace="test",
+            name=f"trusting-{uuid.uuid4().hex[:6]}",
+            user_id=test_user.id,
+            tool_approvals={"rules": [{"match": "*", "action": "auto"}]},
+        )
+        db.add_all([fn, agent])
+        await db.flush()
+        chat = Chat(user_id=test_user.id, agent_id=agent.id, title="trusting chat")
+        db.add(chat)
+        await db.flush()
+        msg = Message(chat_id=chat.id, role="assistant", content=None)
+        db.add(msg)
+        await db.flush()
+
+        tool_name = f"{fn.namespace}_{fn.name}"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "_metadata": {"namespace": fn.namespace, "name": fn.name},
+                },
+            }
+        ]
+        asked = await check_approval_requirements(
+            db=db,
+            tool_calls=[_call(tool_name)],
+            chat_id=str(chat.id),
+            user_id=str(test_user.id),
+            message_id=str(msg.id),
+            messages=[],
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=tools,
+        )
+        assert asked == []
+
+        # Without the agent rule the same function asks.
+        agent.tool_approvals = None
+        await db.flush()
+        asked = await check_approval_requirements(
+            db=db,
+            tool_calls=[_call(tool_name)],
+            chat_id=str(chat.id),
+            user_id=str(test_user.id),
+            message_id=str(msg.id),
+            messages=[],
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=tools,
+        )
+        assert len(asked) == 1
+        assert asked[0]["function_namespace"] == fn.namespace

--- a/backend/tests/unit/test_chat_steering.py
+++ b/backend/tests/unit/test_chat_steering.py
@@ -1,0 +1,241 @@
+"""Steering triad: per-chat lock, cooperative interrupt (#142), injection.
+
+The invariants under test:
+- exactly one agent loop runs per chat (second send injects, never races);
+- an interrupt stops the loop at a tool-round boundary, leaves the
+  transcript intact plus a system marker, and a fresh send clears a stale
+  flag;
+- a message persisted mid-turn is what injection *is* — the loop rebuilds
+  its conversation from the DB at every round boundary.
+"""
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.user import User
+from app.services import chat_steering
+from app.services.message_service import MessageService
+
+
+@pytest_asyncio.fixture
+async def chat(db: AsyncSession, test_user: User) -> Chat:
+    c = Chat(user_id=test_user.id, title="steering test chat")
+    db.add(c)
+    await db.flush()
+    await db.refresh(c)
+    return c
+
+
+class TestChatLock:
+    @pytest.mark.asyncio
+    async def test_lock_is_exclusive_and_releasable(self):
+        chat_id = f"lock-test-{uuid.uuid4().hex}"
+        token = await chat_steering.acquire_chat_lock(chat_id)
+        assert token
+        assert await chat_steering.is_chat_locked(chat_id)
+        assert await chat_steering.acquire_chat_lock(chat_id) is None
+
+        await chat_steering.release_chat_lock(chat_id, token)
+        assert not await chat_steering.is_chat_locked(chat_id)
+        token2 = await chat_steering.acquire_chat_lock(chat_id)
+        assert token2
+
+        # A stale holder must not release the new holder's lock.
+        await chat_steering.release_chat_lock(chat_id, token)
+        assert await chat_steering.is_chat_locked(chat_id)
+        await chat_steering.release_chat_lock(chat_id, token2)
+
+    @pytest.mark.asyncio
+    async def test_acquire_wait_times_out_while_held(self):
+        chat_id = f"lock-wait-{uuid.uuid4().hex}"
+        token = await chat_steering.acquire_chat_lock(chat_id)
+        assert await chat_steering.acquire_chat_lock_wait(chat_id, wait_seconds=1) is None
+        await chat_steering.release_chat_lock(chat_id, token)
+        token2 = await chat_steering.acquire_chat_lock_wait(chat_id, wait_seconds=1)
+        assert token2
+        await chat_steering.release_chat_lock(chat_id, token2)
+
+
+class TestInterruptFlag:
+    @pytest.mark.asyncio
+    async def test_request_consume_clear(self):
+        chat_id = f"intr-{uuid.uuid4().hex}"
+        assert not await chat_steering.consume_interrupt(chat_id)
+        await chat_steering.request_interrupt(chat_id, "tester")
+        assert await chat_steering.consume_interrupt(chat_id)
+        # consumed — gone
+        assert not await chat_steering.consume_interrupt(chat_id)
+
+        await chat_steering.request_interrupt(chat_id)
+        await chat_steering.clear_interrupt(chat_id)
+        assert not await chat_steering.consume_interrupt(chat_id)
+
+
+class TestInjection:
+    @pytest.mark.asyncio
+    async def test_send_while_locked_injects_user_message(self, db, chat, test_user):
+        """A send against a locked chat persists the message for the running
+        loop to drain instead of starting a second loop."""
+        token = await chat_steering.acquire_chat_lock(str(chat.id))
+        try:
+            service = MessageService(db)
+            result = await service.send_message(
+                chat_id=str(chat.id),
+                user_id=str(test_user.id),
+                user_token="",
+                content="steer left!",
+            )
+            assert result.role == "user"
+            assert result.content == "steer left!"
+
+            rows = (
+                await db.execute(select(Message).where(Message.chat_id == chat.id))
+            ).scalars().all()
+            assert [m.role for m in rows] == ["user"]
+        finally:
+            await chat_steering.release_chat_lock(str(chat.id), token)
+
+    @pytest.mark.asyncio
+    async def test_stream_while_locked_yields_injected_event(self, db, chat, test_user):
+        token = await chat_steering.acquire_chat_lock(str(chat.id))
+        try:
+            service = MessageService(db)
+            events = []
+            async for chunk in service.send_message_stream(
+                chat_id=str(chat.id),
+                user_id=str(test_user.id),
+                user_token="",
+                content="mid-turn note",
+            ):
+                events.append(chunk)
+            types = [e.get("type") for e in events]
+            assert types == ["injected", "done"]
+        finally:
+            await chat_steering.release_chat_lock(str(chat.id), token)
+
+    @pytest.mark.asyncio
+    async def test_injection_into_other_users_chat_fails(self, db, chat, admin_user):
+        token = await chat_steering.acquire_chat_lock(str(chat.id))
+        try:
+            service = MessageService(db)
+            with pytest.raises(ValueError):
+                await service.send_message(
+                    chat_id=str(chat.id),
+                    user_id=str(admin_user.id),
+                    user_token="",
+                    content="not my chat",
+                )
+        finally:
+            await chat_steering.release_chat_lock(str(chat.id), token)
+
+
+class TestInterruptBoundary:
+    @pytest.mark.asyncio
+    async def test_followup_boundary_stops_and_marks(self, db, chat, test_user):
+        """An armed interrupt makes the tool-round boundary stop the loop and
+        write the system marker — transcript intact."""
+        db.add(Message(chat_id=chat.id, role="user", content="do things"))
+        await db.commit()
+
+        await chat_steering.request_interrupt(str(chat.id), "tester")
+        service = MessageService(db)
+        events = []
+        async for chunk in service._stream_followup_after_tools(
+            chat_id=str(chat.id),
+            user_id=str(test_user.id),
+            user_token="",
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=[],
+        ):
+            events.append(chunk)
+        assert events == [
+            {"type": "interrupted", "content": chat_steering.INTERRUPT_MARKER}
+        ]
+
+        rows = (
+            await db.execute(
+                select(Message).where(Message.chat_id == chat.id).order_by(Message.created_at)
+            )
+        ).scalars().all()
+        assert [m.role for m in rows] == ["user", "system"]
+        assert rows[-1].content == chat_steering.INTERRUPT_MARKER
+        # flag consumed — the next boundary would run normally
+        assert not await chat_steering.consume_interrupt(str(chat.id))
+
+    @pytest.mark.asyncio
+    async def test_tool_round_boundary_writes_synthetic_results(self, db, chat, test_user):
+        """Interrupting before a round's tools run leaves no dangling
+        tool_calls: every call gets a synthetic 'interrupted' result."""
+        await chat_steering.request_interrupt(str(chat.id), "tester")
+        service = MessageService(db)
+        tool_calls = [
+            {"id": "call_1", "type": "function", "function": {"name": "some_tool", "arguments": "{}"}},
+            {"id": "call_2", "type": "function", "function": {"name": "other_tool", "arguments": "{}"}},
+        ]
+        events = []
+        async for chunk in service._handle_tool_calls(
+            chat_id=str(chat.id),
+            user_id=str(test_user.id),
+            user_token="",
+            messages=[],
+            tool_calls=tool_calls,
+            provider=None,
+            model=None,
+            temperature=0.7,
+            max_tokens=None,
+            tools=[],
+        ):
+            events.append(chunk)
+        assert events[-1]["type"] == "interrupted"
+
+        rows = (
+            await db.execute(
+                select(Message).where(Message.chat_id == chat.id).order_by(Message.created_at)
+            )
+        ).scalars().all()
+        roles = [m.role for m in rows]
+        # assistant (tool_calls) + one tool result per call + system marker
+        assert roles == ["assistant", "tool", "tool", "system"]
+        tool_rows = [m for m in rows if m.role == "tool"]
+        assert {m.tool_call_id for m in tool_rows} == {"call_1", "call_2"}
+        for m in tool_rows:
+            assert "Interrupted" in m.content
+
+
+class TestInterruptEndpoint:
+    @pytest.mark.asyncio
+    async def test_interrupt_endpoint_arms_flag(self, db, chat, client, test_user):
+        from tests.conftest import auth_headers
+
+        resp = await client.post(f"/chats/{chat.id}/interrupt", headers=auth_headers(test_user))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["interrupted"] is True
+        assert body["was_running"] is False
+        assert await chat_steering.consume_interrupt(str(chat.id))
+
+    @pytest.mark.asyncio
+    async def test_interrupt_endpoint_reports_running(self, db, chat, client, test_user):
+        from tests.conftest import auth_headers
+
+        token = await chat_steering.acquire_chat_lock(str(chat.id))
+        try:
+            resp = await client.post(f"/chats/{chat.id}/interrupt", headers=auth_headers(test_user))
+            assert resp.status_code == 200
+            assert resp.json()["was_running"] is True
+        finally:
+            await chat_steering.release_chat_lock(str(chat.id), token)
+
+    @pytest.mark.asyncio
+    async def test_interrupt_other_users_chat_is_404(self, db, chat, client, admin_user):
+        from tests.conftest import auth_headers
+
+        resp = await client.post(f"/chats/{chat.id}/interrupt", headers=auth_headers(admin_user))
+        assert resp.status_code == 404

--- a/backend/tests/unit/test_compaction.py
+++ b/backend/tests/unit/test_compaction.py
@@ -1,0 +1,144 @@
+"""Compaction: summarize-and-continue instead of the 100-message cliff.
+
+Covers: the incremental refresh (each message summarized at most once, the
+prior summary folded into the next), the injection of the stored summary
+into the built history when windowing applies, and the schedule trigger
+when the summary lags the window.
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.chat import Chat, Message
+from app.models.user import User
+from app.services import compaction
+from app.services.conversation_history import build_conversation_history
+from app.services.skill_tools import SkillToolConverter
+
+
+@pytest_asyncio.fixture
+async def long_chat(db: AsyncSession, test_user: User) -> Chat:
+    chat = Chat(user_id=test_user.id, title="long chat")
+    db.add(chat)
+    await db.flush()
+    for i in range(10):
+        role = "user" if i % 2 == 0 else "assistant"
+        db.add(Message(chat_id=chat.id, role=role, content=f"message {i}"))
+        await db.flush()  # distinct created_at ordering
+    await db.refresh(chat)
+    return chat
+
+
+class TestRunCompaction:
+    @pytest.mark.asyncio
+    async def test_incremental_refresh(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 6)
+
+        seen: list[tuple[str, int]] = []
+
+        async def fake_summarize(_db, _chat, prior_summary, delta):
+            seen.append((prior_summary, len(delta)))
+            return f"summary covering {len(delta)} more"
+
+        monkeypatch.setattr(compaction, "_summarize", fake_summarize)
+
+        # First run: 10 messages, window 6 → summarize the first 4.
+        result = await compaction.run_compaction(str(long_chat.id), db=db)
+        assert result["covered_count"] == 4
+        assert seen == [("", 4)]
+
+        # No growth → no re-summarization.
+        again = await compaction.run_compaction(str(long_chat.id), db=db)
+        assert again["covered_count"] == 4
+        assert len(seen) == 1
+
+        # Chat grows by 3 → only the 3-message delta is folded in, with the
+        # prior summary as input.
+        for i in range(3):
+            db.add(Message(chat_id=long_chat.id, role="user", content=f"more {i}"))
+            await db.flush()
+        result = await compaction.run_compaction(str(long_chat.id), db=db)
+        assert result["covered_count"] == 7
+        assert seen[-1] == ("summary covering 4 more", 3)
+
+    @pytest.mark.asyncio
+    async def test_short_chat_is_untouched(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 100)
+        result = await compaction.run_compaction(str(long_chat.id), db=db)
+        assert result is None
+        assert compaction.get_compaction(long_chat) is None
+
+    @pytest.mark.asyncio
+    async def test_failed_summarize_keeps_previous_state(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 6)
+
+        async def broken(_db, _chat, prior, delta):
+            return None
+
+        monkeypatch.setattr(compaction, "_summarize", broken)
+        result = await compaction.run_compaction(str(long_chat.id), db=db)
+        assert result is None
+        assert compaction.get_compaction(long_chat) is None
+
+
+class TestHistoryInjection:
+    @pytest.mark.asyncio
+    async def test_summary_injected_when_windowing(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 6)
+        long_chat.chat_metadata = {
+            "compaction": {"summary": "- user likes terse answers", "covered_count": 4}
+        }
+        await db.flush()
+
+        scheduled: list[str] = []
+        monkeypatch.setattr(
+            compaction, "maybe_schedule_compaction", lambda chat_id: scheduled.append(chat_id)
+        )
+
+        messages = await build_conversation_history(db, long_chat, SkillToolConverter())
+        system_msgs = [m for m in messages if m["role"] == "system"]
+        assert any("user likes terse answers" in m["content"] for m in system_msgs)
+        # summary covers exactly the dropped prefix — no refresh needed
+        assert scheduled == []
+        # windowed history follows the summary
+        assert sum(1 for m in messages if m["role"] in ("user", "assistant")) == 6
+
+    @pytest.mark.asyncio
+    async def test_lagging_summary_triggers_refresh(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 4)  # dropped = 6 > covered 4
+        long_chat.chat_metadata = {
+            "compaction": {"summary": "- old summary", "covered_count": 4}
+        }
+        await db.flush()
+
+        scheduled: list[str] = []
+        monkeypatch.setattr(
+            compaction, "maybe_schedule_compaction", lambda chat_id: scheduled.append(chat_id)
+        )
+        await build_conversation_history(db, long_chat, SkillToolConverter())
+        assert scheduled == [str(long_chat.id)]
+
+    @pytest.mark.asyncio
+    async def test_no_summary_no_injection_but_scheduled(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 6)
+        scheduled: list[str] = []
+        monkeypatch.setattr(
+            compaction, "maybe_schedule_compaction", lambda chat_id: scheduled.append(chat_id)
+        )
+        messages = await build_conversation_history(db, long_chat, SkillToolConverter())
+        assert not any("summarized" in (m.get("content") or "") for m in messages if m["role"] == "system")
+        assert scheduled == [str(long_chat.id)]
+
+    @pytest.mark.asyncio
+    async def test_compaction_disabled_restores_pure_windowing(self, db, long_chat, monkeypatch):
+        monkeypatch.setattr(settings, "max_history_messages", 6)
+        monkeypatch.setattr(settings, "compaction_enabled", False)
+        long_chat.chat_metadata = {
+            "compaction": {"summary": "- should not appear", "covered_count": 4}
+        }
+        await db.flush()
+        messages = await build_conversation_history(db, long_chat, SkillToolConverter())
+        assert not any(
+            "should not appear" in (m.get("content") or "") for m in messages
+        )


### PR DESCRIPTION
## What this adds

The behavioral half of the Claude Code / Cowork gap analysis — everything that makes long autonomous turns safe and long conversations sustainable. **Stacked on #178** (retarget to `dev` after it merges); the diff here is the three commits on top.

### Steering triad
- **Per-chat lock**: every loop entry (send, stream, approval-resume, delegate-resume) holds a Redis lock (token-checked release, TTL = agent job timeout + slack, so a crashed worker can never wedge a chat). Exactly one loop per chat.
- **Mid-turn injection**: a send against a locked chat no longer races it — the message is persisted (on_user_message hooks applied) and the caller gets an `injected` event; the running loop drains it at its next tool-round boundary, since it rebuilds the conversation from the DB there.
- **Cooperative interrupt** (closes #142): `POST /chats/{id}/interrupt` stops the loop at its next boundary, appends an `Interrupted by operator.` system marker, and writes synthetic tool results when a round's tools hadn't run — no dangling `tool_calls` ever reach a provider. The flag's TTL catches queued continuation jobs; a fresh user message clears it. Chat and transcript stay intact, unlike `DELETE /chats/{id}`.

### Permission modes
- `tool_approvals` on agents: first-match glob rules over tool names (`{"default": "auto"|"ask", "rules": [{"match": "write_*", "action": "ask"}]}`), layered over `requires_approval`. Rules can gate **any** tool kind, an explicit `auto` rule deliberately unlocks an approval-gated function (the "auto-allow reads" mode — both knobs belong to the agent author), and `NULL` config is exactly today's behavior.
- `always_allow` on the approval endpoint records a per-chat session grant (Redis set, 7-day TTL, fails closed) so the same tool skips the ask for the rest of the chat.
- `check_approval_requirements` now returns the asked entries and both `approval_required` emit sites announce from that list, so rule-gated generic tools surface to clients identically to function approvals. Plumbed through the v1 API, config-apply (`toolApprovals`), and the serializer.

### Compaction
- The `max_history_messages` cliff is gone: a rolling summary stored in `chat_metadata.compaction` is injected ahead of the windowed history, refreshed asynchronously and **incrementally** (prior summary + only the delta — each message summarized at most once), off the user's critical path behind a Redis NX guard, via the default provider's default model with low temperature and a bounded token budget. Every failure path degrades to plain windowing; `compaction_enabled=false` restores it outright.

Known pre-existing gap (unchanged here, worth its own issue): `_stream_followup_after_tools` rebuilds the full history mid-turn without windowing, so the cap/compaction only applies to fresh sends.

## Testing
- 32 new tests: lock exclusivity/token-checked release/wait-timeout, interrupt request/consume/clear, injection (locked send persists + `injected` event, cross-user denial), boundary behavior (marker + synthetic tool results, flag consumed), interrupt endpoint auth; rule resolution precedence (globs, session grants, auto-overrides-intrinsic, malformed rules), session grant round trip, integration through `check_approval_requirements` incl. back-compat; incremental compaction refresh, history injection, lag-triggered scheduling, disabled flag.
- Full backend suite 495 green against local Postgres 16 + Redis.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKF3t37iK8aEGexrttW5od)_