### PR TITLE
Workbench file references in tool calls + full-result spill

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -316,6 +316,9 @@ class Settings(BaseSettings):
     # and per execution.
     workbench_lazy_fetch_max_bytes: int = 64 * 1024 * 1024
     workbench_lazy_fetch_max_calls: int = 100
+    # File references: cap on the resolved size of one {"$workbench": path}
+    # tool-call parameter.
+    workbench_ref_max_bytes: int = 10 * 1024 * 1024
 
     # Tool results above this many characters are truncated (structure-aware,
     # see services/tool_execution.truncate_tool_result) before they enter the

--- a/backend/app/services/tool_execution.py
+++ b/backend/app/services/tool_execution.py
@@ -658,6 +658,21 @@ async def execute_single_tool(
             result_chat = await db.execute(select(Chat).where(Chat.id == chat_id))
             chat = result_chat.scalar_one_or_none()
 
+            # Workbench file references: {"$workbench": "path"} parameter
+            # values are replaced by the file's content before dispatch, so
+            # content never has to travel through the model. A failed
+            # reference fails the whole call — the sentinel must not leak
+            # through to the tool as literal arguments.
+            from app.services import workbench_refs
+
+            if workbench_refs.contains_reference(arguments):
+                try:
+                    arguments = await workbench_refs.resolve_references(
+                        db, chat, user_id, arguments
+                    )
+                except workbench_refs.ReferenceError_ as e:
+                    return (tool_call["id"], tool_name, json.dumps({"error": str(e)}))
+
             # Look up tool metadata from the tools list (set during tool discovery)
             tool_metadata = {}
             tool_found_in_list = False
@@ -962,7 +977,19 @@ async def execute_single_tool(
             )
             if len(result_content) > max_result_size:
                 print(f"⚠️ Truncating tool result for {tool_name}: {len(result_content)} -> {max_result_size} bytes", flush=True)
+                # Spill the FULL result to the workbench before truncating —
+                # otherwise the excess is gone for good (truncation runs
+                # before any persistence). The inline copy then carries a
+                # pointer the model can follow with workbench_read or code
+                # execution. No workbench → today's truncate-only behavior.
+                spill_path = await workbench_refs.spill_result(
+                    db, chat, user_id, tool_name, tool_call["id"], result_content
+                )
                 result_content = truncate_tool_result(result_content, max_result_size)
+                if spill_path:
+                    result_content = workbench_refs.attach_spill_pointer(
+                        result_content, spill_path
+                    )
 
     except Exception as e:
         print(f"❌ Tool execution failed: {tool_name}: {e}", flush=True)

--- a/backend/app/services/workbench.py
+++ b/backend/app/services/workbench.py
@@ -122,7 +122,11 @@ def get_workbench_tool_definitions() -> list[dict[str, Any]]:
             "workbench_list",
             "List/search files in this chat's workbench — your private, persistent "
             "working tree. Files persist across turns of this conversation. "
-            "Optionally filter by a content query or metadata.",
+            "Optionally filter by a content query or metadata. "
+            "In ANY tool call, you can pass {\"$workbench\": \"<path>\"} as a "
+            "parameter value to send that file's contents without copying them "
+            "(add \"encoding\": \"base64\" for binary parameters). Oversized "
+            "tool results are saved in full under tool_results/ here.",
             {
                 "query": {"type": "string", "description": "Optional text/regex query against file contents"},
                 "metadata_filter": {"type": "object", "description": "Optional key-value metadata filter"},

--- a/backend/app/services/workbench_refs.py
+++ b/backend/app/services/workbench_refs.py
@@ -1,0 +1,227 @@
+"""Workbench file references in tool calls, and result spill.
+
+Two halves of one idea: file content should not have to travel through the
+model.
+
+Outbound — references: a tool-call parameter whose value is the typed
+object {"$workbench": "<path>"} (optionally {"encoding": "text"|"base64"})
+is resolved by the tool executor at dispatch time: the file's current
+version is loaded from the calling chat's workbench and the object is
+replaced by the content. The model passes a reference; the tool receives
+bytes. Works for every tool kind with zero per-service code, and the
+typed-object sentinel cannot collide with legitimate string content.
+
+Inbound — spill: a tool result too large for the context is saved in full
+to the chat's workbench (tool_results/<tool>_<call-id>…) before the inline
+copy is truncated, and the truncated copy carries a pointer. The model can
+then read the full result with workbench_read (offsets) or process it with
+code execution — and, unlike before, the full bytes actually survive
+(truncation used to run before any persistence).
+
+Resolution is chat-scoped by construction: only the calling chat's own
+workbench is reachable. Design: the workbench file-references ADR.
+"""
+import json
+import logging
+import re
+from typing import Any, Optional
+
+from sqlalchemy import select
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+SENTINEL_KEY = "$workbench"
+_ALLOWED_KEYS = {SENTINEL_KEY, "encoding"}
+
+_TEXTUAL_TYPES = ("text/",)
+_TEXTUAL_EXACT = {
+    "application/json",
+    "application/x-yaml",
+    "application/sql",
+    "application/javascript",
+    "application/typescript",
+    "application/xml",
+}
+
+
+class ReferenceError_(Exception):
+    """A workbench reference could not be resolved (bad path, missing file,
+    over the size cap). The whole tool call fails with this message — a
+    sentinel must never leak through to the tool as literal arguments."""
+
+
+def contains_reference(arguments_str: Any) -> bool:
+    """Cheap pre-check so the common case (no references) costs nothing."""
+    if isinstance(arguments_str, str):
+        return f'"{SENTINEL_KEY}"' in arguments_str
+    if isinstance(arguments_str, (dict, list)):
+        return f'"{SENTINEL_KEY}"' in json.dumps(arguments_str)
+    return False
+
+
+def _is_reference(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and SENTINEL_KEY in value
+        and set(value.keys()) <= _ALLOWED_KEYS
+        and isinstance(value[SENTINEL_KEY], str)
+    )
+
+
+def _default_encoding(content_type: str) -> str:
+    if content_type.startswith(_TEXTUAL_TYPES) or content_type in _TEXTUAL_EXACT:
+        return "text"
+    return "base64"
+
+
+async def resolve_references(db, chat, user_id: str, arguments: Any) -> Any:
+    """Replace every {"$workbench": path} object in `arguments` with the
+    referenced file's content. Raises ReferenceError_ on any failure."""
+    from app.services.workbench import _validate_path, get_or_create_workbench
+    from app.models.file import File, FileVersion
+    from app.services.file_storage import get_storage
+
+    if chat is None:
+        raise ReferenceError_("Workbench references require a chat context")
+    if str(chat.user_id) != str(user_id):
+        raise ReferenceError_("Workbench belongs to a different user")
+
+    workbench = await get_or_create_workbench(db, chat)
+    storage = get_storage()
+
+    async def _resolve_one(ref: dict[str, Any]) -> str:
+        path = ref[SENTINEL_KEY]
+        err = _validate_path(path)
+        if err:
+            raise ReferenceError_(f"Invalid workbench reference {path!r}: {err}")
+        f = (
+            await db.execute(
+                select(File).where(File.collection_id == workbench.id, File.name == path)
+            )
+        ).scalar_one_or_none()
+        if not f:
+            raise ReferenceError_(
+                f"Workbench reference {path!r} not found — list files with workbench_list"
+            )
+        version = (
+            await db.execute(
+                select(FileVersion).where(
+                    FileVersion.file_id == f.id,
+                    FileVersion.version_number == f.current_version,
+                )
+            )
+        ).scalar_one_or_none()
+        if version is None:
+            raise ReferenceError_(f"Workbench reference {path!r} has no stored version")
+        if version.size_bytes > settings.workbench_ref_max_bytes:
+            raise ReferenceError_(
+                f"Workbench reference {path!r} is {version.size_bytes} bytes, above the "
+                f"{settings.workbench_ref_max_bytes}-byte reference limit"
+            )
+        try:
+            content = await storage.read(version.storage_path)
+        except Exception as e:
+            raise ReferenceError_(f"Failed to read workbench reference {path!r}: {e}")
+
+        encoding = ref.get("encoding") or _default_encoding(f.content_type)
+        if encoding == "base64":
+            import base64
+
+            return base64.b64encode(content).decode()
+        if encoding == "text":
+            try:
+                return content.decode("utf-8")
+            except UnicodeDecodeError:
+                raise ReferenceError_(
+                    f"Workbench reference {path!r} is not valid UTF-8 text — "
+                    'pass {"encoding": "base64"} in the reference'
+                )
+        raise ReferenceError_(
+            f"Unknown encoding {encoding!r} in workbench reference {path!r} "
+            "(use 'text' or 'base64')"
+        )
+
+    async def _walk(node: Any) -> Any:
+        if _is_reference(node):
+            return await _resolve_one(node)
+        if isinstance(node, dict):
+            return {k: await _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [await _walk(v) for v in node]
+        return node
+
+    return await _walk(arguments)
+
+
+def _spill_filename(tool_name: str, tool_call_id: str, content: str) -> str:
+    safe_tool = re.sub(r"[^A-Za-z0-9_-]", "_", tool_name)[:60]
+    safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", tool_call_id)[:16]
+    try:
+        json.loads(content)
+        ext = "json"
+    except (ValueError, TypeError):
+        ext = "txt"
+    return f"tool_results/{safe_tool}_{safe_id}.{ext}"
+
+
+async def spill_result(
+    db, chat, user_id: str, tool_name: str, tool_call_id: str, content: str
+) -> Optional[str]:
+    """Save a full oversized tool result into the chat's workbench.
+
+    Returns the workbench path, or None when spilling isn't possible (no
+    chat, workbench not enabled for the agent, write failure) — in which
+    case the caller keeps today's truncate-only behavior.
+    """
+    from app.services.collection_tools import _infer_content_type
+    from app.services.file_storage import get_storage
+    from app.services.workbench import (
+        _write_bytes,
+        chat_has_workbench_enabled,
+        get_or_create_workbench,
+    )
+
+    try:
+        if chat is None or str(chat.user_id) != str(user_id):
+            return None
+        if not await chat_has_workbench_enabled(db, chat):
+            return None
+        workbench = await get_or_create_workbench(db, chat)
+        path = _spill_filename(tool_name, tool_call_id, content)
+        result = await _write_bytes(
+            db,
+            get_storage(),
+            workbench,
+            filename=path,
+            content=content.encode("utf-8"),
+            content_type=_infer_content_type(path),
+            user_id=str(chat.user_id),
+            visibility="private",
+            file_metadata={"origin": "tool", "tool_name": tool_name, "tool_call_id": tool_call_id},
+        )
+        if "error" in result:
+            logger.warning(f"Result spill failed for {tool_name}: {result['error']}")
+            return None
+        await db.commit()
+        return path
+    except Exception as e:
+        logger.warning(f"Result spill failed for {tool_name}: {e}")
+        return None
+
+
+def attach_spill_pointer(truncated_content: str, path: str) -> str:
+    """Point the truncated inline result at the spilled workbench file."""
+    note = (
+        f"Full result saved to workbench file '{path}' — read it with "
+        "workbench_read (supports offset/limit) or process it with code execution."
+    )
+    try:
+        parsed = json.loads(truncated_content)
+    except (ValueError, TypeError):
+        return truncated_content + f"\n[{note}]"
+    if isinstance(parsed, dict):
+        parsed["_full_result"] = {"workbench_file": path, "hint": note}
+        return json.dumps(parsed)
+    return truncated_content + f"\n[{note}]"

--- a/backend/docs/adrs/2026-09-01-workbench-file-references-and-result-spill.md
+++ b/backend/docs/adrs/2026-09-01-workbench-file-references-and-result-spill.md
@@ -1,0 +1,121 @@
+# ADR: Workbench file references in tool calls + result spill
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Authors:** Kjeld Oostra (with Claude)
+- **Related code:**
+  - `backend/app/services/workbench_refs.py` — the reference resolver and result spill
+  - `backend/app/services/tool_execution.py` — resolution before dispatch; spill at the truncation point
+  - `backend/app/services/workbench.py` — the workbench this builds on (see the workbench ADR)
+  - `backend/app/services/tool_result_store.py`, `truncate_tool_result` — the prior art this completes
+
+## Context
+
+With the workbench in place, one gap remained in how file content moves:
+it had to travel **through the model**. Sending a workbench PDF to a
+connector meant the model copying base64 into a tool-call argument —
+token-expensive, size-capped, binary-hostile. In the other direction, an
+oversized tool result was structure-aware-truncated for the context, and
+because truncation ran before any persistence, the excess was **lost for
+good** — even `retrieve_tool_result` served the truncated copy.
+
+We also considered a "workbench remotes" interface (checkout/promote
+targets beyond collections: git, Confluence, Drive). See "What we'd NOT
+do" for why that lost the sequencing argument.
+
+## Decision
+
+### Outbound: file references
+
+Any tool-call parameter value that is exactly the typed object
+
+```json
+{"$workbench": "report.pdf"}          // optionally: "encoding": "text" | "base64"
+```
+
+is resolved by the tool executor at dispatch time: the file's current
+version is loaded from the **calling chat's** workbench and the object is
+replaced by the content (UTF-8 text for textual content types by default,
+base64 otherwise or on request). The model passes a reference; the tool
+receives bytes. This works for **every** tool kind — connectors,
+functions, pipelines — with zero per-service code.
+
+Design choices with reasons:
+
+- **Typed object, not a magic string.** `workbench://…` inside a string
+  can collide with legitimate content and invites accidental resolution;
+  a dict whose keys are exactly `{$workbench, encoding?}` cannot appear by
+  accident in model-emitted JSON arguments.
+- **Automatic on the sentinel, not schema-annotated opt-in.** Connector
+  schemas come from OpenAPI and would each need annotation plumbing; the
+  collision-proof sentinel makes opt-in unnecessary. A cheap string
+  pre-check keeps the no-reference case free.
+- **Failure fails the call.** A bad path, missing file, non-UTF-8 text
+  request, or a file over `workbench_ref_max_bytes` returns an error
+  result for that tool call — the sentinel must never leak through to a
+  tool as literal arguments.
+- **Chat-scoped by construction.** The resolver only ever reads the
+  calling chat's own workbench (ownership double-checked), so a reference
+  cannot reach any other user's or chat's files.
+
+### Inbound: result spill
+
+At the existing truncation point, when the chat's agent has the workbench
+enabled, the **full** result is first written to the workbench
+(`tool_results/<tool>_<call-id>.<json|txt>`, private, with
+`file_metadata: {origin: "tool", tool_name, tool_call_id}` as provenance),
+and the truncated inline copy carries a pointer (`_full_result` key inside
+JSON results, a text suffix otherwise). The model can then page through
+the full result with `workbench_read` offsets or process it wholesale with
+code execution — which the sandbox sync makes natural, since the spilled
+file materializes into the working directory.
+
+Without a workbench, behavior is exactly as before (truncate-only). The
+spill is best-effort: any failure degrades to truncate-only, never to a
+failed tool call.
+
+## Impact
+
+| Component | Change |
+|---|---|
+| `workbench_refs.py` (new) | resolver, spill, pointer attachment |
+| `tool_execution.py` | resolve before dispatch; spill at truncation |
+| `workbench.py` | `workbench_list` description advertises the convention |
+| `config.py` | `workbench_ref_max_bytes` (default 10 MB) |
+
+## Open questions
+
+1. Should `retrieve_tool_result` / the tool-result store learn about
+   spilled files (serve the workbench copy when the store holds a
+   truncated one)? Left alone for now — the pointer in the inline result
+   is the discovery mechanism.
+2. Reference support in *message content* (a user attaching
+   `{"$workbench": …}` in structured content parts) — plausible later,
+   out of scope here.
+
+## What we'd NOT do
+
+- **Workbench remotes first.** A checkout/promote provider interface for
+  external systems (git, Confluence, Drive) was considered and
+  deliberately deferred: its value over file references is round-trip
+  provenance with conflict detection, and that contract is only honest
+  where the service has real version primitives (git SHAs, Confluence
+  page versions). Drive-class services lack atomic compare-and-swap —
+  the interface would be thin for two services and a pile of per-connector
+  exceptions for the rest. File references + spill deliver both directions
+  ("upload this workbench file via any connector operation", "save this
+  download into the workbench") with zero per-service code. If remotes
+  return, they come capability-tiered (`conflictDetection: version | etag
+  | none`, last-write-wins-with-warning on `none`) and probably ship for
+  git first — or only.
+- No schema annotations, no per-connector mapping config, no URL-mode
+  resolution (signed URLs for parameters can layer on later if a
+  connector needs a URL rather than bytes).
+
+## Next steps
+
+1. Ship (this PR).
+2. When a real "update the source document in place" need appears, revisit
+   remotes at the reduced scope above — the provenance stamps on spilled
+   and checked-out files already carry the bookkeeping a provider would
+   need.

--- a/backend/tests/unit/test_workbench_refs.py
+++ b/backend/tests/unit/test_workbench_refs.py
@@ -1,0 +1,178 @@
+"""Workbench file references in tool calls + result spill.
+
+Contracts under test: the typed sentinel resolves to file content (text or
+base64) anywhere in the argument tree; every failure mode errors the call
+instead of leaking the sentinel; resolution is chat-scoped; oversized
+results spill in full to tool_results/ with provenance and the inline copy
+points at them; no workbench means exactly the old truncate-only behavior.
+"""
+import base64
+import json
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.chat import Chat
+from app.models.file import File
+from app.models.user import User
+from app.services import workbench_refs
+from app.services.workbench import WorkbenchTools, get_or_create_workbench
+
+
+@pytest.fixture(autouse=True)
+def _tmp_file_storage(tmp_path, monkeypatch):
+    import app.services.file_storage as fs
+
+    monkeypatch.setenv("FILE_STORAGE_PATH", str(tmp_path / "files"))
+    fs._storage = None
+    yield
+    fs._storage = None
+
+
+@pytest_asyncio.fixture
+async def chat(db: AsyncSession, test_user: User) -> Chat:
+    c = Chat(user_id=test_user.id, title="refs test chat")
+    db.add(c)
+    await db.flush()
+    await db.refresh(c)
+    return c
+
+
+async def _write(db, chat, test_user, filename: str, content: str):
+    result = await WorkbenchTools().execute_tool(
+        db, chat, str(test_user.id), "workbench_write",
+        {"filename": filename, "content": content},
+    )
+    assert "error" not in result, result
+
+
+class TestContainsReference:
+    def test_fast_precheck(self):
+        assert workbench_refs.contains_reference('{"body": {"$workbench": "a.txt"}}')
+        assert not workbench_refs.contains_reference('{"body": "plain"}')
+        assert workbench_refs.contains_reference({"body": {"$workbench": "a.txt"}})
+        assert not workbench_refs.contains_reference({"body": "plain"})
+
+
+class TestResolveReferences:
+    @pytest.mark.asyncio
+    async def test_text_reference_resolves_anywhere_in_tree(self, db, chat, test_user):
+        await _write(db, chat, test_user, "report.md", "# Findings\nAll good.")
+        resolved = await workbench_refs.resolve_references(
+            db, chat, str(test_user.id),
+            {
+                "title": "Weekly report",
+                "body": {"$workbench": "report.md"},
+                "attachments": [{"content": {"$workbench": "report.md"}}],
+            },
+        )
+        assert resolved["body"] == "# Findings\nAll good."
+        assert resolved["attachments"][0]["content"] == "# Findings\nAll good."
+        assert resolved["title"] == "Weekly report"
+
+    @pytest.mark.asyncio
+    async def test_base64_encoding_on_request(self, db, chat, test_user):
+        await _write(db, chat, test_user, "data.txt", "payload")
+        resolved = await workbench_refs.resolve_references(
+            db, chat, str(test_user.id),
+            {"file": {"$workbench": "data.txt", "encoding": "base64"}},
+        )
+        assert base64.b64decode(resolved["file"]) == b"payload"
+
+    @pytest.mark.asyncio
+    async def test_missing_file_errors(self, db, chat, test_user):
+        with pytest.raises(workbench_refs.ReferenceError_, match="not found"):
+            await workbench_refs.resolve_references(
+                db, chat, str(test_user.id), {"body": {"$workbench": "nope.txt"}}
+            )
+
+    @pytest.mark.asyncio
+    async def test_traversal_path_errors(self, db, chat, test_user):
+        with pytest.raises(workbench_refs.ReferenceError_, match="Invalid"):
+            await workbench_refs.resolve_references(
+                db, chat, str(test_user.id), {"body": {"$workbench": "../secrets"}}
+            )
+
+    @pytest.mark.asyncio
+    async def test_size_cap(self, db, chat, test_user, monkeypatch):
+        monkeypatch.setattr(settings, "workbench_ref_max_bytes", 10)
+        await _write(db, chat, test_user, "big.txt", "x" * 100)
+        with pytest.raises(workbench_refs.ReferenceError_, match="reference limit"):
+            await workbench_refs.resolve_references(
+                db, chat, str(test_user.id), {"body": {"$workbench": "big.txt"}}
+            )
+
+    @pytest.mark.asyncio
+    async def test_other_users_chat_is_rejected(self, db, chat, admin_user):
+        with pytest.raises(workbench_refs.ReferenceError_, match="different user"):
+            await workbench_refs.resolve_references(
+                db, chat, str(admin_user.id), {"body": {"$workbench": "a.txt"}}
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_sentinel_dicts_pass_through(self, db, chat, test_user):
+        args = {"payload": {"$workbench": "a.txt", "extra": "key"}}  # extra key → not a reference
+        resolved = await workbench_refs.resolve_references(db, chat, str(test_user.id), args)
+        assert resolved == args
+
+
+class TestResultSpill:
+    @pytest_asyncio.fixture
+    async def wb_chat(self, db, test_user):
+        """A chat whose agent has the workbench enabled (spill requires it)."""
+        from app.models import Agent
+
+        agent = Agent(
+            namespace="test", name="spiller", user_id=test_user.id,
+            system_tools=["workbench"],
+        )
+        db.add(agent)
+        await db.flush()
+        c = Chat(user_id=test_user.id, agent_id=agent.id, title="spill chat")
+        db.add(c)
+        await db.flush()
+        await db.refresh(c)
+        return c
+
+    @pytest.mark.asyncio
+    async def test_spill_saves_full_result_with_provenance(self, db, wb_chat, test_user):
+        big = json.dumps({"rows": list(range(1000))})
+        path = await workbench_refs.spill_result(
+            db, wb_chat, str(test_user.id), "some_query", "call_abc123", big
+        )
+        assert path == "tool_results/some_query_call_abc123.json"
+
+        wb = await get_or_create_workbench(db, wb_chat)
+        from sqlalchemy import select
+        f = (
+            await db.execute(select(File).where(File.collection_id == wb.id))
+        ).scalar_one()
+        assert f.name == path
+        assert f.file_metadata["origin"] == "tool"
+        assert f.file_metadata["tool_call_id"] == "call_abc123"
+
+        # And the agent can read it back in full.
+        result = await WorkbenchTools().execute_tool(
+            db, wb_chat, str(test_user.id), "workbench_read", {"filename": path, "limit": 1}
+        )
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_workbench_agent_means_no_spill(self, db, chat, test_user):
+        path = await workbench_refs.spill_result(
+            db, chat, str(test_user.id), "some_query", "call_x", "content"
+        )
+        assert path is None
+
+    def test_pointer_attaches_inside_json_dict(self):
+        truncated = json.dumps({"rows": [1, 2], "_truncated": True})
+        out = workbench_refs.attach_spill_pointer(truncated, "tool_results/q.json")
+        parsed = json.loads(out)
+        assert parsed["_full_result"]["workbench_file"] == "tool_results/q.json"
+
+    def test_pointer_appends_for_non_dict_content(self):
+        out = workbench_refs.attach_spill_pointer("plain text tail", "tool_results/q.txt")
+        assert out.startswith("plain text tail")
+        assert "tool_results/q.txt" in out


### PR DESCRIPTION
## What this adds

ADR + implementation in one PR, per discussion: file content should not have to travel through the model. **Stacked on #179** (which stacks on #178); retarget after those merge — the diff here is one commit.

### Outbound — file references
Any tool-call parameter whose value is exactly the typed object `{"$workbench": "<path>"}` (optionally `"encoding": "text"|"base64"`) is resolved at dispatch time in `execute_single_tool`: the file's current version from the **calling chat's** workbench replaces the reference, UTF-8 text for textual content types by default, base64 otherwise or on request. Works for every tool kind — connectors, functions, pipelines — with zero per-service code. So "promote this report to Drive/Confluence" is just that connector's upload operation called with a reference; no tokens of file content pass through the model, and no credentials get near the arguments.

Guarantees:
- the typed-object sentinel cannot collide with legitimate string content (no magic strings);
- a failed reference (bad path, missing file, over `workbench_ref_max_bytes`, non-UTF-8 for text) **fails the call** with a clear error — the sentinel never leaks through to a tool as literal arguments;
- resolution is chat-scoped by construction (only the calling chat's own workbench, ownership double-checked);
- a cheap string pre-check keeps the no-reference case free.

### Inbound — result spill
At the existing truncation point, the **full** oversized result is first written to the chat's workbench (`tool_results/<tool>_<call-id>.<json|txt>`, private, `origin`/`tool_name`/`tool_call_id` provenance in metadata), and the truncated inline copy carries a pointer (`_full_result` key inside JSON, text suffix otherwise). The model pages through it with `workbench_read` offsets or processes it with code execution — the sandbox sync materializes the spilled file into the working directory.

This fixes a real data-loss bug: truncation ran before any persistence, so the excess was gone for good — `retrieve_tool_result` served the truncated copy too. Spill is best-effort: no workbench on the agent, or any failure, degrades to today's truncate-only behavior.

### ADR
`backend/docs/adrs/2026-09-01-workbench-file-references-and-result-spill.md` records both decisions and the sequencing call from review discussion: the "workbench remotes" provider interface is **deferred** — its conflict-detection contract is only honest where services have real version primitives (git SHAs, Confluence page versions; Drive-class services lack atomic compare-and-swap), while references + spill deliver both directions with zero per-service code. If remotes return, they come capability-tiered and git-first-or-only.

## Testing
12 new tests: sentinel pre-check, resolution anywhere in the argument tree, base64 on request, missing-file / traversal / size-cap / cross-user errors, non-sentinel dicts passing through untouched, spill with provenance readable back through workbench tools, no-workbench no-spill, and pointer attachment for JSON and plain-text results. Full backend suite 507 green against local Postgres 16 + Redis.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKF3t37iK8aEGexrttW5od)_