### PR TITLE
fix(console): stale-tab and silent-failure fixes around store states

### DIFF
--- a/console/nginx.conf
+++ b/console/nginx.conf
@@ -26,6 +26,10 @@ server {
     # allowlist: /ui -> console, everything else -> backend.
     location /ui/ {
         try_files $uri $uri/ /ui/index.html;
+        # The SPA entry must never be cached: a heuristically-cached
+        # index.html keeps referencing old hashed bundles after a deploy,
+        # leaving tabs on stale code (with correspondingly stale API calls).
+        add_header Cache-Control "no-cache" always;
     }
 
     # Immutable caching ONLY for Vite's content-hashed bundles. public/ files

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -510,35 +510,10 @@ class APIClient {
     return response.data;
   }
 
-  // State Store (Runtime API - formerly Context Store)
-  async listStates(params?: {
-    namespace?: string;
-    visibility?: string;
-    skip?: number;
-    limit?: number;
-  }): Promise<any[]> {
-    const response = await this.runtimeClient.get('/states', { params });
-    return response.data;
-  }
 
-  async getState(stateId: string): Promise<any> {
-    const response = await this.runtimeClient.get(`/states/${stateId}`);
-    return response.data;
-  }
 
-  async createState(data: any): Promise<any> {
-    const response = await this.runtimeClient.post('/states', data);
-    return response.data;
-  }
 
-  async updateState(stateId: string, data: any): Promise<any> {
-    const response = await this.runtimeClient.put(`/states/${stateId}`, data);
-    return response.data;
-  }
 
-  async deleteState(stateId: string): Promise<void> {
-    await this.runtimeClient.delete(`/states/${stateId}`);
-  }
 
   // Secrets
   async listSecrets(): Promise<any[]> {

--- a/console/src/pages/Stores.tsx
+++ b/console/src/pages/Stores.tsx
@@ -254,6 +254,10 @@ function StoreStatesPanel({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['store-states', namespace, name] });
     },
+    onError: (err: any) => {
+      // A silent failure here reads as "the button does nothing"
+      alert(`Failed to delete state: ${err?.response?.data?.detail || err?.message || err}`);
+    },
   });
 
   const handleDeleteState = (state: any) => {


### PR DESCRIPTION
A state-delete click that 'did nothing' while the identical DELETE succeeded via curl. The chain: **index.html had no cache headers** → browsers heuristically cache the SPA entry across deploys → a stale tab runs an old bundle whose api client calls the **removed** `/states/{id}` routes → the 404 is swallowed (no `onError`). Each link fixed:

- nginx: `Cache-Control: no-cache` on the SPA entry (hashed bundles remain immutable) — deploys reach tabs on next reload, permanently
- api client: all five legacy `/states` methods deleted — routes gone, zero callers, live paths all use `/stores/{ns}/{name}/states/*`
- `Stores.tsx`: delete failures surface to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)