### PR TITLE
fix(chart): image tags default to the chart's appVersion

### DIFF
--- a/charts/sinas/templates/_helpers.tpl
+++ b/charts/sinas/templates/_helpers.tpl
@@ -33,6 +33,16 @@ ServiceAccount names
 {{- end }}
 
 {{/*
+Image tag: explicit .Values.image.tag wins; empty falls back to the chart's
+appVersion, which CI stamps from the release tag — so a versioned install
+pulls that version's images instead of whatever `latest` points at (or, for
+images only built on tags, an ImagePullBackOff).
+*/}}
+{{- define "sinas.imageTag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion -}}
+{{- end }}
+
+{{/*
 Image pull secret reference — shared by all sinas deployments.
 */}}
 {{- define "sinas.imagePullSecrets" -}}
@@ -147,10 +157,11 @@ Backend environment — shared by backend, all workers, scheduler, cdc-worker
   value: {{ .Values.executor.sandbox | quote }}
 - name: TRUSTED_EXECUTOR
   value: {{ .Values.executor.trusted | quote }}
+{{- $executorImage := .Values.executor.image | default (printf "%s/executor:%s" .Values.image.registry (include "sinas.imageTag" .)) }}
 - name: FUNCTION_CONTAINER_IMAGE
-  value: {{ .Values.executor.image | quote }}
+  value: {{ $executorImage | quote }}
 - name: K8S_SANDBOX_IMAGE
-  value: {{ .Values.executor.image | quote }}
+  value: {{ $executorImage | quote }}
 - name: K8S_SANDBOX_SERVICE_ACCOUNT
   value: {{ include "sinas.sandboxSA" . | quote }}
 - name: K8S_SANDBOX_INSTALL_DEPENDENCIES

--- a/charts/sinas/templates/backend.yaml
+++ b/charts/sinas/templates/backend.yaml
@@ -31,7 +31,7 @@ spec:
         - name: backend
           ## allInOne uses the lite image: backend + the console's built SPA
           ## (served at /ui by the process itself).
-          image: {{ .Values.image.registry }}/{{ ternary "lite" "backend" (.Values.allInOne | default false) }}:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/{{ ternary "lite" "backend" (.Values.allInOne | default false) }}:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh

--- a/charts/sinas/templates/builder.yaml
+++ b/charts/sinas/templates/builder.yaml
@@ -22,7 +22,7 @@ spec:
       {{- with (include "sinas.scheduling" (dict "values" (.Values.builder) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: builder
-          image: {{ .Values.image.registry }}/builder:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/builder:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 3000

--- a/charts/sinas/templates/console.yaml
+++ b/charts/sinas/templates/console.yaml
@@ -22,7 +22,7 @@ spec:
       {{- with (include "sinas.scheduling" (dict "values" (.Values.console) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: console
-          image: {{ .Values.image.registry }}/console:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/console:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 80

--- a/charts/sinas/templates/workers.yaml
+++ b/charts/sinas/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
       {{- with (include "sinas.scheduling" (dict "values" (.Values.queueWorker) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: queue-worker
-          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/backend:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "-m", "arq", "app.queue.worker.WorkerSettings"]
           env:
@@ -63,7 +63,7 @@ spec:
       {{- with (include "sinas.scheduling" (dict "values" (.Values.queueAgent) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: queue-agent
-          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/backend:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "-m", "arq", "app.queue.worker.AgentWorkerSettings"]
           env:
@@ -102,7 +102,7 @@ spec:
       {{- with (include "sinas.scheduling" (dict "values" (.Values.scheduler) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: scheduler
-          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/backend:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "-m", "app.scheduler.service"]
           env:
@@ -140,7 +140,7 @@ spec:
       {{- with (include "sinas.scheduling" (dict "values" (.Values.cdcWorker) "root" . "inherit" true) | trim) }}{{ . | nindent 6 }}{{- end }}
       containers:
         - name: cdc-worker
-          image: {{ .Values.image.registry }}/backend:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/backend:{{ include "sinas.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "-m", "app.cdc.service"]
           env:

--- a/charts/sinas/values.yaml
+++ b/charts/sinas/values.yaml
@@ -1,7 +1,9 @@
 ## Image — the sinas backend image (also used by workers, scheduler, cdc).
 image:
   registry: ghcr.io/sinas-platform/sinas
-  tag: latest
+  ## Empty = the chart's appVersion (stamped from the release tag), so a
+  ## versioned install pulls matching images. Set explicitly to override.
+  tag: ""
   pullPolicy: IfNotPresent
 
 ## Routing
@@ -68,7 +70,9 @@ executor:
   ## (Dependency table) are pip-installed into each pod at create time; bake
   ## them into a custom image and set installDependencies: false to skip that
   ## cold-start cost.
-  image: "ghcr.io/sinas-platform/sinas/executor:latest"
+  ## Empty = <image.registry>/executor:<image tag or appVersion> — keeps the
+  ## sandbox image in lockstep with the release. Set to pin a custom image.
+  image: ""
   installDependencies: true
   podReadyTimeout: 120
 


### PR DESCRIPTION
`helm install --version 0.4.0-rc.10` pulled `:latest` images. For the lite image (only built on tags) that's an **ImagePullBackOff on first install** — hit live during the kind validation; for everything else it's silent chart/workload version skew.

- New `sinas.imageTag` helper: explicit `image.tag` wins; empty falls back to `.Chart.AppVersion` (CI already stamps it from the release tag).
- Applied at all 7 image sites **plus `executor.image`**, which was separately hardcoded `:latest` and is pulled at *runtime* by sandbox pods — same skew, deferred to first execution. Now defaults to `<registry>/executor:<resolved tag>`, still overridable.
- Repo Chart.yaml keeps the `latest` placeholder, so chart-from-git is unchanged; the fallback is only meaningful on packaged charts, where it's correct.

Verified: lint; template with appVersion=9.9.9 resolves every image (incl. lite profile and executor env) to `:9.9.9`; `--set image.tag` override still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)