### PR TITLE
fix(metering): report zero immediately after rollover; diagnosable 409 rejections

### DIFF
--- a/backend/app/services/metering.py
+++ b/backend/app/services/metering.py
@@ -389,13 +389,35 @@ async def _adopt_migrate(db: AsyncSession, redis, old_pid: str, period: dict[str
 async def _adopt_reset(db: AsyncSession, redis, old_pid: str, period: dict[str, Any]) -> None:
     """Rollover adopt: new period starts from zero; the old period's tail is
     discarded (accepted MVP gap — no previous-period finalization)."""
+    from app.models import UsagePeriod
+
     await _persist_period(db, period)
     await redis.set(_platform_pid_key(), period["id"])
     for k in OperationKind:
         await redis.expire(_key(old_pid, f"kind:{k.value}"), _ROLLED_OVER_KEY_TTL)
     await redis.expire(_key(old_pid, "total"), _ROLLED_OVER_KEY_TTL)
-    # No usage_periods row yet: the next snapshot creates it at zero with
-    # snapshot_seq 0 once the first op of the new period lands.
+    # Create the new period's row at zero IMMEDIATELY. Without it, an idle
+    # instance adopted the period but then had nothing to send until its
+    # next operation — showing "Not yet reported" on the Platform for as
+    # long as it stayed idle. A zero row means the very next cycle reports
+    # cumulative "0" under the new period (seq 1), closing the gap.
+    existing = (
+        await db.execute(
+            select(UsagePeriod).where(
+                UsagePeriod.instance_id == instance_id(),
+                UsagePeriod.period_id == period["id"],
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        db.add(
+            UsagePeriod(
+                instance_id=instance_id(),
+                period_id=period["id"],
+                period_start=period["start"],
+                period_end=period["end"],
+            )
+        )
 
 
 async def push(db: AsyncSession) -> int:
@@ -485,9 +507,16 @@ async def push(db: AsyncSession) -> int:
                         )
                     else:
                         # sequence_reused / counter_regression: retrying the
-                        # same payload cannot help — surface loudly.
+                        # same payload cannot help — surface loudly. Include
+                        # what we could(n't) parse: a contract-shape mismatch
+                        # on the Platform's 409 body lands here too, and this
+                        # line is the difference between a one-look diagnosis
+                        # and an instance silently 409ing every cycle.
                         logger.error(
-                            f"Metering push {key} rejected: 409 {disposition}"
+                            f"Metering push {key} rejected: 409 "
+                            f"disposition={disposition!r} "
+                            f"period_parseable={_parse_period(body) is not None} "
+                            f"body~{str(body)[:200]}"
                         )
                     break
 

--- a/backend/tests/unit/test_metering.py
+++ b/backend/tests/unit/test_metering.py
@@ -397,6 +397,16 @@ class TestPushV2:
         assert state.period_id == P2["id"]
         assert row.reported_at == reported_before  # rejected report not marked
 
+        # Recovery must not depend on new operations arriving: the adopt
+        # created a zero row, so the NEXT cycle reports under the new period
+        # even on an idle instance (the "Not yet reported" gap).
+        client = _patch_client(monkeypatch, [_Resp(200, _ack(P2))])
+        assert await metering.push(db) == 1
+        payload = client.posts[0]["json"]
+        assert payload["canonical_period_id"] == P2["id"]
+        assert payload["cumulative"]["total"] == "0"
+        assert payload["snapshot_seq"] == "1"
+
     async def test_409_counter_regression_is_terminal_no_adopt(
         self, db, metering_on, platform, monkeypatch
     ):


### PR DESCRIPTION
From Platform QA's downgrade test (Isidora's 409/period_mismatch report):

1. **Idle instances vanished after rollover.** `_adopt_reset` created no row for the new period, so an idle instance adopted correctly but sent nothing until its next *operation* — 'Not yet reported' for as long as it idled. Adopt now creates the zero row; the next cycle always reports cumulative `"0"` (seq 1) under the new period.
2. **Terminal 409s are now diagnosable**: the log carries disposition, period-parseability, and a body excerpt — a contract-shape mismatch on the Platform's 409 body lands in that branch, and distinguishing it from a real `counter_regression` is now one log line.

**Not a bug here:** the reported repeated-409-without-adoption is the expected behaviour of any build **older than 0.4.0-rc.10** — v1 metering ignored response bodies entirely. The adopt-on-409/200 contract is v2, first shipped in rc.10 (Sep 2). The affected instance's build is identifiable from the `platform_version` field in every report payload the Platform receives.

Tests: 19 metering tests incl. new idle-recovery flow (409 → adopt → zero-report next cycle with no ops in between); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)