### PR TITLE
feat(console): logo mark color-bounce on mount

### DIFF
--- a/console/src/index.css
+++ b/console/src/index.css
@@ -319,8 +319,13 @@ select.input:disabled {
    Lives on the inline <Logo> component — <img>-embedded SVG animations are
    frozen by some Chrome builds. */
 @keyframes sinas-markfade {
-  0%, 25% { stroke: currentColor; }
-}
+  0%, 18% { stroke: currentColor; } /* hold in the theme color */
+  55%     { stroke: #ff8f1f; }      /* overshoot, brighter + hotter */
+  76%     { stroke: #d76300; }      /* swing back under */
+  90%     { stroke: #f58414; }      /* small rebound */
+}                                    /* settle on brand #E97203 (attr) */
 .sinas-logo path[stroke] {
-  animation: sinas-markfade 1.6s ease-out;
+  /* Damped color bounce: ~0.7s hold, glide up past the brand orange,
+     oscillate, settle. Plays once per mount. */
+  animation: sinas-markfade 3.8s ease-in-out;
 }


### PR DESCRIPTION
Follow-up to #182 per Kjeld's direction: the mark's entry is a damped **color bounce**, not a plain fade — hold in the theme text color, overshoot past brand orange to a brighter peak, swing under, rebound, settle on #E97203. 3.8s, once per mount, static end state for animations-off.

Verified by sampling computed stroke through a cycle (peak ≈ #ff8f1f at 2.2s, under-swing ≈ #d76300 at 3.0s, settled #E97203 at 3.8s).

Deliberately out of scope (Kjeld: skip for now): aligning the brand orange with the brighter shade sinas.co uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)