### PR TITLE
fix(console): lite consoles on localhost talked to the wrong backend

### DIFF
--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -84,14 +84,23 @@ import type {
   PipelineRunOutcome,
 } from '../types';
 
-// Auto-detect API base URL based on environment
-// VITE_API_URL overrides (useful for pointing a dev console at any backend)
-// Local: http://localhost:8000
-// Production: https://yourdomain.com (same domain as console, port 443)
+// Auto-detect API base URL based on environment.
+// - VITE_API_URL overrides (point a dev console at any backend)
+// - localhost on the console's own ports (Vite dev, nginx :51245) → the
+//   conventional backend at :8000
+// - localhost on ANY OTHER port → same origin: the backend itself served
+//   the console (lite profile, kubectl port-forward). Blanket-routing all
+//   of localhost to :8000 sent a lite console's API calls to whatever
+//   other instance held that port — silently the wrong deployment.
+// - real domains → same hostname, default port (console may sit on its
+//   own port behind Caddy while the API is on 443)
+const CONSOLE_OWN_PORTS = ['51245', ''];
 export const API_BASE_URL = import.meta.env.VITE_API_URL
   ? import.meta.env.VITE_API_URL
   : window.location.hostname === 'localhost'
-    ? 'http://localhost:8000'
+    ? (import.meta.env.DEV || CONSOLE_OWN_PORTS.includes(window.location.port)
+        ? 'http://localhost:8000'
+        : window.location.origin)
     : `${window.location.protocol}//${window.location.hostname}`;
 
 /**


### PR DESCRIPTION
Found poking the kind lite install: a **password-mode** instance rendered the **OTP** login form. Cause: `API_BASE_URL` blanket-routes `localhost` to `:8000`, so a backend-served console (lite on `:8001` compose or `:8888` port-forward) silently reads — and would log into — whatever *other* instance holds `:8000`.

Rule now: on localhost, only the console's own ports (Vite dev via `import.meta.env.DEV`, nginx `:51245`) hop to `:8000`; any other localhost port ⇒ the backend served the console ⇒ same origin. `VITE_API_URL` and real-domain behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)